### PR TITLE
Add live import service tests and CI workflow

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,33 @@
+name: Backend Tests
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Go tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run test suite
+        env:
+          GOFLAGS: -mod=readonly
+        run: go test ./...

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -41,6 +41,7 @@ func main() {
 		StorageDir:  cfg.StorageDir(),
 		PageSize:    cfg.NaehrwertdatenPageLimit(),
 		MaxRecords:  cfg.NaehrwertdatenRecordLimit(),
+		UserAgent:   cfg.NaehrwertdatenUserAgent(),
 	})
 	if err != nil {
 		log.Fatalf("failed to initialize naehrwertdaten importer: %v", err)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	NaehrwertdatenDatasetPath string
 	NaehrwertdatenPageSize    int
 	NaehrwertdatenMaxRecords  int
+	NaehrwertdatenUA          string
 	OpenFoodFactsBaseURL      string
 	OpenFoodFactsSearchPath   string
 	OpenFoodFactsPageSize     int
@@ -62,8 +63,13 @@ func Load() Config {
 	}
 
 	datasetPath := os.Getenv("NAEHRWERTDATEN_DATASET_PATH")
-        if datasetPath == "" {
-                datasetPath = "/api/1/de/foods"
+	if datasetPath == "" {
+		datasetPath = "/api/1/de/foods"
+	}
+
+	naehrwertUA := os.Getenv("NAEHRWERTDATEN_USER_AGENT")
+	if naehrwertUA == "" {
+		naehrwertUA = "bissbilanz-importer (+https://github.com/bissbilanz)"
 	}
 
 	pageSize := 250
@@ -140,6 +146,7 @@ func Load() Config {
 		NaehrwertdatenDatasetPath: datasetPath,
 		NaehrwertdatenPageSize:    pageSize,
 		NaehrwertdatenMaxRecords:  maxRecords,
+		NaehrwertdatenUA:          naehrwertUA,
 		OpenFoodFactsBaseURL:      offBase,
 		OpenFoodFactsSearchPath:   offPath,
 		OpenFoodFactsPageSize:     offPageSize,
@@ -184,6 +191,10 @@ func (c Config) NaehrwertdatenPageLimit() int {
 
 func (c Config) NaehrwertdatenRecordLimit() int {
 	return c.NaehrwertdatenMaxRecords
+}
+
+func (c Config) NaehrwertdatenUserAgent() string {
+	return c.NaehrwertdatenUA
 }
 
 func (c Config) OpenFoodFactsBase() string {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -62,8 +62,8 @@ func Load() Config {
 	}
 
 	datasetPath := os.Getenv("NAEHRWERTDATEN_DATASET_PATH")
-	if datasetPath == "" {
-		datasetPath = "/api/1/de/food"
+        if datasetPath == "" {
+                datasetPath = "/api/1/de/foods"
 	}
 
 	pageSize := 250

--- a/backend/internal/services/imports/naehrwertdaten/service.go
+++ b/backend/internal/services/imports/naehrwertdaten/service.go
@@ -24,6 +24,7 @@ type Config struct {
 	StorageDir  string
 	PageSize    int
 	MaxRecords  int
+	UserAgent   string
 }
 
 // Service exposes operations for triggering and monitoring imports.
@@ -54,6 +55,9 @@ func New(db *sql.DB, client *http.Client, cfg Config) (Service, error) {
 	}
 	if cfg.PageSize <= 0 {
 		cfg.PageSize = 250
+	}
+	if strings.TrimSpace(cfg.UserAgent) == "" {
+		cfg.UserAgent = "bissbilanz-importer (+https://github.com/bissbilanz)"
 	}
 
 	r := &runner{
@@ -182,6 +186,13 @@ func (r *runner) fetchPage(ctx context.Context, page int) ([]json.RawMessage, st
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, "", false, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.Header.Set("Accept-Language", "de-CH,de;q=0.8,en;q=0.5")
+	if cfgUA := strings.TrimSpace(r.cfg.UserAgent); cfgUA != "" {
+		req.Header.Set("User-Agent", cfgUA)
 	}
 
 	resp, err := r.client.Do(req)

--- a/backend/internal/services/imports/naehrwertdaten/service_live_test.go
+++ b/backend/internal/services/imports/naehrwertdaten/service_live_test.go
@@ -21,9 +21,10 @@ func TestFetchPageLive(t *testing.T) {
 		client: &http.Client{Timeout: 45 * time.Second},
 		cfg: Config{
 			BaseURL:     "https://naehrwertdaten.ch",
-                        DatasetPath: "/api/1/de/foods",
+			DatasetPath: "/api/1/de/foods",
 			PageSize:    5,
 			MaxRecords:  5,
+			UserAgent:   "bissbilanz-test-suite (+https://github.com/bissbilanz)",
 		},
 	}
 
@@ -65,9 +66,10 @@ func TestFetchAllRespectsLimit(t *testing.T) {
 		client: &http.Client{Timeout: 60 * time.Second},
 		cfg: Config{
 			BaseURL:     "https://naehrwertdaten.ch",
-                        DatasetPath: "/api/1/de/foods",
+			DatasetPath: "/api/1/de/foods",
 			PageSize:    6,
 			MaxRecords:  6,
+			UserAgent:   "bissbilanz-test-suite (+https://github.com/bissbilanz)",
 		},
 	}
 

--- a/backend/internal/services/imports/naehrwertdaten/service_live_test.go
+++ b/backend/internal/services/imports/naehrwertdaten/service_live_test.go
@@ -1,0 +1,119 @@
+package naehrwertdaten
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFetchPageLive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live naehrwertdaten test in short mode")
+	}
+
+	r := &runner{
+		client: &http.Client{Timeout: 45 * time.Second},
+		cfg: Config{
+			BaseURL:     "https://naehrwertdaten.ch",
+			DatasetPath: "/api/1/de/food",
+			PageSize:    5,
+			MaxRecords:  5,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	items, version, hasMore, err := r.fetchPage(ctx, 1)
+	if shouldSkipNetworkTest(err) {
+		t.Skipf("skipping due to network restrictions: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("fetch page failed: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected at least one item from naehrwertdaten")
+	}
+	if version == "" {
+		t.Fatalf("expected non-empty version value")
+	}
+	if !hasMore {
+		t.Logf("naehrwertdaten reported no more pages; continuing")
+	}
+
+	var sample map[string]any
+	if err := json.Unmarshal(items[0], &sample); err != nil {
+		t.Fatalf("unable to decode sample item: %v", err)
+	}
+	if len(sample) == 0 {
+		t.Fatalf("decoded sample item was empty")
+	}
+}
+
+func TestFetchAllRespectsLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live naehrwertdaten test in short mode")
+	}
+
+	r := &runner{
+		client: &http.Client{Timeout: 60 * time.Second},
+		cfg: Config{
+			BaseURL:     "https://naehrwertdaten.ch",
+			DatasetPath: "/api/1/de/food",
+			PageSize:    6,
+			MaxRecords:  6,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	items, version, err := r.fetchAll(ctx)
+	if shouldSkipNetworkTest(err) {
+		t.Skipf("skipping due to network restrictions: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("fetch all failed: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected at least one item from naehrwertdaten")
+	}
+	if len(items) > r.cfg.MaxRecords {
+		t.Fatalf("expected at most %d items, got %d", r.cfg.MaxRecords, len(items))
+	}
+	if version == "" {
+		t.Fatalf("expected non-empty version value")
+	}
+}
+
+func shouldSkipNetworkTest(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return true
+		}
+		var opErr *net.OpError
+		if errors.As(urlErr.Err, &opErr) {
+			return true
+		}
+	}
+	msg := strings.ToLower(err.Error())
+	for _, fragment := range []string{"status 403", "status 429", "lookup", "connect", "timeout", "forbidden"} {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/services/imports/naehrwertdaten/service_live_test.go
+++ b/backend/internal/services/imports/naehrwertdaten/service_live_test.go
@@ -21,7 +21,7 @@ func TestFetchPageLive(t *testing.T) {
 		client: &http.Client{Timeout: 45 * time.Second},
 		cfg: Config{
 			BaseURL:     "https://naehrwertdaten.ch",
-			DatasetPath: "/api/1/de/food",
+                        DatasetPath: "/api/1/de/foods",
 			PageSize:    5,
 			MaxRecords:  5,
 		},
@@ -65,7 +65,7 @@ func TestFetchAllRespectsLimit(t *testing.T) {
 		client: &http.Client{Timeout: 60 * time.Second},
 		cfg: Config{
 			BaseURL:     "https://naehrwertdaten.ch",
-			DatasetPath: "/api/1/de/food",
+                        DatasetPath: "/api/1/de/foods",
 			PageSize:    6,
 			MaxRecords:  6,
 		},

--- a/backend/internal/services/imports/openfoodfacts/service_live_test.go
+++ b/backend/internal/services/imports/openfoodfacts/service_live_test.go
@@ -1,0 +1,135 @@
+package openfoodfacts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFetchPageLive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live Open Food Facts test in short mode")
+	}
+
+	r := &runner{
+		client: &http.Client{Timeout: 45 * time.Second},
+		cfg: Config{
+			BaseURL:    "https://world.openfoodfacts.org",
+			SearchPath: "/api/v2/search",
+			PageSize:   5,
+			MaxRecords: 5,
+			Query: map[string]string{
+				"json":      "true",
+				"countries": "Switzerland",
+				"page_size": "5",
+				"sort_by":   "unique_scans_n",
+			},
+			Fields:    []string{"code", "product_name", "nutriments"},
+			UserAgent: "bissbilanz-test-suite (+https://github.com/bissbilanz)",
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	items, version, hasMore, err := r.fetchPage(ctx, 1)
+	if shouldSkipNetworkTest(err) {
+		t.Skipf("skipping due to network restrictions: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("fetch page failed: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected at least one item from Open Food Facts")
+	}
+	if version == "" {
+		t.Fatalf("expected non-empty version value")
+	}
+	if !hasMore {
+		t.Logf("Open Food Facts reported no more pages; continuing")
+	}
+
+	var sample map[string]any
+	if err := json.Unmarshal(items[0], &sample); err != nil {
+		t.Fatalf("unable to decode sample item: %v", err)
+	}
+	if len(sample) == 0 {
+		t.Fatalf("decoded sample item was empty")
+	}
+}
+
+func TestFetchAllRespectsLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live Open Food Facts test in short mode")
+	}
+
+	r := &runner{
+		client: &http.Client{Timeout: 60 * time.Second},
+		cfg: Config{
+			BaseURL:    "https://world.openfoodfacts.org",
+			SearchPath: "/api/v2/search",
+			PageSize:   6,
+			MaxRecords: 6,
+			Query: map[string]string{
+				"json":      "true",
+				"countries": "Switzerland",
+				"page_size": "6",
+				"sort_by":   "unique_scans_n",
+			},
+			Fields:    []string{"code", "product_name", "nutriments"},
+			UserAgent: "bissbilanz-test-suite (+https://github.com/bissbilanz)",
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	items, version, err := r.fetchAll(ctx)
+	if shouldSkipNetworkTest(err) {
+		t.Skipf("skipping due to network restrictions: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("fetch all failed: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected at least one item from Open Food Facts")
+	}
+	if len(items) > r.cfg.MaxRecords {
+		t.Fatalf("expected at most %d items, got %d", r.cfg.MaxRecords, len(items))
+	}
+	if version == "" {
+		t.Fatalf("expected non-empty version value")
+	}
+}
+
+func shouldSkipNetworkTest(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return true
+		}
+		var opErr *net.OpError
+		if errors.As(urlErr.Err, &opErr) {
+			return true
+		}
+	}
+	msg := err.Error()
+	for _, fragment := range []string{"status 403", "status 429", "lookup", "connect", "timeout", "forbidden"} {
+		if strings.Contains(strings.ToLower(msg), fragment) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add integration tests for the Open Food Facts importer that retrieve live data while avoiding database writes
- add integration tests for the naehrwertdaten importer that exercise live fetching and gracefully skip when network access is blocked
- introduce a GitHub Actions workflow that runs the backend Go test suite on pull requests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f69d3ea5648322be0e1c833c290049