### PR TITLE
Add Swagger UI and OpenAPI client generation pipeline

### DIFF
--- a/.github/workflows/api-client-generation.yml
+++ b/.github/workflows/api-client-generation.yml
@@ -1,0 +1,18 @@
+name: API client generation
+
+on:
+  pull_request:
+
+jobs:
+  generate-clients:
+    name: Generate API clients
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Generate TypeScript client
+        run: make api-client-web
+
+      - name: Generate Swift client
+        run: make api-client-ios

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+OPENAPI_SPEC := backend/docs/openapi.json
+OPENAPI_GENERATOR_IMAGE := openapitools/openapi-generator-cli:v7.5.0
+
+.PHONY: api-docs
+api-docs:
+	@echo "OpenAPI specification: $(OPENAPI_SPEC)"
+
+.PHONY: api-client-web
+api-client-web:
+	docker run --rm -v $(PWD):/local $(OPENAPI_GENERATOR_IMAGE) generate \
+		-i /local/$(OPENAPI_SPEC) \
+		-g typescript-fetch \
+		-o /local/web/src/api/generated \
+		--additional-properties=npmName=@bissbilanz/api-client
+
+.PHONY: api-client-ios
+api-client-ios:
+	docker run --rm -v $(PWD):/local $(OPENAPI_GENERATOR_IMAGE) generate \
+		-i /local/$(OPENAPI_SPEC) \
+		-g swift5 \
+		-o /local/ios/Generated/API \
+		--additional-properties=projectName=BissbilanzAPI
+
+.PHONY: api-client-all
+api-client-all: api-client-web api-client-ios

--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@
 - `android/`: Native Android application projects and shared resources.
 
 Each directory currently contains a placeholder README to keep the folder tracked until platform-specific code is added.
+
+## API documentation and client generation
+
+The backend ships with an embedded OpenAPI description that powers Swagger UI at `http://localhost:3000/swagger`. Regenerate API clients from the repository root with the provided Makefile:
+
+```bash
+make api-client-web   # TypeScript client (web/src/api/generated)
+make api-client-ios   # Swift client (ios/Generated/API)
+```
+
+Both commands run the official OpenAPI Generator Docker image and require Docker to be installed locally.

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,7 +24,7 @@ cd backend
 PORT=3000 MCP_PORT=4000 go run ./cmd/server
 ```
 
-The binary starts both the HTTP API and the MCP endpoint. The HTTP server exposes a basic health check at `GET /health`. The MCP server listens for tool invocations at `POST /call`. Requests should include the tool name and optional arguments, for example:
+The binary starts both the HTTP API and the MCP endpoint. The HTTP server exposes a basic health check at `GET /health`, importer endpoints under `/imports/{source}`, and interactive API documentation at `GET /swagger`. The MCP server listens for tool invocations at `POST /call`. Requests should include the tool name and optional arguments, for example:
 
 ```bash
 curl -X POST \
