### PR TITLE
Add GitHub workflow to build iOS app

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,42 @@
+name: iOS Build
+
+on:
+  push:
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-build.yml'
+  pull_request:
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-build.yml'
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode 15.4
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
+
+      - name: Resolve Swift package dependencies
+        run: |
+          cd ios/Bissbilanz
+          xcodebuild \
+            -project Bissbilanz.xcodeproj \
+            -scheme Bissbilanz \
+            -resolvePackageDependencies
+
+      - name: Build for iOS Simulator
+        run: |
+          cd ios/Bissbilanz
+          xcodebuild \
+            -project Bissbilanz.xcodeproj \
+            -scheme Bissbilanz \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            build


### PR DESCRIPTION
## Summary
- add a macOS GitHub Actions workflow to build the SwiftUI iOS client
- resolve Swift package dependencies and build the Bissbilanz scheme for the iOS simulator with Xcode 15.4

## Testing
- bun install *(fails: npm registry returned 403 responses)*
- bun run lint
- bun run test --if-present
- bun run build *(fails: Next.js could not download Inter font without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68f6a6c0a2f48322951fef4a5e6e3f05