### PR TITLE
Add iOS login app and backend authentication endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -14,9 +14,11 @@ import (
 
 	"github.com/bissbilanz/backend/internal/config"
 	"github.com/bissbilanz/backend/internal/database"
+	authhandler "github.com/bissbilanz/backend/internal/handlers/auth"
 	healthhandler "github.com/bissbilanz/backend/internal/handlers/health"
 	importshandler "github.com/bissbilanz/backend/internal/handlers/imports"
 	"github.com/bissbilanz/backend/internal/mcp"
+	authservice "github.com/bissbilanz/backend/internal/services/auth"
 	healthservice "github.com/bissbilanz/backend/internal/services/health"
 	importservice "github.com/bissbilanz/backend/internal/services/imports"
 	naehrwertdatenservice "github.com/bissbilanz/backend/internal/services/imports/naehrwertdaten"
@@ -66,6 +68,16 @@ func main() {
 	}
 
 	app := fiber.New()
+	authSvc := authservice.New(authservice.Config{
+		Email:       cfg.DemoUserEmail,
+		Password:    cfg.DemoUserPassword,
+		Token:       cfg.DemoUserToken,
+		UserID:      cfg.DemoUserID,
+		DisplayName: cfg.DemoUserDisplayName,
+	})
+
+	authHandler := authhandler.New(authSvc)
+	authHandler.RegisterRoutes(app)
 	healthHandler := healthhandler.New(healthSvc)
 	healthHandler.RegisterRoutes(app)
 	importsHandler := importshandler.New(services)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -26,6 +26,11 @@ type Config struct {
 	OpenFoodFactsQuery        map[string]string
 	OpenFoodFactsFields       []string
 	OpenFoodFactsUA           string
+	DemoUserEmail             string
+	DemoUserPassword          string
+	DemoUserToken             string
+	DemoUserID                string
+	DemoUserDisplayName       string
 }
 
 func Load() Config {
@@ -129,6 +134,12 @@ func Load() Config {
 
 	userAgent := os.Getenv("OPENFOODFACTS_USER_AGENT")
 
+	demoEmail := os.Getenv("AUTH_DEMO_EMAIL")
+	demoPassword := os.Getenv("AUTH_DEMO_PASSWORD")
+	demoToken := os.Getenv("AUTH_DEMO_TOKEN")
+	demoUserID := os.Getenv("AUTH_DEMO_USER_ID")
+	demoDisplayName := os.Getenv("AUTH_DEMO_DISPLAY_NAME")
+
 	return Config{
 		Port:                      port,
 		DatabaseURL:               databaseURL,
@@ -147,6 +158,11 @@ func Load() Config {
 		OpenFoodFactsQuery:        queryParams,
 		OpenFoodFactsFields:       fields,
 		OpenFoodFactsUA:           userAgent,
+		DemoUserEmail:             demoEmail,
+		DemoUserPassword:          demoPassword,
+		DemoUserToken:             demoToken,
+		DemoUserID:                demoUserID,
+		DemoUserDisplayName:       demoDisplayName,
 	}
 }
 

--- a/backend/internal/handlers/auth/handler.go
+++ b/backend/internal/handlers/auth/handler.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gofiber/fiber/v2"
+
+	authservice "github.com/bissbilanz/backend/internal/services/auth"
+)
+
+// Handler exposes authentication related HTTP endpoints.
+type Handler struct {
+	service *authservice.Service
+}
+
+// New creates a new Handler instance.
+func New(service *authservice.Service) *Handler {
+	return &Handler{service: service}
+}
+
+// RegisterRoutes registers the login endpoint on the provided router.
+func (h *Handler) RegisterRoutes(app *fiber.App) {
+	app.Post("/auth/login", h.login)
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type loginResponse struct {
+	Token string                  `json:"token"`
+	User  authservice.UserProfile `json:"user"`
+}
+
+func (h *Handler) login(c *fiber.Ctx) error {
+	var req loginRequest
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(http.StatusBadRequest, "invalid request body")
+	}
+
+	if req.Email == "" || req.Password == "" {
+		return fiber.NewError(http.StatusBadRequest, "email and password are required")
+	}
+
+	result, err := h.service.Authenticate(c.Context(), req.Email, req.Password)
+	if err != nil {
+		if errors.Is(err, authservice.ErrInvalidCredentials) {
+			return fiber.NewError(http.StatusUnauthorized, "invalid credentials")
+		}
+		return fiber.NewError(http.StatusInternalServerError, "authentication failed")
+	}
+
+	return c.Status(http.StatusOK).JSON(loginResponse{Token: result.Token, User: result.User})
+}

--- a/backend/internal/handlers/auth/handler_test.go
+++ b/backend/internal/handlers/auth/handler_test.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	authservice "github.com/bissbilanz/backend/internal/services/auth"
+)
+
+func TestLoginSuccess(t *testing.T) {
+	app := fiber.New()
+	service := authservice.New(authservice.Config{Email: "user@example.com", Password: "secret", Token: "token-123"})
+	handler := New(service)
+	handler.RegisterRoutes(app)
+
+	payload := map[string]string{"email": "user@example.com", "password": "secret"}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test error: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var result loginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if result.Token != "token-123" {
+		t.Fatalf("unexpected token: %s", result.Token)
+	}
+	if result.User.Email != "user@example.com" {
+		t.Fatalf("unexpected email: %s", result.User.Email)
+	}
+}
+
+func TestLoginInvalidCredentials(t *testing.T) {
+	app := fiber.New()
+	service := authservice.New(authservice.Config{Email: "user@example.com", Password: "secret"})
+	handler := New(service)
+	handler.RegisterRoutes(app)
+
+	payload := map[string]string{"email": "user@example.com", "password": "wrong"}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test error: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoginBadRequest(t *testing.T) {
+	app := fiber.New()
+	service := authservice.New(authservice.Config{})
+	handler := New(service)
+	handler.RegisterRoutes(app)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader([]byte("{invalid")))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test error: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", resp.StatusCode)
+	}
+}

