### PR TITLE
Remove food localization table and model

### DIFF
--- a/backend/database/migrations/000002_create_core_schema.sql
+++ b/backend/database/migrations/000002_create_core_schema.sql
@@ -1,0 +1,245 @@
+-- +goose Up
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE measurement_units (
+    id              BIGSERIAL PRIMARY KEY,
+    name            TEXT NOT NULL UNIQUE,
+    symbol          TEXT NOT NULL UNIQUE,
+    quantity        TEXT,
+    description     TEXT
+);
+
+CREATE TABLE nutrient_groups (
+    id          BIGSERIAL PRIMARY KEY,
+    name        TEXT NOT NULL UNIQUE,
+    description TEXT
+);
+
+CREATE TABLE data_sources (
+    id           BIGSERIAL PRIMARY KEY,
+    name         TEXT NOT NULL,
+    type         TEXT NOT NULL,
+    endpoint_url TEXT,
+    license      TEXT,
+    notes        TEXT,
+    UNIQUE (name, type)
+);
+
+CREATE TABLE import_batches (
+    id           BIGSERIAL PRIMARY KEY,
+    source_id    BIGINT NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    imported_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version      TEXT,
+    raw_file_path TEXT,
+    status       TEXT NOT NULL DEFAULT 'completed'
+);
+
+CREATE TABLE nutrient_definitions (
+    id            BIGSERIAL PRIMARY KEY,
+    code          TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL,
+    group_id      BIGINT REFERENCES nutrient_groups(id) ON DELETE SET NULL,
+    unit_id       BIGINT NOT NULL REFERENCES measurement_units(id) ON DELETE RESTRICT,
+    daily_value   NUMERIC(18,6),
+    description   TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE nutrient_aliases (
+    id           BIGSERIAL PRIMARY KEY,
+    nutrient_id  BIGINT NOT NULL REFERENCES nutrient_definitions(id) ON DELETE CASCADE,
+    source_id    BIGINT NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    code         TEXT NOT NULL,
+    name         TEXT,
+    UNIQUE (nutrient_id, source_id, code)
+);
+
+CREATE TABLE foods (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    canonical_name      TEXT NOT NULL,
+    generic_name        TEXT,
+    brand_name          TEXT,
+    category_path       TEXT,
+    is_product          BOOLEAN NOT NULL DEFAULT FALSE,
+    default_unit_id     BIGINT NOT NULL REFERENCES measurement_units(id) ON DELETE RESTRICT,
+    source_id           BIGINT REFERENCES data_sources(id) ON DELETE SET NULL,
+    external_id         TEXT,
+    data_quality_score  SMALLINT,
+    last_verified_at    TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX foods_source_external_idx ON foods(source_id, external_id) WHERE external_id IS NOT NULL;
+
+CREATE TABLE food_portions (
+    id           BIGSERIAL PRIMARY KEY,
+    food_id      UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    portion_name TEXT NOT NULL,
+    quantity     NUMERIC(18,6) NOT NULL CHECK (quantity > 0),
+    unit_id      BIGINT NOT NULL REFERENCES measurement_units(id) ON DELETE RESTRICT,
+    gram_weight  NUMERIC(18,6),
+    UNIQUE (food_id, portion_name)
+);
+
+CREATE TABLE food_categories (
+    id        BIGSERIAL PRIMARY KEY,
+    name      TEXT NOT NULL,
+    parent_id BIGINT REFERENCES food_categories(id) ON DELETE SET NULL,
+    UNIQUE (name, parent_id)
+);
+
+CREATE TABLE food_category_assignments (
+    food_id     UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    category_id BIGINT NOT NULL REFERENCES food_categories(id) ON DELETE CASCADE,
+    PRIMARY KEY (food_id, category_id)
+);
+
+CREATE TABLE food_source_records (
+    id           BIGSERIAL PRIMARY KEY,
+    food_id      UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    source_id    BIGINT NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+    external_id  TEXT,
+    raw_payload  JSONB,
+    batch_id     BIGINT REFERENCES import_batches(id) ON DELETE SET NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX food_source_records_source_external_idx
+    ON food_source_records(source_id, external_id)
+    WHERE external_id IS NOT NULL;
+
+CREATE TABLE food_nutrients (
+    food_id           UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    nutrient_id       BIGINT NOT NULL REFERENCES nutrient_definitions(id) ON DELETE CASCADE,
+    amount_per_100g   NUMERIC(18,6) NOT NULL CHECK (amount_per_100g >= 0),
+    derivation_method TEXT,
+    precision_source  TEXT,
+    last_updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (food_id, nutrient_id)
+);
+
+CREATE TABLE food_nutrient_portions (
+    portion_id BIGINT NOT NULL REFERENCES food_portions(id) ON DELETE CASCADE,
+    nutrient_id BIGINT NOT NULL REFERENCES nutrient_definitions(id) ON DELETE CASCADE,
+    amount     NUMERIC(18,6) NOT NULL CHECK (amount >= 0),
+    PRIMARY KEY (portion_id, nutrient_id)
+);
+
+CREATE TABLE substances (
+    id                BIGSERIAL PRIMARY KEY,
+    code              TEXT UNIQUE,
+    name              TEXT NOT NULL,
+    description       TEXT,
+    risk_level        TEXT,
+    regulatory_status TEXT,
+    substance_type    TEXT
+);
+
+CREATE TABLE substance_synonyms (
+    id            BIGSERIAL PRIMARY KEY,
+    substance_id  BIGINT NOT NULL REFERENCES substances(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    locale        TEXT,
+    UNIQUE (substance_id, name, locale)
+);
+
+CREATE TABLE food_substances (
+    food_id          UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    substance_id     BIGINT NOT NULL REFERENCES substances(id) ON DELETE CASCADE,
+    amount_per_100g  NUMERIC(18,6) CHECK (amount_per_100g >= 0),
+    source_id        BIGINT REFERENCES data_sources(id) ON DELETE SET NULL,
+    notes            TEXT,
+    PRIMARY KEY (food_id, substance_id)
+);
+
+CREATE TABLE studies (
+    id                BIGSERIAL PRIMARY KEY,
+    title             TEXT NOT NULL,
+    abstract          TEXT,
+    publication_date  DATE,
+    doi_or_url        TEXT,
+    source            TEXT,
+    access_type       TEXT,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE study_substances (
+    study_id      BIGINT NOT NULL REFERENCES studies(id) ON DELETE CASCADE,
+    substance_id  BIGINT NOT NULL REFERENCES substances(id) ON DELETE CASCADE,
+    finding_type  TEXT NOT NULL,
+    evidence_level TEXT,
+    summary       TEXT,
+    link_strength SMALLINT,
+    PRIMARY KEY (study_id, substance_id)
+);
+
+CREATE TABLE study_foods (
+    study_id     BIGINT NOT NULL REFERENCES studies(id) ON DELETE CASCADE,
+    food_id      UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    finding_type TEXT,
+    summary      TEXT,
+    PRIMARY KEY (study_id, food_id)
+);
+
+CREATE TABLE food_equivalents (
+    primary_food_id   UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    equivalent_food_id UUID NOT NULL REFERENCES foods(id) ON DELETE CASCADE,
+    confidence        NUMERIC(5,4),
+    notes             TEXT,
+    PRIMARY KEY (primary_food_id, equivalent_food_id),
+    CHECK (primary_food_id <> equivalent_food_id)
+);
+
+CREATE TABLE app_users (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email        TEXT UNIQUE,
+    display_name TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE user_food_logs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+    food_id         UUID NOT NULL REFERENCES foods(id) ON DELETE RESTRICT,
+    logged_at       TIMESTAMPTZ NOT NULL,
+    quantity_grams  NUMERIC(18,6) NOT NULL CHECK (quantity_grams >= 0),
+    portion_id      BIGINT REFERENCES food_portions(id) ON DELETE SET NULL,
+    notes           TEXT,
+    source          TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE user_food_log_tags (
+    log_id UUID NOT NULL REFERENCES user_food_logs(id) ON DELETE CASCADE,
+    tag    TEXT NOT NULL,
+    PRIMARY KEY (log_id, tag)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS user_food_log_tags;
+DROP TABLE IF EXISTS user_food_logs;
+DROP TABLE IF EXISTS app_users;
+DROP TABLE IF EXISTS food_equivalents;
+DROP TABLE IF EXISTS study_foods;
+DROP TABLE IF EXISTS study_substances;
+DROP TABLE IF EXISTS studies;
+DROP TABLE IF EXISTS food_substances;
+DROP TABLE IF EXISTS substance_synonyms;
+DROP TABLE IF EXISTS substances;
+DROP TABLE IF EXISTS food_nutrient_portions;
+DROP TABLE IF EXISTS food_nutrients;
+DROP TABLE IF EXISTS food_source_records;
+DROP TABLE IF EXISTS food_category_assignments;
+DROP TABLE IF EXISTS food_categories;
+DROP TABLE IF EXISTS food_portions;
+DROP TABLE IF EXISTS foods;
+DROP TABLE IF EXISTS nutrient_aliases;
+DROP TABLE IF EXISTS nutrient_definitions;
+DROP TABLE IF EXISTS import_batches;
+DROP TABLE IF EXISTS data_sources;
+DROP TABLE IF EXISTS nutrient_groups;
+DROP TABLE IF EXISTS measurement_units;
+DROP EXTENSION IF EXISTS "pgcrypto";

--- a/backend/internal/models/food.go
+++ b/backend/internal/models/food.go
@@ -1,0 +1,71 @@
+package models
+
+import "time"
+
+// Food represents a unified food entry sourced from one or more datasets.
+type Food struct {
+	ID               string     `db:"id"`
+	CanonicalName    string     `db:"canonical_name"`
+	GenericName      *string    `db:"generic_name"`
+	BrandName        *string    `db:"brand_name"`
+	CategoryPath     *string    `db:"category_path"`
+	IsProduct        bool       `db:"is_product"`
+	DefaultUnitID    int64      `db:"default_unit_id"`
+	SourceID         *int64     `db:"source_id"`
+	ExternalID       *string    `db:"external_id"`
+	DataQualityScore *int16     `db:"data_quality_score"`
+	LastVerifiedAt   *time.Time `db:"last_verified_at"`
+	CreatedAt        time.Time  `db:"created_at"`
+	UpdatedAt        time.Time  `db:"updated_at"`
+}
+
+// FoodPortion defines a serving or portion size for a food.
+type FoodPortion struct {
+	ID          int64    `db:"id"`
+	FoodID      string   `db:"food_id"`
+	PortionName string   `db:"portion_name"`
+	Quantity    float64  `db:"quantity"`
+	UnitID      int64    `db:"unit_id"`
+	GramWeight  *float64 `db:"gram_weight"`
+}
+
+// FoodCategory provides a hierarchical classification for foods.
+type FoodCategory struct {
+	ID       int64  `db:"id"`
+	Name     string `db:"name"`
+	ParentID *int64 `db:"parent_id"`
+}
+
+// FoodCategoryAssignment links foods to their categories.
+type FoodCategoryAssignment struct {
+	FoodID     string `db:"food_id"`
+	CategoryID int64  `db:"category_id"`
+}
+
+// FoodSourceRecord retains raw source payloads for traceability.
+type FoodSourceRecord struct {
+	ID         int64     `db:"id"`
+	FoodID     string    `db:"food_id"`
+	SourceID   int64     `db:"source_id"`
+	ExternalID *string   `db:"external_id"`
+	RawPayload []byte    `db:"raw_payload"`
+	BatchID    *int64    `db:"batch_id"`
+	LastSeenAt time.Time `db:"last_seen_at"`
+}
+
+// FoodNutrient stores the amount of a nutrient per 100 grams for a food.
+type FoodNutrient struct {
+	FoodID           string    `db:"food_id"`
+	NutrientID       int64     `db:"nutrient_id"`
+	AmountPer100g    float64   `db:"amount_per_100g"`
+	DerivationMethod *string   `db:"derivation_method"`
+	PrecisionSource  *string   `db:"precision_source"`
+	LastUpdatedAt    time.Time `db:"last_updated_at"`
+}
+
+// FoodNutrientPortion stores nutrient overrides for specific portions.
+type FoodNutrientPortion struct {
+	PortionID  int64   `db:"portion_id"`
+	NutrientID int64   `db:"nutrient_id"`
+	Amount     float64 `db:"amount"`
+}

--- a/backend/internal/models/reference.go
+++ b/backend/internal/models/reference.go
@@ -1,0 +1,61 @@
+package models
+
+import "time"
+
+// MeasurementUnit represents a canonical SI measurement unit used in the database.
+type MeasurementUnit struct {
+	ID          int64   `db:"id"`
+	Name        string  `db:"name"`
+	Symbol      string  `db:"symbol"`
+	Quantity    *string `db:"quantity"`
+	Description *string `db:"description"`
+}
+
+// NutrientGroup classifies nutrients into macro, micro, amino acid and other groupings.
+type NutrientGroup struct {
+	ID          int64   `db:"id"`
+	Name        string  `db:"name"`
+	Description *string `db:"description"`
+}
+
+// DataSource tracks external systems that provide nutrition or substance data.
+type DataSource struct {
+	ID          int64   `db:"id"`
+	Name        string  `db:"name"`
+	Type        string  `db:"type"`
+	EndpointURL *string `db:"endpoint_url"`
+	License     *string `db:"license"`
+	Notes       *string `db:"notes"`
+}
+
+// ImportBatch captures a single ingestion run from a data source.
+type ImportBatch struct {
+	ID          int64     `db:"id"`
+	SourceID    int64     `db:"source_id"`
+	ImportedAt  time.Time `db:"imported_at"`
+	Version     *string   `db:"version"`
+	RawFilePath *string   `db:"raw_file_path"`
+	Status      string    `db:"status"`
+}
+
+// NutrientDefinition defines a nutrient and its measurement semantics.
+type NutrientDefinition struct {
+	ID          int64     `db:"id"`
+	Code        string    `db:"code"`
+	Name        string    `db:"name"`
+	GroupID     *int64    `db:"group_id"`
+	UnitID      int64     `db:"unit_id"`
+	DailyValue  *float64  `db:"daily_value"`
+	Description *string   `db:"description"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
+}
+
+// NutrientAlias stores source-specific identifiers for nutrients.
+type NutrientAlias struct {
+	ID         int64   `db:"id"`
+	NutrientID int64   `db:"nutrient_id"`
+	SourceID   int64   `db:"source_id"`
+	Code       string  `db:"code"`
+	Name       *string `db:"name"`
+}

--- a/backend/internal/models/studies.go
+++ b/backend/internal/models/studies.go
@@ -1,0 +1,41 @@
+package models
+
+import "time"
+
+// Study stores references to scientific literature relating to foods or substances.
+type Study struct {
+	ID              int64      `db:"id"`
+	Title           string     `db:"title"`
+	Abstract        *string    `db:"abstract"`
+	PublicationDate *time.Time `db:"publication_date"`
+	DOIOrURL        *string    `db:"doi_or_url"`
+	Source          *string    `db:"source"`
+	AccessType      *string    `db:"access_type"`
+	CreatedAt       time.Time  `db:"created_at"`
+}
+
+// StudySubstance links a study to a specific substance with metadata on findings.
+type StudySubstance struct {
+	StudyID       int64   `db:"study_id"`
+	SubstanceID   int64   `db:"substance_id"`
+	FindingType   string  `db:"finding_type"`
+	EvidenceLevel *string `db:"evidence_level"`
+	Summary       *string `db:"summary"`
+	LinkStrength  *int16  `db:"link_strength"`
+}
+
+// StudyFood links a study to a food item.
+type StudyFood struct {
+	StudyID     int64   `db:"study_id"`
+	FoodID      string  `db:"food_id"`
+	FindingType *string `db:"finding_type"`
+	Summary     *string `db:"summary"`
+}
+
+// FoodEquivalent links two food entries believed to represent the same product.
+type FoodEquivalent struct {
+	PrimaryFoodID    string   `db:"primary_food_id"`
+	EquivalentFoodID string   `db:"equivalent_food_id"`
+	Confidence       *float64 `db:"confidence"`
+	Notes            *string  `db:"notes"`
+}

--- a/backend/internal/models/substances.go
+++ b/backend/internal/models/substances.go
@@ -1,0 +1,29 @@
+package models
+
+// Substance represents an additive or other tracked compound.
+type Substance struct {
+	ID               int64   `db:"id"`
+	Code             *string `db:"code"`
+	Name             string  `db:"name"`
+	Description      *string `db:"description"`
+	RiskLevel        *string `db:"risk_level"`
+	RegulatoryStatus *string `db:"regulatory_status"`
+	SubstanceType    *string `db:"substance_type"`
+}
+
+// SubstanceSynonym stores alternate labels for substances.
+type SubstanceSynonym struct {
+	ID          int64   `db:"id"`
+	SubstanceID int64   `db:"substance_id"`
+	Name        string  `db:"name"`
+	Locale      *string `db:"locale"`
+}
+
+// FoodSubstance links foods and substances optionally with quantity data.
+type FoodSubstance struct {
+	FoodID        string   `db:"food_id"`
+	SubstanceID   int64    `db:"substance_id"`
+	AmountPer100g *float64 `db:"amount_per_100g"`
+	SourceID      *int64   `db:"source_id"`
+	Notes         *string  `db:"notes"`
+}

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -1,0 +1,31 @@
+package models
+
+import "time"
+
+// AppUser represents an end user of the application that can log foods.
+type AppUser struct {
+	ID          string    `db:"id"`
+	Email       *string   `db:"email"`
+	DisplayName *string   `db:"display_name"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
+}
+
+// UserFoodLog captures a user's consumption of a specific food item.
+type UserFoodLog struct {
+	ID            string    `db:"id"`
+	UserID        string    `db:"user_id"`
+	FoodID        string    `db:"food_id"`
+	LoggedAt      time.Time `db:"logged_at"`
+	QuantityGrams float64   `db:"quantity_grams"`
+	PortionID     *int64    `db:"portion_id"`
+	Notes         *string   `db:"notes"`
+	Source        *string   `db:"source"`
+	CreatedAt     time.Time `db:"created_at"`
+}
+
+// UserFoodLogTag stores labels that users can apply to their food log entries.
+type UserFoodLogTag struct {
+	LogID string `db:"log_id"`
+	Tag   string `db:"tag"`
+}


### PR DESCRIPTION
## Summary
- remove the unused food_localizations table from the core schema migration
- drop the Go model that represented localized food names so only canonical names remain

## Testing
- go test ./... *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f4f67c12108322bcf25fbf28db3131