### PR TITLE
refactor: add missing quality fields to FoodFormData type

### DIFF
--- a/src/lib/components/foods/FoodForm.svelte
+++ b/src/lib/components/foods/FoodForm.svelte
@@ -49,6 +49,10 @@
 		barcode: string;
 		isFavorite: boolean;
 		nutriScore?: 'a' | 'b' | 'c' | 'd' | 'e' | null;
+		novaGroup?: number | null;
+		additives?: string[] | null;
+		ingredientsText?: string | null;
+		imageUrl?: string | null;
 	};
 
 	type Props = {
@@ -86,7 +90,11 @@
 		cholesterol: initial.cholesterol ?? null,
 		barcode: initial.barcode ?? '',
 		isFavorite: initial.isFavorite ?? false,
-		nutriScore: initial.nutriScore ?? null
+		nutriScore: initial.nutriScore ?? null,
+		novaGroup: initial.novaGroup ?? null,
+		additives: initial.additives ?? null,
+		ingredientsText: initial.ingredientsText ?? null,
+		imageUrl: initial.imageUrl ?? null
 	});
 
 	let isValid = $derived(form.name.trim().length > 0 && form.servingSize > 0);


### PR DESCRIPTION
Closes #43

## Summary
- Add `novaGroup`, `additives`, `ingredientsText`, and `imageUrl` optional fields to the `FoodFormData` type in `FoodForm.svelte`
- Initialize these fields from the `initial` prop with `null` defaults
- No caller changes needed — `foods/new/+page.svelte` already merges quality fields separately in its `handleSave`

## Test plan
- [ ] Verify `bun run dev` starts without errors
- [ ] Create a new food via barcode scan (quality fields should pass through)
- [ ] Create a new food manually (quality fields default to null)