### PR TITLE
Refactor health service for shared logic

### DIFF
--- a/backend/internal/handlers/health/handler.go
+++ b/backend/internal/handlers/health/handler.go
@@ -17,5 +17,5 @@ func (h *Handler) RegisterRoutes(app *fiber.App) {
 }
 
 func (h *Handler) Health(c *fiber.Ctx) error {
-	return c.Status(fiber.StatusOK).JSON(h.service.Status())
+	return c.Status(fiber.StatusOK).JSON(h.service.Status(c.UserContext()))
 }

--- a/backend/internal/services/health/service.go
+++ b/backend/internal/services/health/service.go
@@ -1,26 +1,50 @@
 package health
 
-import "database/sql"
+import "context"
 
+// Pinger describes the minimal dependency required from a database
+// connection to execute a health check.
+type Pinger interface {
+	PingContext(ctx context.Context) error
+}
+
+// Status represents the health information returned to callers.
+type Status struct {
+	Status string            `json:"status"`
+	Checks map[string]string `json:"checks"`
+}
+
+// Service exposes health related operations consumed by HTTP handlers.
 type Service interface {
-	Status() map[string]string
+	Status(ctx context.Context) Status
 }
 
 type service struct {
-	db *sql.DB
+	db Pinger
 }
 
-func New(db *sql.DB) Service {
+// New constructs a health service backed by the provided database handle.
+func New(db Pinger) Service {
 	return &service{db: db}
 }
 
-func (s *service) Status() map[string]string {
-	status := "ok"
-	if err := s.db.Ping(); err != nil {
-		status = "database_unreachable"
+func (s *service) Status(ctx context.Context) Status {
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	return map[string]string{
-		"status": status,
+	checks := map[string]string{}
+	overall := "ok"
+
+	if err := s.db.PingContext(ctx); err != nil {
+		overall = "database_unreachable"
+		checks["database"] = "unreachable"
+	} else {
+		checks["database"] = "ok"
+	}
+
+	return Status{
+		Status: overall,
+		Checks: checks,
 	}
 }

--- a/backend/internal/services/health/service_test.go
+++ b/backend/internal/services/health/service_test.go
@@ -1,0 +1,66 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubPinger struct {
+	err     error
+	lastCtx context.Context
+}
+
+func (s *stubPinger) PingContext(ctx context.Context) error {
+	s.lastCtx = ctx
+	return s.err
+}
+
+func TestStatusDatabaseReachable(t *testing.T) {
+	svc := New(&stubPinger{})
+
+	result := svc.Status(context.Background())
+
+	if result.Status != "ok" {
+		t.Fatalf("expected overall status to be ok, got %q", result.Status)
+	}
+
+	dbStatus, ok := result.Checks["database"]
+	if !ok {
+		t.Fatalf("expected database check to be present")
+	}
+
+	if dbStatus != "ok" {
+		t.Fatalf("expected database status to be ok, got %q", dbStatus)
+	}
+}
+
+func TestStatusDatabaseUnreachable(t *testing.T) {
+	svc := New(&stubPinger{err: errors.New("unreachable")})
+
+	result := svc.Status(context.Background())
+
+	if result.Status != "database_unreachable" {
+		t.Fatalf("expected overall status to indicate database issue, got %q", result.Status)
+	}
+
+	dbStatus, ok := result.Checks["database"]
+	if !ok {
+		t.Fatalf("expected database check to be present")
+	}
+
+	if dbStatus != "unreachable" {
+		t.Fatalf("expected database status to be unreachable, got %q", dbStatus)
+	}
+}
+
+func TestStatusNilContextFallsBackToBackground(t *testing.T) {
+	pinger := &stubPinger{}
+	svc := New(pinger)
+
+	_ = svc.Status(nil)
+
+	if pinger.lastCtx == nil {
+		t.Fatalf("expected PingContext to receive a non-nil context")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce a health service interface that works with any dependency exposing PingContext and returns a structured status payload
- update the Fiber health handler to consume the new service signature and forward request context
- add unit tests covering healthy, unhealthy, and nil-context cases for the health service

## Testing
- go test ./... *(fails: unable to download Go module dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f52d1854cc8322acb7d478300dacbd