### PR TITLE
Set up Go Fiber backend scaffold

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,45 @@
 # Backend
 
-This directory will contain the server-side application code, APIs, and related backend services.
+This directory contains the Go backend for the Bissbilanz project. It uses the [Fiber](https://gofiber.io/) web framework and follows a layered structure with separate packages for configuration, services, and HTTP handlers.
+
+## Prerequisites
+
+- Go 1.21 or newer
+
+## Installation
+
+Fetch dependencies (requires network access to download modules):
+
+```bash
+cd backend
+GOPROXY=https://proxy.golang.org,direct go get github.com/gofiber/fiber/v2@latest
+```
+
+If access to the public Go proxy is restricted, configure an alternative proxy or download the module manually before running the application.
+
+## Running the server
+
+```bash
+cd backend
+PORT=3000 go run ./cmd/server
+```
+
+The server exposes a basic health check at `GET /health`.
+
+## Project structure
+
+```
+backend/
+├── cmd/
+│   └── server/
+│       └── main.go        # Application entrypoint
+├── internal/
+│   ├── config/            # Configuration helpers
+│   ├── handlers/
+│   │   └── health/        # HTTP handlers
+│   └── services/
+│       └── health/        # Business logic/services
+├── go.mod
+├── go.sum                 # Generated after downloading dependencies
+└── README.md
+```

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/bissbilanz/backend/internal/config"
+	healthhandler "github.com/bissbilanz/backend/internal/handlers/health"
+	healthservice "github.com/bissbilanz/backend/internal/services/health"
+)
+
+func main() {
+	cfg := config.Load()
+
+	app := fiber.New()
+
+	healthSvc := healthservice.New()
+	healthHandler := healthhandler.New(healthSvc)
+	healthHandler.RegisterRoutes(app)
+
+	log.Printf("Starting server on %s", cfg.Address())
+	if err := app.Listen(cfg.Address()); err != nil {
+		log.Fatalf("failed to start server: %v", err)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,5 @@
+module github.com/bissbilanz/backend
+
+go 1.24.3
+
+require github.com/gofiber/fiber/v2 v2.52.4

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+type Config struct {
+	Port string
+}
+
+func Load() Config {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+
+	return Config{Port: port}
+}
+
+func (c Config) Address() string {
+	return fmt.Sprintf(":%s", c.Port)
+}

--- a/backend/internal/handlers/health/handler.go
+++ b/backend/internal/handlers/health/handler.go
@@ -1,0 +1,21 @@
+package health
+
+import "github.com/gofiber/fiber/v2"
+
+import healthservice "github.com/bissbilanz/backend/internal/services/health"
+
+type Handler struct {
+	service healthservice.Service
+}
+
+func New(service healthservice.Service) *Handler {
+	return &Handler{service: service}
+}
+
+func (h *Handler) RegisterRoutes(app *fiber.App) {
+	app.Get("/health", h.Health)
+}
+
+func (h *Handler) Health(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusOK).JSON(h.service.Status())
+}

--- a/backend/internal/services/health/service.go
+++ b/backend/internal/services/health/service.go
@@ -1,0 +1,17 @@
+package health
+
+type Service interface {
+	Status() map[string]string
+}
+
+type service struct{}
+
+func New() Service {
+	return &service{}
+}
+
+func (s *service) Status() map[string]string {
+	return map[string]string{
+		"status": "ok",
+	}
+}


### PR DESCRIPTION
## Summary
- initialize a Go module for the backend and declare the Fiber dependency
- add a Fiber-powered server entrypoint with internal packages for config, services, and handlers
- document setup and run instructions for the backend project structure

## Testing
- go run ./cmd/server *(fails: missing Fiber module download due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68f4f05db0d0832281c39e30875d78a2