--- a/backend/internal/services/auth/service.go
+++ b/backend/internal/services/auth/service.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrInvalidCredentials = errors.New("invalid credentials")
+
+// Config defines the expected demo credentials used for authenticating users
+// in development environments. In the absence of a real user store, these
+// values allow clients to exercise the login flow end-to-end.
+type Config struct {
+	Email       string
+	Password    string
+	Token       string
+	UserID      string
+	DisplayName string
+}
+
+// UserProfile describes the minimal information returned for an authenticated
+// user.
+type UserProfile struct {
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	DisplayName string `json:"displayName"`
+}
+
+// AuthResult captures the authentication token and associated profile returned
+// by the service when credentials are valid.
+type AuthResult struct {
+	Token string
+	User  UserProfile
+}
+
+// Service verifies user credentials against the configured demo account.
+type Service struct {
+	cfg Config
+}
+
+// New instantiates a Service using the provided configuration. Fields left
+// empty fall back to opinionated development defaults.
+func New(cfg Config) *Service {
+	defaults := Config{
+		Email:       "demo@bissbilanz.ch",
+		Password:    "password123",
+		Token:       "demo-token",
+		UserID:      "demo-user",
+		DisplayName: "Demo User",
+	}
+
+	if cfg.Email == "" {
+		cfg.Email = defaults.Email
+	}
+	if cfg.Password == "" {
+		cfg.Password = defaults.Password
+	}
+	if cfg.Token == "" {
+		cfg.Token = defaults.Token
+	}
+	if cfg.UserID == "" {
+		cfg.UserID = defaults.UserID
+	}
+	if cfg.DisplayName == "" {
+		cfg.DisplayName = defaults.DisplayName
+	}
+
+	return &Service{cfg: cfg}
+}
+
+// Authenticate validates the provided credentials. On success it returns the
+// configured token and user profile, otherwise ErrInvalidCredentials.
+func (s *Service) Authenticate(_ context.Context, email, password string) (AuthResult, error) {
+	if email != s.cfg.Email || password != s.cfg.Password {
+		return AuthResult{}, ErrInvalidCredentials
+	}
+
+	profile := UserProfile{
+		ID:          s.cfg.UserID,
+		Email:       s.cfg.Email,
+		DisplayName: s.cfg.DisplayName,
+	}
+
+	return AuthResult{Token: s.cfg.Token, User: profile}, nil
+}

