### PR TITLE
Run MCP server alongside main backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR /app
 COPY --from=builder /app/server ./server
 
 ENV PORT=3000
-EXPOSE 3000
+ENV MCP_HOST=0.0.0.0
+ENV MCP_PORT=4000
+EXPOSE 3000 4000
 
 CMD ["/app/server"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,10 +21,26 @@ If access to the public Go proxy is restricted, configure an alternative proxy o
 
 ```bash
 cd backend
-PORT=3000 go run ./cmd/server
+PORT=3000 MCP_PORT=4000 go run ./cmd/server
 ```
 
-The server exposes a basic health check at `GET /health`.
+The binary starts both the HTTP API and the MCP endpoint. The HTTP server exposes a basic health check at `GET /health`. The MCP server listens for tool invocations at `POST /call`. Requests should include the tool name and optional arguments, for example:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"tool":"health.status"}' \
+  http://localhost:4000/call
+```
+
+Set `MCP_TOKEN` to require Bearer token authentication and `MCP_HOST`/`MCP_PORT` to change the bind address.
+
+To run in Docker:
+
+```bash
+docker build -t bissbilanz-backend ./backend
+docker run --rm -p 3000:3000 -p 4000:4000 bissbilanz-backend
+```
 
 ## Project structure
 
@@ -32,11 +48,12 @@ The server exposes a basic health check at `GET /health`.
 backend/
 ├── cmd/
 │   └── server/
-│       └── main.go        # Application entrypoint
+│       └── main.go        # Application entrypoint (HTTP + MCP)
 ├── internal/
 │   ├── config/            # Configuration helpers
 │   ├── handlers/
 │   │   └── health/        # HTTP handlers
+│   ├── mcp/               # Minimal MCP server implementation
 │   └── services/
 │       └── health/        # Business logic/services
 ├── go.mod

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"context"
 	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/bissbilanz/backend/internal/config"
 	"github.com/bissbilanz/backend/internal/database"
 	healthhandler "github.com/bissbilanz/backend/internal/handlers/health"
+	"github.com/bissbilanz/backend/internal/mcp"
 	healthservice "github.com/bissbilanz/backend/internal/services/health"
 )
 
@@ -20,14 +27,79 @@ func main() {
 	}
 	defer db.Close()
 
-	app := fiber.New()
-
 	healthSvc := healthservice.New(db)
+
+	app := fiber.New()
 	healthHandler := healthhandler.New(healthSvc)
 	healthHandler.RegisterRoutes(app)
 
-	log.Printf("Starting server on %s", cfg.Address())
-	if err := app.Listen(cfg.Address()); err != nil {
-		log.Fatalf("failed to start server: %v", err)
+	var serverOpts []mcp.ServerOption
+	if token := cfg.MCPAuthToken(); token != "" {
+		serverOpts = append(serverOpts, mcp.WithAuthToken(token))
+	}
+
+	mcpServer := mcp.NewServer("bissbilanz-mcp", serverOpts...)
+	mcpServer.RegisterTool("health.status", func(ctx context.Context, call *mcp.ToolCall) (*mcp.ToolResponse, error) {
+		status := healthSvc.Status(ctx)
+		return &mcp.ToolResponse{Result: status}, nil
+	})
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := mcpServer.ListenAndServe(ctx, cfg.MCPAddress()); err != nil {
+			select {
+			case errCh <- err:
+			default:
+				log.Printf("mcp server error: %v", err)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := app.Listen(cfg.Address()); err != nil {
+			select {
+			case errCh <- err:
+			default:
+				log.Printf("http server error: %v", err)
+			}
+		}
+	}()
+
+	log.Printf("HTTP server listening on %s", cfg.Address())
+	log.Printf("MCP server listening on %s", cfg.MCPAddress())
+
+	select {
+	case <-ctx.Done():
+		log.Println("Shutdown signal received")
+	case err := <-errCh:
+		if err != nil {
+			log.Printf("server error: %v", err)
+		}
+	}
+
+	stop()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := app.ShutdownWithContext(shutdownCtx); err != nil {
+		log.Printf("failed to gracefully shutdown HTTP server: %v", err)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			log.Printf("server shutdown error: %v", err)
+		}
 	}
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,8 +3,8 @@ module github.com/bissbilanz/backend
 go 1.22
 
 require (
-	github.com/gofiber/fiber/v2 v2.52.4
-	github.com/lib/pq v1.10.9
+        github.com/gofiber/fiber/v2 v2.52.4
+        github.com/lib/pq v1.10.9
 )
 
 require (

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,6 +8,9 @@ import (
 type Config struct {
 	Port        string
 	DatabaseURL string
+	MCPHost     string
+	MCPPort     string
+	MCPToken    string
 }
 
 func Load() Config {
@@ -21,9 +24,24 @@ func Load() Config {
 		databaseURL = "postgres://postgres:postgres@localhost:5432/bissbilanz?sslmode=disable"
 	}
 
+	mcpHost := os.Getenv("MCP_HOST")
+	if mcpHost == "" {
+		mcpHost = "0.0.0.0"
+	}
+
+	mcpPort := os.Getenv("MCP_PORT")
+	if mcpPort == "" {
+		mcpPort = "4000"
+	}
+
+	mcpToken := os.Getenv("MCP_TOKEN")
+
 	return Config{
 		Port:        port,
 		DatabaseURL: databaseURL,
+		MCPHost:     mcpHost,
+		MCPPort:     mcpPort,
+		MCPToken:    mcpToken,
 	}
 }
 
@@ -33,4 +51,12 @@ func (c Config) Address() string {
 
 func (c Config) DSN() string {
 	return c.DatabaseURL
+}
+
+func (c Config) MCPAddress() string {
+	return fmt.Sprintf("%s:%s", c.MCPHost, c.MCPPort)
+}
+
+func (c Config) MCPAuthToken() string {
+	return c.MCPToken
 }

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -1,0 +1,145 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ToolHandler func(context.Context, *ToolCall) (*ToolResponse, error)
+
+type ToolCall struct {
+	Tool      string         `json:"tool"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+type ToolResponse struct {
+	Result any    `json:"result,omitempty"`
+	Error  *Error `json:"error,omitempty"`
+}
+
+type Error struct {
+	Message string `json:"message"`
+}
+
+type Server struct {
+	name      string
+	authToken string
+
+	mu    sync.RWMutex
+	tools map[string]ToolHandler
+}
+
+type ServerOption func(*Server)
+
+func WithAuthToken(token string) ServerOption {
+	return func(s *Server) {
+		s.authToken = token
+	}
+}
+
+func NewServer(name string, opts ...ServerOption) *Server {
+	srv := &Server{
+		name:  name,
+		tools: make(map[string]ToolHandler),
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(srv)
+		}
+	}
+
+	return srv
+}
+
+func (s *Server) RegisterTool(name string, handler ToolHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if handler == nil {
+		delete(s.tools, name)
+		return
+	}
+	s.tools[name] = handler
+}
+
+func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
+	server := &http.Server{
+		Addr:    addr,
+		Handler: s,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		close(done)
+	}()
+
+	err := server.ListenAndServe()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	<-done
+	return nil
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost || r.URL.Path != "/call" {
+		http.NotFound(w, r)
+		return
+	}
+
+	if s.authToken != "" {
+		auth := r.Header.Get("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(auth, prefix) || strings.TrimSpace(auth[len(prefix):]) != s.authToken {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	var call ToolCall
+	if err := json.NewDecoder(r.Body).Decode(&call); err != nil {
+		http.Error(w, "invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	handler := s.lookupTool(call.Tool)
+	if handler == nil {
+		writeJSON(w, http.StatusNotFound, &ToolResponse{Error: &Error{Message: "unknown tool"}})
+		return
+	}
+
+	resp, err := handler(r.Context(), &call)
+	if err != nil {
+		writeJSON(w, http.StatusOK, &ToolResponse{Error: &Error{Message: err.Error()}})
+		return
+	}
+
+	if resp == nil {
+		resp = &ToolResponse{}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) lookupTool(name string) ToolHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tools[name]
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}


### PR DESCRIPTION
## Summary
- run the MCP endpoint inside the existing server binary so both services share the same process
- remove the standalone MCP command and simplify the Docker image build
- refresh backend documentation to describe the unified entrypoint and updated container usage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f52f3989588322841140cb3fc7e116