@@ -34,6 +34,27 @@ curl -X POST \
 ```
 
 Set `MCP_TOKEN` to require Bearer token authentication and `MCP_HOST`/`MCP_PORT` to change the bind address.
+
+## API documentation
+
+Generated OpenAPI documentation is embedded in the server binary and exposed through Swagger UI:
+
+- Interactive UI: <http://localhost:3000/swagger>
+- Raw OpenAPI document: <http://localhost:3000/swagger/swagger.json>
+
+The source specification lives at [`backend/docs/openapi.json`](./docs/openapi.json). Update this file when adding new endpoints to keep the documentation and generated clients in sync.
+
+## Client generation
+
+Use the repository Makefile to generate strongly typed API clients from the OpenAPI document. Both commands run the official OpenAPI Generator CLI via Docker, so no local installation is required:
+
+```bash
+# From the repository root
+make api-client-web   # generates TypeScript bindings in web/src/api/generated
+make api-client-ios   # generates Swift bindings in ios/Generated/API
+```
+
+Run `make api-client-all` to regenerate both clients at once.
 
 To run in Docker:
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -70,6 +70,7 @@ func main() {
 	healthHandler.RegisterRoutes(app)
 	importsHandler := importshandler.New(services)
 	importsHandler.RegisterRoutes(app)
+	registerSwagger(app)
 
 	var serverOpts []mcp.ServerOption
 	if token := cfg.MCPAuthToken(); token != "" {

--- a/backend/cmd/server/swagger.go
+++ b/backend/cmd/server/swagger.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/bissbilanz/backend/docs"
+)
+
+func registerSwagger(app *fiber.App) {
+	app.Get("/swagger", func(c *fiber.Ctx) error {
+		c.Type("html", "utf-8")
+		return c.SendString(docs.SwaggerUI())
+	})
+
+	app.Get("/swagger/", func(c *fiber.Ctx) error {
+		c.Type("html", "utf-8")
+		return c.SendString(docs.SwaggerUI())
+	})
+
+	app.Get("/swagger/swagger.json", func(c *fiber.Ctx) error {
+		c.Type("json", "utf-8")
+		return c.Send(docs.OpenAPI)
+	})
+}

--- a/backend/docs/embed.go
+++ b/backend/docs/embed.go
@@ -1,0 +1,18 @@
+package docs
+
+import _ "embed"
+
+// OpenAPI holds the generated OpenAPI specification in JSON format.
+//
+//go:embed openapi.json
+var OpenAPI []byte
+
+// swaggerUI is a minimal HTML page that loads Swagger UI assets from a CDN.
+//
+//go:embed swagger.html
+var swaggerUI string
+
+// SwaggerUI returns the Swagger UI HTML page.
+func SwaggerUI() string {
+	return swaggerUI
+}

--- a/backend/docs/openapi.json
+++ b/backend/docs/openapi.json
@@ -1,0 +1,256 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Bissbilanz API",
+    "description": "HTTP API for orchestrating data imports and reporting service health.",
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local development server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Health",
+      "description": "Service health checks"
+    },
+    {
+      "name": "Imports",
+      "description": "Triggering and monitoring importer jobs"
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Retrieve the current service health status",
+        "operationId": "healthStatus",
+        "responses": {
+          "200": {
+            "description": "Successful health status response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/imports/{source}": {
+      "post": {
+        "tags": [
+          "Imports"
+        ],
+        "summary": "Trigger a new import run",
+        "operationId": "triggerImport",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ImportSource"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The import was accepted and is running in the background",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportStatus"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested import source is not registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "An import for the requested source is already in progress",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportInProgressError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The import runner encountered an unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/imports/{source}/status": {
+      "get": {
+        "tags": [
+          "Imports"
+        ],
+        "summary": "Retrieve the most recent status for an import source",
+        "operationId": "getImportStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ImportSource"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current status information for the import source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportStatus"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested import source is not registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "ImportSource": {
+        "name": "source",
+        "in": "path",
+        "required": true,
+        "description": "Identifier of the import source (e.g. `naehrwertdaten`, `openfoodfacts`).",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "schemas": {
+      "HealthStatus": {
+        "type": "object",
+        "required": [
+          "status",
+          "checks"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Overall health indicator"
+          },
+          "checks": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Breakdown of individual subsystem health checks"
+          }
+        }
+      },
+      "ImportStatus": {
+        "type": "object",
+        "required": [
+          "job_id",
+          "running",
+          "started_at",
+          "items_processed"
+        ],
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "description": "Unique identifier of the import job"
+          },
+          "running": {
+            "type": "boolean",
+            "description": "Whether the import is currently executing"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the import began"
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp when the import finished, if available"
+          },
+          "batch_id": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Identifier of the batch that was processed"
+          },
+          "version": {
+            "type": "string",
+            "description": "Version of the imported dataset"
+          },
+          "items_processed": {
+            "type": "integer",
+            "description": "Number of processed items"
+          },
+          "last_error": {
+            "type": "string",
+            "description": "Last error message reported by the importer"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human readable error message"
+          },
+          "source": {
+            "type": "string",
+            "description": "Identifier of the import source involved in the error"
+          }
+        }
+      },
+      "ImportInProgressError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Error"
+          },
+          {
+            "type": "object",
+            "required": [
+              "status"
+            ],
+            "properties": {
+              "status": {
+                "$ref": "#/components/schemas/ImportStatus"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/backend/docs/swagger.html
+++ b/backend/docs/swagger.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bissbilanz API Reference</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+      }
+      #swagger-ui {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      window.addEventListener("load", () => {
+        SwaggerUIBundle({
+          url: "./swagger.json",
+          dom_id: "#swagger-ui",
+          presets: [SwaggerUIBundle.presets.apis],
+          layout: "BaseLayout",
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/backend/internal/handlers/health/handler.go
+++ b/backend/internal/handlers/health/handler.go
@@ -16,6 +16,12 @@ func (h *Handler) RegisterRoutes(app *fiber.App) {
 	app.Get("/health", h.Health)
 }
 
+// Health godoc
+// @Summary Retrieve the current service health status
+// @Tags Health
+// @Produce json
+// @Success 200 {object} healthservice.Status
+// @Router /health [get]
 func (h *Handler) Health(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusOK).JSON(h.service.Status(c.UserContext()))
 }

--- a/backend/internal/handlers/imports/handler.go
+++ b/backend/internal/handlers/imports/handler.go
@@ -34,6 +34,15 @@ func (h *Handler) RegisterRoutes(app *fiber.App) {
 }
 
 // Trigger starts a new background import run.
+// @Summary Trigger a new import run
+// @Tags Imports
+// @Param source path string true "Import source"
+// @Produce json
+// @Success 202 {object} importservice.ImportStatus
+// @Failure 404 {object} fiber.Map
+// @Failure 409 {object} fiber.Map
+// @Failure 500 {object} fiber.Map
+// @Router /imports/{source} [post]
 func (h *Handler) Trigger(c *fiber.Ctx) error {
 	source := strings.ToLower(c.Params("source"))
 	svc, ok := h.services[source]
@@ -60,6 +69,13 @@ func (h *Handler) Trigger(c *fiber.Ctx) error {
 }
 
 // Status returns the last known import status without triggering a new run.
+// @Summary Retrieve the most recent status of an import source
+// @Tags Imports
+// @Param source path string true "Import source"
+// @Produce json
+// @Success 200 {object} importservice.ImportStatus
+// @Failure 404 {object} fiber.Map
+// @Router /imports/{source}/status [get]
 func (h *Handler) Status(c *fiber.Ctx) error {
 	source := strings.ToLower(c.Params("source"))
 	svc, ok := h.services[source]


### PR DESCRIPTION
## Summary
- embed the OpenAPI specification in the backend and expose a Swagger UI endpoint
- annotate existing handlers and document the new API contract
- add repository Makefile targets for generating TypeScript and Swift API clients

## Testing
- go test ./... *(fails: blocked from downloading Go modules in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f69e0da73083229c99d3d95b71e2c1