--- a/backend/internal/services/auth/service_test.go
+++ b/backend/internal/services/auth/service_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAuthenticateSuccess(t *testing.T) {
+	svc := New(Config{Email: "user@example.com", Password: "secret", Token: "token-123", UserID: "user-1", DisplayName: "Test User"})
+
+	res, err := svc.Authenticate(context.Background(), "user@example.com", "secret")
+	if err != nil {
+		t.Fatalf("Authenticate returned error: %v", err)
+	}
+
+	if res.Token != "token-123" {
+		t.Fatalf("unexpected token: %s", res.Token)
+	}
+
+	if res.User.ID != "user-1" || res.User.Email != "user@example.com" || res.User.DisplayName != "Test User" {
+		t.Fatalf("unexpected user profile: %+v", res.User)
+	}
+}
+
+func TestAuthenticateInvalidCredentials(t *testing.T) {
+	svc := New(Config{Email: "user@example.com", Password: "secret"})
+
+	_, err := svc.Authenticate(context.Background(), "user@example.com", "wrong")
+	if err == nil {
+		t.Fatal("expected error for invalid credentials")
+	}
+	if err != ErrInvalidCredentials {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/ios/Bissbilanz/Bissbilanz.xcodeproj/project.pbxproj
+++ b/ios/Bissbilanz/Bissbilanz.xcodeproj/project.pbxproj
@@ -1,0 +1,333 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+AA1F6D9E2B1C4B1A00000040 /* BissbilanzApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1F6D9E2B1C4B1A00000020 /* BissbilanzApp.swift */; };
+AA1F6D9E2B1C4B1A00000041 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1F6D9E2B1C4B1A00000021 /* ContentView.swift */; };
+AA1F6D9E2B1C4B1A00000042 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1F6D9E2B1C4B1A00000022 /* APIClient.swift */; };
+AA1F6D9E2B1C4B1A00000043 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1F6D9E2B1C4B1A00000023 /* LoginViewModel.swift */; };
+AA1F6D9E2B1C4B1A00000044 /* AuthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1F6D9E2B1C4B1A00000024 /* AuthModels.swift */; };
+AA1F6D9E2B1C4B1A00000045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA1F6D9E2B1C4B1A00000025 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+AA1F6D9E2B1C4B1A00000020 /* BissbilanzApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BissbilanzApp.swift; sourceTree = "<group>"; };
+AA1F6D9E2B1C4B1A00000021 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+AA1F6D9E2B1C4B1A00000022 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+AA1F6D9E2B1C4B1A00000023 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+AA1F6D9E2B1C4B1A00000024 /* AuthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthModels.swift; sourceTree = "<group>"; };
+AA1F6D9E2B1C4B1A00000025 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+AA1F6D9E2B1C4B1A00000026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+AA1F6D9E2B1C4B1A00000027 /* Bissbilanz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bissbilanz.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+AA1F6D9E2B1C4B1A00000062 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ( ); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+AA1F6D9E2B1C4B1A00000011 = {
+isa = PBXGroup;
+children = (
+AA1F6D9E2B1C4B1A00000012 /* Bissbilanz */,
+AA1F6D9E2B1C4B1A00000017 /* Products */,
+);
+sourceTree = "<group>";
+};
+AA1F6D9E2B1C4B1A00000012 /* Bissbilanz */ = {
+isa = PBXGroup;
+children = (
+AA1F6D9E2B1C4B1A00000020 /* BissbilanzApp.swift */,
+AA1F6D9E2B1C4B1A00000021 /* ContentView.swift */,
+AA1F6D9E2B1C4B1A00000013 /* Models */,
+AA1F6D9E2B1C4B1A00000014 /* Services */,
+AA1F6D9E2B1C4B1A00000015 /* ViewModels */,
+AA1F6D9E2B1C4B1A00000016 /* Supporting */,
+AA1F6D9E2B1C4B1A00000025 /* Assets.xcassets */,
+);
+path = Bissbilanz;
+sourceTree = "<group>";
+};
+AA1F6D9E2B1C4B1A00000013 /* Models */ = {
+isa = PBXGroup;
+children = (
+AA1F6D9E2B1C4B1A00000024 /* AuthModels.swift */,
+);
+path = Models;
+sourceTree = "<group>";
+};
+AA1F6D9E2B1C4B1A00000014 /* Services */ = {
+isa = PBXGroup;
+children = (
+AA1F6D9E2B1C4B1A00000022 /* APIClient.swift */,
+);
+path = Services;
+sourceTree = "<group>";
+};
+AA1F6D9E2B1C4B1A00000015 /* ViewModels */ = {
+isa = PBXGroup;
+children = (
+AA1F6D9E2B1C4B1A00000023 /* LoginViewModel.swift */,
+);
+path = ViewModels;
+sourceTree = "<group>";
+};
+AA1F6D9E2B1C4B1A00000016 /* Supporting */ = {
+isa = PBXGroup;
+children = (
+AA1F6D9E2B1C4B1A00000026 /* Info.plist */,
+);
+path = Supporting;
+sourceTree = "<group>";
+};
+AA1F6D9E2B1C4B1A00000017 /* Products */ = {
+isa = PBXGroup;
+children = (
+AA1F6D9E2B1C4B1A00000027 /* Bissbilanz.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+AA1F6D9E2B1C4B1A00000050 /* Bissbilanz */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = AA1F6D9E2B1C4B1A00000071 /* Build configuration list for PBXNativeTarget "Bissbilanz" */;
+buildPhases = (
+AA1F6D9E2B1C4B1A00000060 /* Sources */,
+AA1F6D9E2B1C4B1A00000062 /* Frameworks */,
+AA1F6D9E2B1C4B1A00000061 /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = Bissbilanz;
+productName = Bissbilanz;
+productReference = AA1F6D9E2B1C4B1A00000027 /* Bissbilanz.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+AA1F6D9E2B1C4B1A00000010 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = YES;
+LastUpgradeCheck = 1530;
+TargetAttributes = {
+AA1F6D9E2B1C4B1A00000050 = {
+CreatedOnToolsVersion = 15.3;
+};
+};
+};
+buildConfigurationList = AA1F6D9E2B1C4B1A00000070 /* Build configuration list for PBXProject "Bissbilanz" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+);
+mainGroup = AA1F6D9E2B1C4B1A00000011;
+productRefGroup = AA1F6D9E2B1C4B1A00000017 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+AA1F6D9E2B1C4B1A00000050 /* Bissbilanz */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+AA1F6D9E2B1C4B1A00000061 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (
+AA1F6D9E2B1C4B1A00000045 /* Assets.xcassets in Resources */,
+); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+AA1F6D9E2B1C4B1A00000060 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
+AA1F6D9E2B1C4B1A00000042 /* APIClient.swift in Sources */,
+AA1F6D9E2B1C4B1A00000044 /* AuthModels.swift in Sources */,
+AA1F6D9E2B1C4B1A00000040 /* BissbilanzApp.swift in Sources */,
+AA1F6D9E2B1C4B1A00000041 /* ContentView.swift in Sources */,
+AA1F6D9E2B1C4B1A00000043 /* LoginViewModel.swift in Sources */,
+); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+AA1F6D9E2B1C4B1A00000080 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_ASSET_PATHS = "\"Bissbilanz/Assets.xcassets\"";
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = Bissbilanz/Supporting/Info.plist;
+INFOPLIST_KEY_CFBundleDisplayName = Bissbilanz;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks");
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.bissbilanz.app;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+AA1F6D9E2B1C4B1A00000081 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_ASSET_PATHS = "\"Bissbilanz/Assets.xcassets\"";
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = Bissbilanz/Supporting/Info.plist;
+INFOPLIST_KEY_CFBundleDisplayName = Bissbilanz;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks");
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.bissbilanz.app;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+AA1F6D9E2B1C4B1A00000082 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+SWIFT_VERSION = 5.0;
+};
+name = Debug;
+};
+AA1F6D9E2B1C4B1A00000083 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_VERSION = 5.0;
+VALIDATE_PRODUCT = YES;
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+AA1F6D9E2B1C4B1A00000070 /* Build configuration list for PBXProject "Bissbilanz" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AA1F6D9E2B1C4B1A00000082 /* Debug */,
+AA1F6D9E2B1C4B1A00000083 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+AA1F6D9E2B1C4B1A00000071 /* Build configuration list for PBXNativeTarget "Bissbilanz" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AA1F6D9E2B1C4B1A00000080 /* Debug */,
+AA1F6D9E2B1C4B1A00000081 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+};
+rootObject = AA1F6D9E2B1C4B1A00000010 /* Project object */;
+}

