### PR TITLE
feat: add re-enrich button on food edit page

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -261,6 +261,8 @@
 	"quality_ingredients": "Zutaten",
 	"quality_enrich": "Anreichern",
 	"quality_enriching": "Anreichern...",
+	"quality_enrich_success": "Lebensmittel mit Open Food Facts Daten angereichert",
+	"quality_enrich_failed": "Anreicherung fehlgeschlagen",
 	"quality_off_loading": "Produkt wird gesucht...",
 	"quality_off_not_found": "Produkt nicht in Open Food Facts gefunden",
 	"quality_off_prefilled": "Vorausgefüllt aus Open Food Facts",

--- a/messages/en.json
+++ b/messages/en.json
@@ -261,6 +261,8 @@
 	"quality_ingredients": "Ingredients",
 	"quality_enrich": "Enrich",
 	"quality_enriching": "Enriching...",
+	"quality_enrich_success": "Food enriched with Open Food Facts data",
+	"quality_enrich_failed": "Failed to enrich food",
 	"quality_off_loading": "Looking up product...",
 	"quality_off_not_found": "Product not found in Open Food Facts",
 	"quality_off_prefilled": "Pre-filled from Open Food Facts",

--- a/src/routes/(app)/foods/[id]/+page.svelte
+++ b/src/routes/(app)/foods/[id]/+page.svelte
@@ -10,6 +10,7 @@
 	import { apiFetch } from '$lib/utils/api';
 	import { toast } from 'svelte-sonner';
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+	import Sparkles from '@lucide/svelte/icons/sparkles';
 	import * as m from '$lib/paraglide/messages';
 
 	type Food = {
@@ -39,6 +40,7 @@
 	let food: Food | null = $state(null);
 	let loading = $state(true);
 	let saving = $state(false);
+	let enriching = $state(false);
 
 	// Editable fields
 	let name = $state('');
@@ -173,6 +175,36 @@
 		}
 	};
 
+	const enrichFood = async () => {
+		if (!food?.barcode) return;
+		enriching = true;
+		try {
+			const res = await fetch(`/api/openfoodfacts/${food.barcode}`);
+			if (!res.ok) {
+				toast.error(m.quality_enrich_failed());
+				return;
+			}
+			const { product } = await res.json();
+			await apiFetch(`/api/foods/${food.id}`, {
+				method: 'PATCH',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					nutriScore: product.nutriScore,
+					novaGroup: product.novaGroup,
+					additives: product.additives,
+					ingredientsText: product.ingredientsText,
+					imageUrl: product.imageUrl
+				})
+			});
+			await loadFood();
+			toast.success(m.quality_enrich_success());
+		} catch {
+			toast.error(m.quality_enrich_failed());
+		} finally {
+			enriching = false;
+		}
+	};
+
 	onMount(() => {
 		loadFood();
 	});
@@ -184,6 +216,12 @@
 			<ArrowLeft class="size-4 sm:mr-1" />
 			<span class="hidden sm:inline">{m.back_to_foods()}</span>
 		</Button>
+		{#if food?.barcode}
+			<Button variant="outline" size="sm" class="ml-auto" onclick={enrichFood} disabled={enriching}>
+				<Sparkles class="size-4 sm:mr-1" />
+				<span class="hidden sm:inline">{enriching ? m.quality_enriching() : m.quality_enrich()}</span>
+			</Button>
+		{/if}
 	</div>
 
 	{#if loading}

--- a/src/routes/(app)/foods/[id]/+page.svelte
+++ b/src/routes/(app)/foods/[id]/+page.svelte
@@ -185,7 +185,7 @@
 				return;
 			}
 			const { product } = await res.json();
-			await apiFetch(`/api/foods/${food.id}`, {
+			const patchRes = await apiFetch(`/api/foods/${food.id}`, {
 				method: 'PATCH',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({
@@ -196,6 +196,10 @@
 					imageUrl: product.imageUrl
 				})
 			});
+			if (!patchRes.ok) {
+				toast.error(m.quality_enrich_failed());
+				return;
+			}
 			await loadFood();
 			toast.success(m.quality_enrich_success());
 		} catch {
@@ -217,7 +221,7 @@
 			<span class="hidden sm:inline">{m.back_to_foods()}</span>
 		</Button>
 		{#if food?.barcode}
-			<Button variant="outline" size="sm" class="ml-auto" onclick={enrichFood} disabled={enriching}>
+			<Button variant="outline" size="sm" class="ml-auto" onclick={enrichFood} disabled={enriching} aria-label={m.quality_enrich()}>
 				<Sparkles class="size-4 sm:mr-1" />
 				<span class="hidden sm:inline">{enriching ? m.quality_enriching() : m.quality_enrich()}</span>
 			</Button>


### PR DESCRIPTION
## Summary
- Adds an "Enrich" button (Sparkles icon) to the food edit page header bar, visible when the food has a barcode
- Fetches Open Food Facts data and updates quality fields (nutriScore, novaGroup, additives, ingredientsText, imageUrl)
- Shows loading state while enriching and toast notifications for success/failure
- Adds i18n keys for enrich success/failed messages (en + de)

Closes #42

## Test plan
- [ ] Open a food with a barcode on `/foods/[id]` — verify the Enrich button appears in the header
- [ ] Open a food without a barcode — verify no Enrich button shown
- [ ] Click Enrich on a food with a valid barcode — verify quality fields update and success toast shows
- [ ] Click Enrich on a food with an invalid barcode — verify error toast shows
- [ ] Verify button shows loading state ("Enriching...") during the request