### PR TITLE
Add Open Food Facts importer via generic import framework

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -18,7 +18,9 @@ import (
 	importshandler "github.com/bissbilanz/backend/internal/handlers/imports"
 	"github.com/bissbilanz/backend/internal/mcp"
 	healthservice "github.com/bissbilanz/backend/internal/services/health"
+	importservice "github.com/bissbilanz/backend/internal/services/imports"
 	naehrwertdatenservice "github.com/bissbilanz/backend/internal/services/imports/naehrwertdaten"
+	openfoodfactsservice "github.com/bissbilanz/backend/internal/services/imports/openfoodfacts"
 )
 
 func main() {
@@ -31,7 +33,9 @@ func main() {
 	defer db.Close()
 
 	healthSvc := healthservice.New(db)
-	naehrwertSvc, err := naehrwertdatenservice.New(db, &http.Client{Timeout: 120 * time.Second}, naehrwertdatenservice.Config{
+	httpClient := &http.Client{Timeout: 120 * time.Second}
+
+	naehrwertSvc, err := naehrwertdatenservice.New(db, httpClient, naehrwertdatenservice.Config{
 		BaseURL:     cfg.NaehrwertdatenBase(),
 		DatasetPath: cfg.NaehrwertdatenDataset(),
 		StorageDir:  cfg.StorageDir(),
@@ -42,10 +46,29 @@ func main() {
 		log.Fatalf("failed to initialize naehrwertdaten importer: %v", err)
 	}
 
+	openfoodfactsSvc, err := openfoodfactsservice.New(db, httpClient, openfoodfactsservice.Config{
+		BaseURL:    cfg.OpenFoodFactsBase(),
+		SearchPath: cfg.OpenFoodFactsSearchEndpoint(),
+		StorageDir: cfg.StorageDir(),
+		PageSize:   cfg.OpenFoodFactsPageLimit(),
+		MaxRecords: cfg.OpenFoodFactsRecordLimit(),
+		Query:      cfg.OpenFoodFactsQueryParams(),
+		Fields:     cfg.OpenFoodFactsFieldList(),
+		UserAgent:  cfg.OpenFoodFactsUserAgent(),
+	})
+	if err != nil {
+		log.Fatalf("failed to initialize Open Food Facts importer: %v", err)
+	}
+
+	services := map[string]importservice.Service{
+		"naehrwertdaten": naehrwertSvc,
+		"openfoodfacts":  openfoodfactsSvc,
+	}
+
 	app := fiber.New()
 	healthHandler := healthhandler.New(healthSvc)
 	healthHandler.RegisterRoutes(app)
-	importsHandler := importshandler.New(naehrwertSvc)
+	importsHandler := importshandler.New(services)
 	importsHandler.RegisterRoutes(app)
 
 	var serverOpts []mcp.ServerOption
@@ -58,10 +81,14 @@ func main() {
 		status := healthSvc.Status(ctx)
 		return &mcp.ToolResponse{Result: status}, nil
 	})
-       mcpServer.RegisterTool("naehrwertdaten.status", func(ctx context.Context, call *mcp.ToolCall) (*mcp.ToolResponse, error) {
-               status := naehrwertSvc.Status()
-               return &mcp.ToolResponse{Result: status}, nil
-       })
+	mcpServer.RegisterTool("naehrwertdaten.status", func(ctx context.Context, call *mcp.ToolCall) (*mcp.ToolResponse, error) {
+		status := naehrwertSvc.Status()
+		return &mcp.ToolResponse{Result: status}, nil
+	})
+	mcpServer.RegisterTool("openfoodfacts.status", func(ctx context.Context, call *mcp.ToolCall) (*mcp.ToolResponse, error) {
+		status := openfoodfactsSvc.Status()
+		return &mcp.ToolResponse{Result: status}, nil
+	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 )
 
 type Config struct {
@@ -17,6 +19,13 @@ type Config struct {
 	NaehrwertdatenDatasetPath string
 	NaehrwertdatenPageSize    int
 	NaehrwertdatenMaxRecords  int
+	OpenFoodFactsBaseURL      string
+	OpenFoodFactsSearchPath   string
+	OpenFoodFactsPageSize     int
+	OpenFoodFactsMaxRecords   int
+	OpenFoodFactsQuery        map[string]string
+	OpenFoodFactsFields       []string
+	OpenFoodFactsUA           string
 }
 
 func Load() Config {
@@ -71,6 +80,55 @@ func Load() Config {
 		}
 	}
 
+	offBase := os.Getenv("OPENFOODFACTS_BASE_URL")
+	if offBase == "" {
+		offBase = "https://world.openfoodfacts.org"
+	}
+
+	offPath := os.Getenv("OPENFOODFACTS_SEARCH_PATH")
+	if offPath == "" {
+		offPath = "/api/v2/search"
+	}
+
+	offPageSize := 200
+	if v := os.Getenv("OPENFOODFACTS_PAGE_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			offPageSize = n
+		}
+	}
+
+	offMaxRecords := 0
+	if v := os.Getenv("OPENFOODFACTS_MAX_RECORDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offMaxRecords = n
+		}
+	}
+
+	queryParams := make(map[string]string)
+	if raw := os.Getenv("OPENFOODFACTS_QUERY"); raw != "" {
+		if values, err := url.ParseQuery(raw); err == nil {
+			for key, vals := range values {
+				if len(vals) > 0 {
+					queryParams[key] = vals[len(vals)-1]
+				}
+			}
+		}
+	}
+
+	var fields []string
+	if raw := os.Getenv("OPENFOODFACTS_FIELDS"); raw != "" {
+		parts := strings.Split(raw, ",")
+		fields = make([]string, 0, len(parts))
+		for _, part := range parts {
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" {
+				fields = append(fields, trimmed)
+			}
+		}
+	}
+
+	userAgent := os.Getenv("OPENFOODFACTS_USER_AGENT")
+
 	return Config{
 		Port:                      port,
 		DatabaseURL:               databaseURL,
@@ -82,6 +140,13 @@ func Load() Config {
 		NaehrwertdatenDatasetPath: datasetPath,
 		NaehrwertdatenPageSize:    pageSize,
 		NaehrwertdatenMaxRecords:  maxRecords,
+		OpenFoodFactsBaseURL:      offBase,
+		OpenFoodFactsSearchPath:   offPath,
+		OpenFoodFactsPageSize:     offPageSize,
+		OpenFoodFactsMaxRecords:   offMaxRecords,
+		OpenFoodFactsQuery:        queryParams,
+		OpenFoodFactsFields:       fields,
+		OpenFoodFactsUA:           userAgent,
 	}
 }
 
@@ -119,4 +184,41 @@ func (c Config) NaehrwertdatenPageLimit() int {
 
 func (c Config) NaehrwertdatenRecordLimit() int {
 	return c.NaehrwertdatenMaxRecords
+}
+
+func (c Config) OpenFoodFactsBase() string {
+	return c.OpenFoodFactsBaseURL
+}
+
+func (c Config) OpenFoodFactsSearchEndpoint() string {
+	return c.OpenFoodFactsSearchPath
+}
+
+func (c Config) OpenFoodFactsPageLimit() int {
+	return c.OpenFoodFactsPageSize
+}
+
+func (c Config) OpenFoodFactsRecordLimit() int {
+	return c.OpenFoodFactsMaxRecords
+}
+
+func (c Config) OpenFoodFactsQueryParams() map[string]string {
+	result := make(map[string]string, len(c.OpenFoodFactsQuery))
+	for key, value := range c.OpenFoodFactsQuery {
+		result[key] = value
+	}
+	return result
+}
+
+func (c Config) OpenFoodFactsFieldList() []string {
+	if len(c.OpenFoodFactsFields) == 0 {
+		return nil
+	}
+	result := make([]string, len(c.OpenFoodFactsFields))
+	copy(result, c.OpenFoodFactsFields)
+	return result
+}
+
+func (c Config) OpenFoodFactsUserAgent() string {
+	return c.OpenFoodFactsUA
 }

--- a/backend/internal/handlers/imports/handler.go
+++ b/backend/internal/handlers/imports/handler.go
@@ -2,37 +2,54 @@ package imports
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
-	naehrwertservice "github.com/bissbilanz/backend/internal/services/imports/naehrwertdaten"
+	importservice "github.com/bissbilanz/backend/internal/services/imports"
 )
 
-// Handler wires HTTP routes to the importer service.
+// Handler wires HTTP routes to importer services.
 type Handler struct {
-	service naehrwertservice.Service
+	services map[string]importservice.Service
 }
 
-// New constructs a new handler using the provided importer service.
-func New(service naehrwertservice.Service) *Handler {
-	return &Handler{service: service}
+// New constructs a new handler using the provided importer services.
+func New(services map[string]importservice.Service) *Handler {
+	normalized := make(map[string]importservice.Service, len(services))
+	for key, svc := range services {
+		if svc == nil {
+			continue
+		}
+		normalized[strings.ToLower(key)] = svc
+	}
+	return &Handler{services: normalized}
 }
 
 // RegisterRoutes binds the import endpoints to the provided router.
 func (h *Handler) RegisterRoutes(app *fiber.App) {
 	group := app.Group("/imports")
-	group.Post("/naehrwertdaten", h.Trigger)
-	group.Get("/naehrwertdaten/status", h.Status)
+	group.Post("/:source", h.Trigger)
+	group.Get("/:source/status", h.Status)
 }
 
 // Trigger starts a new background import run.
 func (h *Handler) Trigger(c *fiber.Ctx) error {
-	status, err := h.service.Trigger(c.UserContext())
+	source := strings.ToLower(c.Params("source"))
+	svc, ok := h.services[source]
+	if !ok {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error":  "unknown import source",
+			"source": source,
+		})
+	}
+
+	status, err := svc.Trigger(c.UserContext())
 	if err != nil {
-		if errors.Is(err, naehrwertservice.ErrImportInProgress) {
+		if errors.Is(err, importservice.ErrImportInProgress) {
 			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
 				"error":  "import already in progress",
-				"status": h.service.Status(),
+				"status": svc.Status(),
 			})
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -44,5 +61,13 @@ func (h *Handler) Trigger(c *fiber.Ctx) error {
 
 // Status returns the last known import status without triggering a new run.
 func (h *Handler) Status(c *fiber.Ctx) error {
-	return c.Status(fiber.StatusOK).JSON(h.service.Status())
+	source := strings.ToLower(c.Params("source"))
+	svc, ok := h.services[source]
+	if !ok {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error":  "unknown import source",
+			"source": source,
+		})
+	}
+	return c.Status(fiber.StatusOK).JSON(svc.Status())
 }

--- a/backend/internal/services/imports/openfoodfacts/service.go
+++ b/backend/internal/services/imports/openfoodfacts/service.go
@@ -1,4 +1,4 @@
-package naehrwertdaten
+package openfoodfacts
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,13 +18,16 @@ import (
 	"github.com/bissbilanz/backend/internal/services/imports"
 )
 
-// Config collects runtime configuration for the importer service.
+// Config collects runtime configuration for the Open Food Facts importer.
 type Config struct {
-	BaseURL     string
-	DatasetPath string
-	StorageDir  string
-	PageSize    int
-	MaxRecords  int
+	BaseURL    string
+	SearchPath string
+	StorageDir string
+	PageSize   int
+	MaxRecords int
+	Query      map[string]string
+	Fields     []string
+	UserAgent  string
 }
 
 // Service exposes operations for triggering and monitoring imports.
@@ -38,13 +42,19 @@ type runner struct {
 	cfg    Config
 }
 
-// New constructs a new naehrwertdaten importer service instance.
+// New constructs a new Open Food Facts importer service instance.
 func New(db *sql.DB, client *http.Client, cfg Config) (Service, error) {
 	if db == nil {
 		return nil, errors.New("db is required")
 	}
 	if client == nil {
 		client = http.DefaultClient
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://world.openfoodfacts.org"
+	}
+	if cfg.SearchPath == "" {
+		cfg.SearchPath = "/api/v2/search"
 	}
 	if cfg.StorageDir == "" {
 		cfg.StorageDir = "./data"
@@ -53,7 +63,14 @@ func New(db *sql.DB, client *http.Client, cfg Config) (Service, error) {
 		return nil, fmt.Errorf("create storage dir: %w", err)
 	}
 	if cfg.PageSize <= 0 {
-		cfg.PageSize = 250
+		cfg.PageSize = 200
+	}
+	if cfg.Query == nil {
+		cfg.Query = map[string]string{
+			"json": "true",
+		}
+	} else {
+		cfg.Query["json"] = "true"
 	}
 
 	r := &runner{
@@ -70,9 +87,8 @@ func (r *runner) Execute(ctx context.Context) (imports.Result, error) {
 	if err != nil {
 		return imports.Result{}, err
 	}
-
 	if len(data) == 0 {
-		return imports.Result{Version: version}, errors.New("no data returned from naehrwertdaten")
+		return imports.Result{Version: version}, errors.New("no data returned from openfoodfacts")
 	}
 
 	filePath, err := r.persistRaw(data)
@@ -81,11 +97,11 @@ func (r *runner) Execute(ctx context.Context) (imports.Result, error) {
 	}
 
 	sourceID, err := imports.EnsureDataSource(ctx, r.db, imports.DataSourceInfo{
-		Name:        "Swiss Food Composition (naehrwertdaten.ch)",
+		Name:        "Open Food Facts",
 		Type:        "open_data",
 		EndpointURL: r.cfg.BaseURL,
-		License:     "CC BY 4.0",
-		Notes:       "Imported via automated pipeline from https://naehrwertdaten.ch/de/.",
+		License:     "ODbL 1.0",
+		Notes:       "Imported via automated pipeline from https://world.openfoodfacts.org.",
 	})
 	if err != nil {
 		return imports.Result{Version: version}, err
@@ -114,7 +130,7 @@ func (r *runner) fetchAll(ctx context.Context) ([]json.RawMessage, string, error
 	var all []json.RawMessage
 	var version string
 	page := 1
-	recordsLimit := r.cfg.MaxRecords
+	limit := r.cfg.MaxRecords
 
 	for {
 		select {
@@ -127,19 +143,16 @@ func (r *runner) fetchAll(ctx context.Context) ([]json.RawMessage, string, error
 		if err != nil {
 			return nil, version, err
 		}
-
 		if version == "" {
 			version = pageVersion
 		}
-
 		if len(items) == 0 {
 			break
 		}
-
 		all = append(all, items...)
 
-		if recordsLimit > 0 && len(all) >= recordsLimit {
-			all = all[:recordsLimit]
+		if limit > 0 && len(all) >= limit {
+			all = all[:limit]
 			break
 		}
 
@@ -155,33 +168,37 @@ func (r *runner) fetchAll(ctx context.Context) ([]json.RawMessage, string, error
 
 func (r *runner) fetchPage(ctx context.Context, page int) ([]json.RawMessage, string, bool, error) {
 	base := strings.TrimSuffix(r.cfg.BaseURL, "/")
-	path := r.cfg.DatasetPath
+	path := r.cfg.SearchPath
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	reqURL := fmt.Sprintf("%s%s", base, path)
+	endpoint := fmt.Sprintf("%s%s", base, path)
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("parse endpoint: %w", err)
+	}
 
-	query := make([]string, 0, 3)
-	if strings.Contains(reqURL, "?") {
-		parts := strings.SplitN(reqURL, "?", 2)
-		reqURL = parts[0]
-		if len(parts) == 2 && parts[1] != "" {
-			query = append(query, parts[1])
+	query := parsed.Query()
+	for key, value := range r.cfg.Query {
+		if strings.TrimSpace(value) != "" {
+			query.Set(key, value)
 		}
 	}
-
-	query = append(query, fmt.Sprintf("page=%d", page))
+	query.Set("page", strconv.Itoa(page))
 	if r.cfg.PageSize > 0 {
-		query = append(query, fmt.Sprintf("pageSize=%d", r.cfg.PageSize))
+		query.Set("page_size", strconv.Itoa(r.cfg.PageSize))
 	}
-
-	if len(query) > 0 {
-		reqURL = reqURL + "?" + strings.Join(query, "&")
+	if len(r.cfg.Fields) > 0 {
+		query.Set("fields", strings.Join(r.cfg.Fields, ","))
 	}
+	parsed.RawQuery = query.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 	if err != nil {
 		return nil, "", false, fmt.Errorf("build request: %w", err)
+	}
+	if ua := strings.TrimSpace(r.cfg.UserAgent); ua != "" {
+		req.Header.Set("User-Agent", ua)
 	}
 
 	resp, err := r.client.Do(req)
@@ -200,19 +217,28 @@ func (r *runner) fetchPage(ctx context.Context, page int) ([]json.RawMessage, st
 		return nil, "", false, fmt.Errorf("decode response page %d: %w", page, err)
 	}
 
-	items, err := extractItems(payload)
+	items, err := extractProducts(payload)
 	if err != nil {
 		return nil, "", false, err
 	}
 
-	version := extractString(payload, "version")
+	version := extractString(payload, "search_id")
+	if version == "" {
+		count := extractInt(payload, "count")
+		if count > 0 {
+			version = fmt.Sprintf("count-%d", count)
+		} else {
+			version = time.Now().UTC().Format(time.RFC3339)
+		}
+	}
+
 	hasMore := computeHasMore(payload, len(items), page)
 
 	return items, version, hasMore, nil
 }
 
 func (r *runner) persistRaw(items []json.RawMessage) (string, error) {
-	fileName := fmt.Sprintf("naehrwertdaten-%s.json", time.Now().UTC().Format("20060102-150405"))
+	fileName := fmt.Sprintf("openfoodfacts-%s.json", time.Now().UTC().Format("20060102-150405"))
 	path := filepath.Join(r.cfg.StorageDir, fileName)
 
 	tmpPath := path + ".tmp"
@@ -266,7 +292,7 @@ func (r *runner) applyData(ctx context.Context, batchID, sourceID int64, items [
 
 	var processed int
 	for _, raw := range items {
-		record, err := parseFood(raw)
+		record, err := parseProduct(raw)
 		if err != nil {
 			continue
 		}
@@ -301,69 +327,17 @@ func (r *runner) applyData(ctx context.Context, batchID, sourceID int64, items [
 	return processed, nil
 }
 
-func computeHasMore(payload map[string]json.RawMessage, itemsCount, page int) bool {
+func extractProducts(payload map[string]json.RawMessage) ([]json.RawMessage, error) {
 	if payload == nil {
-		return false
+		return nil, errors.New("empty response payload")
 	}
-	for _, key := range []string{"has_more", "hasMore"} {
-		if raw, ok := payload[key]; ok {
-			if b, err := strconv.ParseBool(strings.ToLower(strings.Trim(string(raw), "\""))); err == nil {
-				return b
-			}
-		}
+	if raw, ok := payload["products"]; ok {
+		return decodeArray(raw)
 	}
-
-	totalPages := extractInt(payload, "page_count")
-	if totalPages == 0 {
-		totalPages = extractInt(payload, "pageCount")
-	}
-	if totalPages == 0 {
-		totalPages = extractInt(payload, "total_pages")
-	}
-	if totalPages == 0 {
-		totalPages = extractInt(payload, "totalPages")
-	}
-	if totalPages > 0 {
-		return page < totalPages
-	}
-
-	totalItems := extractInt(payload, "total")
-	if totalItems == 0 {
-		totalItems = extractInt(payload, "total_items")
-	}
-	if totalItems > 0 && itemsCount > 0 {
-		pageSize := extractInt(payload, "page_size")
-		if pageSize == 0 {
-			pageSize = extractInt(payload, "pageSize")
-		}
-		if pageSize == 0 {
-			pageSize = itemsCount
-		}
-		return page*pageSize < totalItems
-	}
-
-	return itemsCount > 0
+	return nil, errors.New("unable to locate products array in response")
 }
 
-func extractItems(payload map[string]json.RawMessage) ([]json.RawMessage, error) {
-	keys := []string{"items", "data", "foods", "results", "records"}
-	for _, key := range keys {
-		if raw, ok := payload[key]; ok {
-			if arr, err := decodeArray(raw); err == nil {
-				return arr, nil
-			}
-			var nested map[string]json.RawMessage
-			if err := json.Unmarshal(raw, &nested); err == nil {
-				if arr, err := extractItems(nested); err == nil {
-					return arr, nil
-				}
-			}
-		}
-	}
-	return nil, errors.New("unable to locate items array in response")
-}
-
-func parseFood(raw json.RawMessage) (imports.FoodRecord, error) {
+func parseProduct(raw json.RawMessage) (imports.FoodRecord, error) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return imports.FoodRecord{}, err
@@ -374,142 +348,121 @@ func parseFood(raw json.RawMessage) (imports.FoodRecord, error) {
 		decodeString(obj["id"]),
 		decodeString(obj["_id"]),
 		decodeString(obj["code"]),
-		decodeString(obj["foodId"]),
 	)
 	record.Code = firstNonEmpty(
 		decodeString(obj["code"]),
-		decodeString(obj["foodCode"]),
+		decodeString(obj["id"]),
 	)
-	record.Name = firstNonEmpty(
-		decodeName(obj["name"]),
-		decodeName(obj["description"]),
-		decodeName(obj["displayName"]),
-		decodeString(obj["title"]),
-	)
-	record.CategoryPath = decodeCategory(obj["category"])
-	if record.CategoryPath == "" {
-		record.CategoryPath = decodeCategory(obj["categories"])
-	}
-	record.Nutrients = decodeNutrients(obj)
+	record.Name = decodeProductName(obj)
+	record.CategoryPath = decodeCategories(obj)
+	record.Nutrients = decodeNutriments(obj)
 	return record, nil
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if strings.TrimSpace(v) != "" {
-			return strings.TrimSpace(v)
+func decodeProductName(obj map[string]json.RawMessage) string {
+	languages := []string{"de", "en", "fr", "it", "es"}
+	for _, lang := range languages {
+		key := fmt.Sprintf("product_name_%s", lang)
+		if val := decodeString(obj[key]); val != "" {
+			return val
+		}
+	}
+	for _, lang := range languages {
+		key := fmt.Sprintf("generic_name_%s", lang)
+		if val := decodeString(obj[key]); val != "" {
+			return val
+		}
+	}
+	if val := decodeString(obj["product_name"]); val != "" {
+		return val
+	}
+	if val := decodeString(obj["generic_name"]); val != "" {
+		return val
+	}
+	if val := decodeString(obj["product_name_translations"]); val != "" {
+		return val
+	}
+	return ""
+}
+
+func decodeCategories(obj map[string]json.RawMessage) string {
+	if raw, ok := obj["categories_hierarchy"]; ok {
+		if arr, err := decodeArray(raw); err == nil {
+			return formatCategoryHierarchy(arr)
+		}
+	}
+	if raw, ok := obj["categories_tags"]; ok {
+		if arr, err := decodeArray(raw); err == nil {
+			return formatCategoryHierarchy(arr)
+		}
+	}
+	if raw, ok := obj["categories"]; ok {
+		if s := decodeString(raw); s != "" {
+			parts := strings.Split(s, ",")
+			for i := range parts {
+				parts[i] = formatCategory(parts[i])
+			}
+			return strings.Join(parts, " > ")
 		}
 	}
 	return ""
 }
 
-func decodeName(raw json.RawMessage) string {
-	if len(raw) == 0 {
+func formatCategoryHierarchy(arr []json.RawMessage) string {
+	if len(arr) == 0 {
 		return ""
 	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err == nil {
-		return strings.TrimSpace(s)
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err == nil {
-		for _, key := range []string{"de", "en", "fr", "it", "label", "name"} {
-			if val, ok := obj[key]; ok {
-				if str := decodeName(val); str != "" {
-					return str
-				}
-			}
+	parts := make([]string, 0, len(arr))
+	for _, raw := range arr {
+		if str := decodeString(raw); str != "" {
+			parts = append(parts, formatCategory(str))
 		}
 	}
-	return ""
+	return strings.Join(parts, " > ")
 }
 
-func decodeCategory(raw json.RawMessage) string {
-	if len(raw) == 0 {
+func formatCategory(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
 		return ""
 	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err == nil {
-		return strings.TrimSpace(s)
+	if idx := strings.Index(value, ":"); idx >= 0 && idx < len(value)-1 {
+		value = value[idx+1:]
 	}
-	var arr []json.RawMessage
-	if err := json.Unmarshal(raw, &arr); err == nil {
-		parts := make([]string, 0, len(arr))
-		for _, item := range arr {
-			if name := decodeName(item); name != "" {
-				parts = append(parts, name)
-				continue
-			}
-			if str := decodeString(item); str != "" {
-				parts = append(parts, str)
-			}
-		}
-		return strings.Join(parts, " > ")
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err == nil {
-		if path, ok := obj["path"]; ok {
-			if str := decodeCategory(path); str != "" {
-				return str
-			}
-		}
-		if name, ok := obj["name"]; ok {
-			if str := decodeName(name); str != "" {
-				return str
-			}
-		}
-	}
-	return ""
+	value = strings.ReplaceAll(value, "-", " ")
+	value = strings.ReplaceAll(value, "_", " ")
+	return strings.Title(value)
 }
 
-func decodeNutrients(obj map[string]json.RawMessage) []imports.NutrientRecord {
-	if obj == nil {
+func decodeNutriments(obj map[string]json.RawMessage) []imports.NutrientRecord {
+	raw, ok := obj["nutriments"]
+	if !ok || len(raw) == 0 {
 		return nil
 	}
-	var raw json.RawMessage
-	if val, ok := obj["nutrients"]; ok {
-		raw = val
-	} else if val, ok := obj["values"]; ok {
-		raw = val
-	}
-	if len(raw) == 0 {
+	var nutriments map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &nutriments); err != nil {
 		return nil
 	}
-	arr, err := decodeArray(raw)
-	if err != nil {
-		return nil
-	}
-	result := make([]imports.NutrientRecord, 0, len(arr))
-	for _, item := range arr {
-		var entry map[string]json.RawMessage
-		if err := json.Unmarshal(item, &entry); err != nil {
+	result := make([]imports.NutrientRecord, 0)
+	for key, valueRaw := range nutriments {
+		if !strings.HasSuffix(key, "_100g") {
 			continue
 		}
-		value := decodeFloat(entry["value"])
-		if value == 0 {
-			value = decodeFloat(entry["per100g"])
-		}
-		if value == 0 {
-			value = decodeFloat(entry["amount"])
-		}
-		code := firstNonEmpty(
-			decodeString(entry["code"]),
-			decodeString(entry["nutrientCode"]),
-			decodeString(entry["id"]),
-			decodeString(entry["short"]),
-		)
-		name := firstNonEmpty(
-			decodeName(entry["name"]),
-			decodeName(entry["description"]),
-			decodeString(entry["label"]),
-		)
-		unit := extractUnit(entry)
+		base := strings.TrimSuffix(key, "_100g")
+		value := decodeFloat(valueRaw)
 		if value == 0 {
 			continue
 		}
-		if code == "" && name == "" {
-			continue
+		unit := decodeString(nutriments[base+"_unit"])
+		if unit == "" {
+			if strings.HasSuffix(base, "-kcal") {
+				unit = "kcal"
+			} else if strings.HasSuffix(base, "-kj") {
+				unit = "kJ"
+			}
 		}
+		name := formatNutrientName(base)
+		code := formatNutrientCode(base)
 		result = append(result, imports.NutrientRecord{
 			Code:  code,
 			Name:  name,
@@ -520,54 +473,48 @@ func decodeNutrients(obj map[string]json.RawMessage) []imports.NutrientRecord {
 	return result
 }
 
-func extractUnit(entry map[string]json.RawMessage) string {
-	if entry == nil {
+func formatNutrientName(key string) string {
+	key = strings.TrimSpace(key)
+	key = strings.ReplaceAll(key, "_", " ")
+	key = strings.ReplaceAll(key, "-", " ")
+	if key == "" {
 		return ""
 	}
-	if raw, ok := entry["unit"]; ok {
-		if s := decodeString(raw); s != "" {
-			return s
-		}
-		var obj map[string]json.RawMessage
-		if err := json.Unmarshal(raw, &obj); err == nil {
-			for _, key := range []string{"symbol", "short", "abbreviation", "name"} {
-				if val, ok := obj[key]; ok {
-					if s := decodeString(val); s != "" {
-						return s
-					}
-				}
-			}
-		}
+	words := strings.Fields(key)
+	for i, word := range words {
+		words[i] = strings.Title(word)
 	}
-	for _, key := range []string{"unitShort", "unitSymbol", "unitLabel"} {
-		if raw, ok := entry[key]; ok {
-			if s := decodeString(raw); s != "" {
-				return s
-			}
-		}
-	}
-	return ""
+	return strings.Join(words, " ")
 }
 
-func decodeFloat(raw json.RawMessage) float64 {
-	if len(raw) == 0 {
-		return 0
+func formatNutrientCode(key string) string {
+	replacer := strings.NewReplacer("-", "_", " ", "_", ":", "_", ".", "_")
+	return strings.ToUpper(replacer.Replace(key))
+}
+
+func computeHasMore(payload map[string]json.RawMessage, itemsCount, page int) bool {
+	if payload == nil {
+		return false
 	}
-	var f float64
-	if err := json.Unmarshal(raw, &f); err == nil {
-		return f
+	totalPages := extractInt(payload, "page_count")
+	if totalPages == 0 {
+		totalPages = extractInt(payload, "pageCount")
 	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err == nil {
-		s = strings.TrimSpace(strings.ReplaceAll(s, ",", "."))
-		if s == "" {
-			return 0
+	if totalPages > 0 {
+		return page < totalPages
+	}
+	totalItems := extractInt(payload, "count")
+	if totalItems > 0 && itemsCount > 0 {
+		pageSize := extractInt(payload, "page_size")
+		if pageSize == 0 {
+			pageSize = extractInt(payload, "pageSize")
 		}
-		if v, err := strconv.ParseFloat(s, 64); err == nil {
-			return v
+		if pageSize == 0 {
+			pageSize = itemsCount
 		}
+		return page*pageSize < totalItems
 	}
-	return 0
+	return itemsCount > 0
 }
 
 func decodeArray(raw json.RawMessage) ([]json.RawMessage, error) {
@@ -596,6 +543,27 @@ func decodeString(raw json.RawMessage) string {
 		return strings.TrimSpace(s)
 	}
 	return ""
+}
+
+func decodeFloat(raw json.RawMessage) float64 {
+	if len(raw) == 0 {
+		return 0
+	}
+	var f float64
+	if err := json.Unmarshal(raw, &f); err == nil {
+		return f
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		s = strings.TrimSpace(strings.ReplaceAll(s, ",", "."))
+		if s == "" {
+			return 0
+		}
+		if v, err := strconv.ParseFloat(s, 64); err == nil {
+			return v
+		}
+	}
+	return 0
 }
 
 func extractString(payload map[string]json.RawMessage, key string) string {
@@ -629,4 +597,13 @@ func extractInt(payload map[string]json.RawMessage, key string) int {
 		}
 	}
 	return 0
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
 }

--- a/backend/internal/services/imports/service.go
+++ b/backend/internal/services/imports/service.go
@@ -1,0 +1,142 @@
+package imports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ErrImportInProgress indicates that a previous import run has not yet finished.
+var ErrImportInProgress = errors.New("import already running")
+
+// ImportStatus captures the current or last execution status of an importer.
+type ImportStatus struct {
+	JobID          string     `json:"job_id"`
+	Running        bool       `json:"running"`
+	StartedAt      time.Time  `json:"started_at"`
+	CompletedAt    *time.Time `json:"completed_at,omitempty"`
+	BatchID        *int64     `json:"batch_id,omitempty"`
+	Version        string     `json:"version,omitempty"`
+	ItemsProcessed int        `json:"items_processed"`
+	LastError      string     `json:"last_error,omitempty"`
+}
+
+// Result captures the output of an import execution.
+type Result struct {
+	Version        string
+	BatchID        int64
+	ItemsProcessed int
+}
+
+// Runner defines the behaviour required to execute a concrete import.
+type Runner interface {
+	Execute(ctx context.Context) (Result, error)
+}
+
+// Service exposes operations for triggering and monitoring imports.
+type Service interface {
+	Trigger(ctx context.Context) (ImportStatus, error)
+	Status() ImportStatus
+}
+
+type service struct {
+	runner Runner
+
+	mu      sync.Mutex
+	current ImportStatus
+	running bool
+	cancel  context.CancelFunc
+}
+
+// NewService constructs a new import service instance using the supplied runner.
+func NewService(runner Runner) (Service, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("runner is required")
+	}
+	return &service{runner: runner}, nil
+}
+
+// Trigger launches a new import run in the background.
+func (s *service) Trigger(ctx context.Context) (ImportStatus, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		return s.current, ErrImportInProgress
+	}
+
+	jobID := fmt.Sprintf("%d", time.Now().UnixNano())
+	now := time.Now().UTC()
+	jobCtx, cancel := context.WithCancel(context.Background())
+	if ctx != nil {
+		go func(parent context.Context, job context.Context, cancel context.CancelFunc) {
+			select {
+			case <-parent.Done():
+				cancel()
+			case <-job.Done():
+			}
+		}(ctx, jobCtx, cancel)
+	}
+
+	status := ImportStatus{
+		JobID:     jobID,
+		Running:   true,
+		StartedAt: now,
+	}
+	s.current = status
+	s.running = true
+	s.cancel = cancel
+
+	go s.run(jobCtx)
+
+	return status, nil
+}
+
+// Status returns information about the last known import state.
+func (s *service) Status() ImportStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.current
+}
+
+func (s *service) run(ctx context.Context) {
+	defer func() {
+		s.mu.Lock()
+		s.running = false
+		s.cancel = nil
+		s.mu.Unlock()
+	}()
+
+	status := s.Status()
+
+	result, err := s.runner.Execute(ctx)
+
+	completed := time.Now().UTC()
+
+	s.mu.Lock()
+	if result.BatchID != 0 {
+		status.BatchID = &result.BatchID
+	}
+	status.CompletedAt = &completed
+	status.ItemsProcessed = result.ItemsProcessed
+	status.Version = result.Version
+	status.Running = false
+	if err != nil {
+		status.LastError = err.Error()
+	} else {
+		status.LastError = ""
+	}
+	s.current = status
+	s.mu.Unlock()
+}
+
+// Cancel attempts to stop the current import run, if any.
+func (s *service) Cancel() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		s.cancel()
+	}
+}

--- a/backend/internal/services/imports/store.go
+++ b/backend/internal/services/imports/store.go
@@ -1,4 +1,4 @@
-package naehrwertdaten
+package imports
 
 import (
 	"context"
@@ -10,18 +10,47 @@ import (
 	"unicode"
 )
 
-type querier interface {
+// Querier abstracts the database operations needed by the importers.
+type Querier interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
-func ensureDataSource(ctx context.Context, q querier, baseURL string) (int64, error) {
-	const (
-		name    = "Swiss Food Composition (naehrwertdaten.ch)"
-		srcType = "open_data"
-		license = "CC BY 4.0"
-	)
-	notes := "Imported via automated pipeline from https://naehrwertdaten.ch/de/."
+// DataSourceInfo captures metadata about an external data source.
+type DataSourceInfo struct {
+	Name        string
+	Type        string
+	EndpointURL string
+	License     string
+	Notes       string
+}
+
+// FoodRecord represents the normalized data extracted from an external item.
+type FoodRecord struct {
+	ExternalID   string
+	Code         string
+	Name         string
+	CategoryPath string
+	Nutrients    []NutrientRecord
+	Raw          json.RawMessage
+}
+
+// NutrientRecord captures nutrient information for a food item.
+type NutrientRecord struct {
+	Code  string
+	Name  string
+	Unit  string
+	Value float64
+}
+
+// EnsureDataSource upserts a data source entry and returns its identifier.
+func EnsureDataSource(ctx context.Context, q Querier, info DataSourceInfo) (int64, error) {
+	if strings.TrimSpace(info.Name) == "" {
+		return 0, fmt.Errorf("data source name required")
+	}
+	if info.Type == "" {
+		info.Type = "open_data"
+	}
 	var id int64
 	if err := q.QueryRowContext(ctx, `
                 INSERT INTO data_sources (name, type, endpoint_url, license, notes)
@@ -31,13 +60,14 @@ func ensureDataSource(ctx context.Context, q querier, baseURL string) (int64, er
                     license = EXCLUDED.license,
                     notes = EXCLUDED.notes
                 RETURNING id
-        `, name, srcType, baseURL, license, notes).Scan(&id); err != nil {
+        `, info.Name, info.Type, info.EndpointURL, nullString(info.License), nullString(info.Notes)).Scan(&id); err != nil {
 		return 0, fmt.Errorf("ensure data source: %w", err)
 	}
 	return id, nil
 }
 
-func createImportBatch(ctx context.Context, q querier, sourceID int64, version, rawPath, status string) (int64, error) {
+// CreateImportBatch creates a new import batch entry.
+func CreateImportBatch(ctx context.Context, q Querier, sourceID int64, version, rawPath, status string) (int64, error) {
 	if status == "" {
 		status = "running"
 	}
@@ -52,7 +82,8 @@ func createImportBatch(ctx context.Context, q querier, sourceID int64, version, 
 	return id, nil
 }
 
-func updateImportBatchStatus(ctx context.Context, q querier, batchID int64, status string) error {
+// UpdateImportBatchStatus updates the completion status of a batch.
+func UpdateImportBatchStatus(ctx context.Context, q Querier, batchID int64, status string) error {
 	if _, err := q.ExecContext(ctx, `
                 UPDATE import_batches
                 SET status = $1, imported_at = NOW()
@@ -63,7 +94,8 @@ func updateImportBatchStatus(ctx context.Context, q querier, batchID int64, stat
 	return nil
 }
 
-func ensureMeasurementUnit(ctx context.Context, q querier, name, symbol, quantity, description string) (int64, error) {
+// EnsureMeasurementUnit upserts a measurement unit and returns its identifier.
+func EnsureMeasurementUnit(ctx context.Context, q Querier, name, symbol, quantity, description string) (int64, error) {
 	symbol = strings.TrimSpace(symbol)
 	if symbol == "" {
 		symbol = strings.ToLower(name)
@@ -87,7 +119,8 @@ func ensureMeasurementUnit(ctx context.Context, q querier, name, symbol, quantit
 	return id, nil
 }
 
-func upsertFood(ctx context.Context, q querier, sourceID, defaultUnitID int64, record FoodRecord) (string, error) {
+// UpsertFood inserts or updates a food entry and returns its identifier.
+func UpsertFood(ctx context.Context, q Querier, sourceID, defaultUnitID int64, record FoodRecord) (string, error) {
 	var foodID string
 	if err := q.QueryRowContext(ctx, `
                 INSERT INTO foods (
@@ -113,7 +146,8 @@ func upsertFood(ctx context.Context, q querier, sourceID, defaultUnitID int64, r
 	return foodID, nil
 }
 
-func upsertSourceRecord(ctx context.Context, q querier, sourceID, batchID int64, foodID string, externalID string, raw json.RawMessage) error {
+// UpsertSourceRecord stores the raw payload for a food item linked to an import batch.
+func UpsertSourceRecord(ctx context.Context, q Querier, sourceID, batchID int64, foodID string, externalID string, raw json.RawMessage) error {
 	if externalID == "" {
 		return fmt.Errorf("external id required for source record")
 	}
@@ -131,7 +165,8 @@ func upsertSourceRecord(ctx context.Context, q querier, sourceID, batchID int64,
 	return nil
 }
 
-func applyNutrients(ctx context.Context, q querier, foodID string, nutrients []NutrientRecord) error {
+// ApplyNutrients upserts the nutrient values for a food item.
+func ApplyNutrients(ctx context.Context, q Querier, foodID string, nutrients []NutrientRecord) error {
 	if len(nutrients) == 0 {
 		return nil
 	}
@@ -140,14 +175,14 @@ func applyNutrients(ctx context.Context, q querier, foodID string, nutrients []N
 		if nutrient.Value <= 0 {
 			continue
 		}
-		unitSymbol := normalizeUnitSymbol(nutrient.Unit)
+		unitSymbol := NormalizeUnitSymbol(nutrient.Unit)
 		if unitSymbol == "" {
 			unitSymbol = "g"
 		}
 		unitID, ok := unitCache[unitSymbol]
 		if !ok {
-			name := unitNameForSymbol(unitSymbol)
-			id, err := ensureMeasurementUnit(ctx, q, name, unitSymbol, "", "")
+			name := UnitNameForSymbol(unitSymbol)
+			id, err := EnsureMeasurementUnit(ctx, q, name, unitSymbol, "", "")
 			if err != nil {
 				return err
 			}
@@ -165,7 +200,7 @@ func applyNutrients(ctx context.Context, q querier, foodID string, nutrients []N
 	return nil
 }
 
-func ensureNutrientDefinition(ctx context.Context, q querier, nutrient NutrientRecord, unitID int64) (int64, error) {
+func ensureNutrientDefinition(ctx context.Context, q Querier, nutrient NutrientRecord, unitID int64) (int64, error) {
 	name := strings.TrimSpace(nutrient.Name)
 	code := strings.TrimSpace(nutrient.Code)
 	if code == "" {
@@ -192,7 +227,7 @@ func ensureNutrientDefinition(ctx context.Context, q querier, nutrient NutrientR
 	return id, nil
 }
 
-func upsertFoodNutrient(ctx context.Context, q querier, foodID string, nutrientID int64, amount float64) error {
+func upsertFoodNutrient(ctx context.Context, q Querier, foodID string, nutrientID int64, amount float64) error {
 	if _, err := q.ExecContext(ctx, `
                 INSERT INTO food_nutrients (food_id, nutrient_id, amount_per_100g, last_updated_at)
                 VALUES ($1, $2, $3, NOW())
@@ -205,6 +240,7 @@ func upsertFoodNutrient(ctx context.Context, q querier, foodID string, nutrientI
 	return nil
 }
 
+// NullString converts an empty string into a sql.NullString.
 func nullString(v string) sql.NullString {
 	v = strings.TrimSpace(v)
 	if v == "" {
@@ -213,7 +249,8 @@ func nullString(v string) sql.NullString {
 	return sql.NullString{String: v, Valid: true}
 }
 
-func normalizeUnitSymbol(symbol string) string {
+// NormalizeUnitSymbol canonicalizes unit symbols for consistent storage.
+func NormalizeUnitSymbol(symbol string) string {
 	symbol = strings.TrimSpace(symbol)
 	if symbol == "" {
 		return ""
@@ -257,7 +294,8 @@ func normalizeUnitSymbol(symbol string) string {
 	}
 }
 
-func unitNameForSymbol(symbol string) string {
+// UnitNameForSymbol returns a human readable name for a unit symbol.
+func UnitNameForSymbol(symbol string) string {
 	switch strings.ToLower(symbol) {
 	case "g":
 		return "Gram"


### PR DESCRIPTION
## Summary
- extract a reusable import service and shared persistence helpers for background runs
- refactor the naehrwertdaten importer to use the generic workflow
- add an Open Food Facts importer and expose it through HTTP and MCP endpoints with new configuration options

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f69685b7088322b8fba71c567cce11