--- a/ios/Bissbilanz/Bissbilanz/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/Bissbilanz/Bissbilanz/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.451",
+          "green" : "0.412",
+          "red" : "0.082"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Bissbilanz/Bissbilanz/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/Bissbilanz/Bissbilanz/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,33 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Bissbilanz/Bissbilanz/Assets.xcassets/Contents.json
+++ b/ios/Bissbilanz/Bissbilanz/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Bissbilanz/Bissbilanz/BissbilanzApp.swift
+++ b/ios/Bissbilanz/Bissbilanz/BissbilanzApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct BissbilanzApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/Bissbilanz/Bissbilanz/ContentView.swift
+++ b/ios/Bissbilanz/Bissbilanz/ContentView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = LoginViewModel()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Email")
+                        .font(.subheadline)
+                        .bold()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    TextField("demo@bissbilanz.ch", text: $viewModel.email)
+                        .textContentType(.username)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                        .padding(12)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(8)
+
+                    Text("Password")
+                        .font(.subheadline)
+                        .bold()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    SecureField("••••••••", text: $viewModel.password)
+                        .textContentType(.password)
+                        .padding(12)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(8)
+                }
+
+                if let token = viewModel.token {
+                    VStack(spacing: 8) {
+                        Text("Authenticated!")
+                            .font(.headline)
+                        Text("Token: \(token)")
+                            .font(.footnote)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.green.opacity(0.15))
+                    .cornerRadius(12)
+                }
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                }
+
+                Button(action: viewModel.login) {
+                    if viewModel.isLoading {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                    } else {
+                        Text("Log In")
+                            .fontWeight(.semibold)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!viewModel.canSubmit)
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Bissbilanz Login")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/Bissbilanz/Bissbilanz/Models/AuthModels.swift
+++ b/ios/Bissbilanz/Bissbilanz/Models/AuthModels.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct LoginRequest: Encodable {
+    let email: String
+    let password: String
+}
+
+struct LoginResponse: Decodable {
+    let token: String
+    let user: UserProfile
+}
+
+struct UserProfile: Decodable {
+    let id: String
+    let email: String
+    let displayName: String
+}

--- a/ios/Bissbilanz/Bissbilanz/Services/APIClient.swift
+++ b/ios/Bissbilanz/Bissbilanz/Services/APIClient.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+protocol APIClientProtocol {
+    func login(email: String, password: String) async throws -> LoginResponse
+}
+
+struct APIClient: APIClientProtocol {
+    enum APIError: LocalizedError {
+        case invalidURL
+        case invalidResponse
+        case decodingFailed
+        case unauthorized
+        case server(message: String?)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "The login endpoint could not be reached."
+            case .invalidResponse:
+                return "Received an unexpected response from the server."
+            case .decodingFailed:
+                return "Failed to decode the response from the server."
+            case .unauthorized:
+                return "Invalid email or password."
+            case .server(let message):
+                return message ?? "The server reported an error."
+            }
+        }
+    }
+
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(baseURL: URL = URL(string: "http://localhost:3000")!, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func login(email: String, password: String) async throws -> LoginResponse {
+        let endpoint = baseURL.appendingPathComponent("auth/login")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let payload = LoginRequest(email: email, password: password)
+        do {
+            request.httpBody = try JSONEncoder().encode(payload)
+        } catch {
+            throw APIError.invalidURL
+        }
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw APIError.server(message: error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            do {
+                return try JSONDecoder().decode(LoginResponse.self, from: data)
+            } catch {
+                throw APIError.decodingFailed
+            }
+        case 400:
+            let message = String(data: data, encoding: .utf8)
+            throw APIError.server(message: message)
+        case 401:
+            throw APIError.unauthorized
+        default:
+            let message = String(data: data, encoding: .utf8)
+            throw APIError.server(message: message)
+        }
+    }
+}

--- a/ios/Bissbilanz/Bissbilanz/Supporting/Info.plist
+++ b/ios/Bissbilanz/Bissbilanz/Supporting/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Bissbilanz</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIMainStoryboardFile</key>
+    <string></string>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    </array>
+</dict>
+</plist>

--- a/ios/Bissbilanz/Bissbilanz/ViewModels/LoginViewModel.swift
+++ b/ios/Bissbilanz/Bissbilanz/ViewModels/LoginViewModel.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Combine
+
+@MainActor
+final class LoginViewModel: ObservableObject {
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var token: String?
+    @Published private(set) var errorMessage: String?
+
+    private let client: APIClientProtocol
+
+    init(client: APIClientProtocol = APIClient()) {
+        self.client = client
+    }
+
+    var canSubmit: Bool {
+        !email.isEmpty && !password.isEmpty && !isLoading
+    }
+
+    func login() {
+        guard canSubmit else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        Task {
+            do {
+                let response = try await client.login(email: email, password: password)
+                token = response.token
+                errorMessage = nil
+            } catch {
+                if let apiError = error as? APIClient.APIError {
+                    errorMessage = apiError.localizedDescription
+                } else {
+                    errorMessage = "Something went wrong. Please try again."
+                }
+                token = nil
+            }
+            isLoading = false
+        }
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,3 +1,23 @@
 # iOS
 
-Native iOS application projects and resources belong here.
+This directory contains the native SwiftUI client for the Bissbilanz platform.
+
+## Project structure
+
+- `Bissbilanz/` – Application sources, resources and configuration files.
+- `Bissbilanz.xcodeproj/` – Xcode project containing the build settings for the iOS app.
+
+## Running the app
+
+1. Start the Go backend so the login endpoint is available:
+   ```bash
+   cd backend
+   PORT=3000 go run ./cmd/server
+   ```
+2. Open `ios/Bissbilanz/Bissbilanz.xcodeproj` in Xcode 15 or newer.
+3. Select the *Bissbilanz* scheme and a simulator or device target.
+4. Build and run. Use the demo credentials defined in the backend configuration
+   (defaults: `demo@bissbilanz.ch` / `password123`).
+
+The login screen sends the email and password to `POST /auth/login` and displays
+either the returned token and user information or an error message.


### PR DESCRIPTION
## Summary
- add a demo authentication service and HTTP handler that exposes POST /auth/login
- wire the login route into the Go server configuration alongside new demo credential settings
- scaffold a SwiftUI iOS app that authenticates against the backend login API and document build steps

## Testing
- GOPROXY=off go test ./internal/handlers/auth ./internal/services/auth

------
https://chatgpt.com/codex/tasks/task_e_68f69dc4fccc83228526693da683a309