### PR TITLE
feat: allow logging food by unit amount or servings with live preview

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -44,7 +44,7 @@
 
 	"amount_mode_servings": "Portionen",
 	"amount_mode_unit": "Menge",
-	"amount_preview_equals": "= {amount}{unit}",
+	"amount_preview_equals": "= {amount} {unit}",
 	"amount_preview_kcal": "{kcal} kcal",
 
 	"edit_entry_title": "Eintrag bearbeiten",

--- a/messages/de.json
+++ b/messages/de.json
@@ -42,6 +42,11 @@
 	"add_food_add": "Hinzufügen",
 	"add_food_servings": "Portionen",
 
+	"amount_mode_servings": "Portionen",
+	"amount_mode_unit": "Menge",
+	"amount_preview_equals": "= {amount}{unit}",
+	"amount_preview_kcal": "{kcal} kcal",
+
 	"edit_entry_title": "Eintrag bearbeiten",
 	"edit_entry_servings": "Portionen",
 	"edit_entry_meal": "Mahlzeit",

--- a/messages/en.json
+++ b/messages/en.json
@@ -42,6 +42,11 @@
 	"add_food_add": "Add",
 	"add_food_servings": "Servings",
 
+	"amount_mode_servings": "Servings",
+	"amount_mode_unit": "Amount",
+	"amount_preview_equals": "= {amount}{unit}",
+	"amount_preview_kcal": "{kcal} kcal",
+
 	"edit_entry_title": "Edit Entry",
 	"edit_entry_servings": "Servings",
 	"edit_entry_meal": "Meal",

--- a/messages/en.json
+++ b/messages/en.json
@@ -44,7 +44,7 @@
 
 	"amount_mode_servings": "Servings",
 	"amount_mode_unit": "Amount",
-	"amount_preview_equals": "= {amount}{unit}",
+	"amount_preview_equals": "= {amount} {unit}",
 	"amount_preview_kcal": "{kcal} kcal",
 
 	"edit_entry_title": "Edit Entry",

--- a/src/lib/components/entries/AddFoodModal.svelte
+++ b/src/lib/components/entries/AddFoodModal.svelte
@@ -66,7 +66,14 @@
 	let loadingRecent = $state(false);
 	let favoriteRecipes: FavoriteItem[] = $state([]);
 	let loadingFavorites = $state(false);
-	let selectedFood: { id: string; name: string; type: 'food' | 'recipe'; servingSize?: number | null; servingUnit?: string | null; calories?: number | null } | null = $state(null);
+	let selectedFood: {
+		id: string;
+		name: string;
+		type: 'food' | 'recipe';
+		servingSize?: number | null;
+		servingUnit?: string | null;
+		calories?: number | null;
+	} | null = $state(null);
 
 	const filtered = () =>
 		foods.filter((food) => food.name.toLowerCase().includes(query.toLowerCase()));
@@ -93,8 +100,21 @@
 
 	const allFavorites = $derived([...favoriteFoods, ...favoriteRecipes]);
 
-	const selectFood = (food: FoodItem) => {
-		selectedFood = { id: food.id, name: food.name, type: 'food', servingSize: food.servingSize, servingUnit: food.servingUnit, calories: food.calories };
+	const selectFood = (food: {
+		id: string;
+		name: string;
+		servingSize?: number | null;
+		servingUnit?: string | null;
+		calories?: number;
+	}) => {
+		selectedFood = {
+			id: food.id,
+			name: food.name,
+			type: 'food',
+			servingSize: food.servingSize,
+			servingUnit: food.servingUnit,
+			calories: food.calories
+		};
 		servings = 1;
 	};
 
@@ -104,7 +124,14 @@
 	};
 
 	const selectFavorite = (item: FavoriteItem) => {
-		selectedFood = { id: item.id, name: item.name, type: item.type, servingSize: item.servingSize, servingUnit: item.servingUnit, calories: item.calories };
+		selectedFood = {
+			id: item.id,
+			name: item.name,
+			type: item.type,
+			servingSize: item.servingSize,
+			servingUnit: item.servingUnit,
+			calories: item.calories
+		};
 		servings = 1;
 	};
 
@@ -172,7 +199,15 @@
 	};
 </script>
 
-<Dialog.Root bind:open onOpenChange={(o) => { if (!o) { onClose(); selectedFood = null; } }}>
+<Dialog.Root
+	bind:open
+	onOpenChange={(o) => {
+		if (!o) {
+			onClose();
+			selectedFood = null;
+		}
+	}}
+>
 	<Dialog.Content class="max-w-lg overflow-hidden">
 		<Dialog.Header>
 			<Dialog.Title>{m.add_food_title()}</Dialog.Title>
@@ -277,7 +312,14 @@
 										size="sm"
 										class="shrink-0"
 										aria-label={m.add_food_add()}
-										onclick={() => selectFood({ ...food, type: 'food' } as any)}
+										onclick={() => {
+											const fullFood = foods.find((f) => f.id === food.id);
+											if (fullFood) {
+												selectFood(fullFood);
+											} else {
+												selectFood({ id: food.id, name: food.name });
+											}
+										}}
 									>
 										<Plus class="size-4 sm:mr-1" />
 										<span class="hidden sm:inline">{m.add_food_add()}</span>

--- a/src/lib/components/entries/AddFoodModal.svelte
+++ b/src/lib/components/entries/AddFoodModal.svelte
@@ -4,9 +4,24 @@
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
-	import { Label } from '$lib/components/ui/label/index.js';
+	import AmountInput from '$lib/components/entries/AmountInput.svelte';
 	import Plus from '@lucide/svelte/icons/plus';
+	import Check from '@lucide/svelte/icons/check';
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import * as m from '$lib/paraglide/messages';
+
+	type FoodItem = {
+		id: string;
+		name: string;
+		isFavorite?: boolean;
+		calories?: number;
+		protein?: number;
+		carbs?: number;
+		fat?: number;
+		imageUrl?: string | null;
+		servingSize?: number | null;
+		servingUnit?: string | null;
+	};
 
 	type FavoriteItem = {
 		id: string;
@@ -17,20 +32,13 @@
 		carbs: number;
 		fat: number;
 		type: 'food' | 'recipe';
+		servingSize?: number | null;
+		servingUnit?: string | null;
 	};
 
 	type Props = {
 		open?: boolean;
-		foods?: Array<{
-			id: string;
-			name: string;
-			isFavorite?: boolean;
-			calories?: number;
-			protein?: number;
-			carbs?: number;
-			fat?: number;
-			imageUrl?: string | null;
-		}>;
+		foods?: FoodItem[];
 		recipes?: Array<{ id: string; name: string; isFavorite?: boolean }>;
 		mealType?: string;
 		onClose: () => void;
@@ -58,6 +66,7 @@
 	let loadingRecent = $state(false);
 	let favoriteRecipes: FavoriteItem[] = $state([]);
 	let loadingFavorites = $state(false);
+	let selectedFood: { id: string; name: string; type: 'food' | 'recipe'; servingSize?: number | null; servingUnit?: string | null; calories?: number | null } | null = $state(null);
 
 	const filtered = () =>
 		foods.filter((food) => food.name.toLowerCase().includes(query.toLowerCase()));
@@ -75,19 +84,42 @@
 				protein: f.protein ?? 0,
 				carbs: f.carbs ?? 0,
 				fat: f.fat ?? 0,
-				type: 'food'
+				type: 'food',
+				servingSize: f.servingSize,
+				servingUnit: f.servingUnit
 			})
 		)
 	);
 
 	const allFavorites = $derived([...favoriteFoods, ...favoriteRecipes]);
 
-	const handleAddFood = (foodId: string) => {
-		onSave({ foodId, mealType, servings });
+	const selectFood = (food: FoodItem) => {
+		selectedFood = { id: food.id, name: food.name, type: 'food', servingSize: food.servingSize, servingUnit: food.servingUnit, calories: food.calories };
+		servings = 1;
 	};
 
-	const handleAddRecipe = (recipeId: string) => {
-		onSave({ recipeId, mealType, servings });
+	const selectRecipe = (recipe: { id: string; name: string }) => {
+		selectedFood = { id: recipe.id, name: recipe.name, type: 'recipe' };
+		servings = 1;
+	};
+
+	const selectFavorite = (item: FavoriteItem) => {
+		selectedFood = { id: item.id, name: item.name, type: item.type, servingSize: item.servingSize, servingUnit: item.servingUnit, calories: item.calories };
+		servings = 1;
+	};
+
+	const confirmAdd = () => {
+		if (!selectedFood) return;
+		if (selectedFood.type === 'food') {
+			onSave({ foodId: selectedFood.id, mealType, servings });
+		} else {
+			onSave({ recipeId: selectedFood.id, mealType, servings });
+		}
+		selectedFood = null;
+	};
+
+	const goBack = () => {
+		selectedFood = null;
 	};
 
 	const loadRecentFoods = async () => {
@@ -138,91 +170,57 @@
 			loadFavoriteRecipes();
 		}
 	};
-
-	const handleFavoriteTap = (item: FavoriteItem) => {
-		if (item.type === 'food') {
-			handleAddFood(item.id);
-		} else {
-			handleAddRecipe(item.id);
-		}
-	};
 </script>
 
-<Dialog.Root bind:open onOpenChange={(o) => !o && onClose()}>
+<Dialog.Root bind:open onOpenChange={(o) => { if (!o) { onClose(); selectedFood = null; } }}>
 	<Dialog.Content class="max-w-lg overflow-hidden">
 		<Dialog.Header>
 			<Dialog.Title>{m.add_food_title()}</Dialog.Title>
 		</Dialog.Header>
 
-		<Tabs.Root value={tab} onValueChange={handleTabChange}>
-			<Tabs.List class="grid h-auto w-full grid-cols-2 gap-1 sm:h-9 sm:grid-cols-4">
-				<Tabs.Trigger value="search" class="text-xs sm:text-sm"
-					>{m.add_food_tab_search()}</Tabs.Trigger
-				>
-				<Tabs.Trigger value="favorites" class="text-xs sm:text-sm"
-					>{m.add_food_tab_favorites()}</Tabs.Trigger
-				>
-				<Tabs.Trigger value="recent" class="text-xs sm:text-sm"
-					>{m.add_food_tab_recent()}</Tabs.Trigger
-				>
-				<Tabs.Trigger value="recipes" class="text-xs sm:text-sm"
-					>{m.add_food_tab_recipes()}</Tabs.Trigger
-				>
-			</Tabs.List>
+		{#if selectedFood}
+			<div class="space-y-4">
+				<div class="flex items-center gap-2">
+					<Button variant="ghost" size="icon" onclick={goBack} class="shrink-0 size-8">
+						<ArrowLeft class="size-4" />
+					</Button>
+					<span class="text-sm font-medium">{selectedFood.name}</span>
+				</div>
 
-			<Tabs.Content value="search" class="space-y-4">
-				<Input placeholder={m.add_food_search_placeholder()} bind:value={query} />
-				<ul class="max-h-60 space-y-2 overflow-auto">
-					{#each filtered() as food}
-						<li class="flex min-w-0 items-start justify-between gap-2">
-							<span class="min-w-0 flex-1 truncate text-sm">{food.name}</span>
-							<Button
-								variant="outline"
-								size="sm"
-								class="shrink-0"
-								aria-label={m.add_food_add()}
-								onclick={() => handleAddFood(food.id)}
-							>
-								<Plus class="size-4 sm:mr-1" />
-								<span class="hidden sm:inline">{m.add_food_add()}</span>
-							</Button>
-						</li>
-					{/each}
-				</ul>
-			</Tabs.Content>
+				<AmountInput
+					{servings}
+					servingSize={selectedFood.servingSize}
+					servingUnit={selectedFood.servingUnit}
+					caloriesPerServing={selectedFood.calories}
+					onServingsChange={(v) => (servings = v)}
+				/>
 
-			<Tabs.Content value="favorites" class="space-y-4">
-				{#if loadingFavorites}
-					<p class="text-muted-foreground">{m.add_food_loading()}</p>
-				{:else}
+				<Button class="w-full" onclick={confirmAdd}>
+					<Check class="mr-1 size-4" />
+					{m.add_food_add()}
+				</Button>
+			</div>
+		{:else}
+			<Tabs.Root value={tab} onValueChange={handleTabChange}>
+				<Tabs.List class="grid h-auto w-full grid-cols-2 gap-1 sm:h-9 sm:grid-cols-4">
+					<Tabs.Trigger value="search" class="text-xs sm:text-sm"
+						>{m.add_food_tab_search()}</Tabs.Trigger
+					>
+					<Tabs.Trigger value="favorites" class="text-xs sm:text-sm"
+						>{m.add_food_tab_favorites()}</Tabs.Trigger
+					>
+					<Tabs.Trigger value="recent" class="text-xs sm:text-sm"
+						>{m.add_food_tab_recent()}</Tabs.Trigger
+					>
+					<Tabs.Trigger value="recipes" class="text-xs sm:text-sm"
+						>{m.add_food_tab_recipes()}</Tabs.Trigger
+					>
+				</Tabs.List>
+
+				<Tabs.Content value="search" class="space-y-4">
+					<Input placeholder={m.add_food_search_placeholder()} bind:value={query} />
 					<ul class="max-h-60 space-y-2 overflow-auto">
-						{#each allFavorites as item (item.id)}
-							<li class="flex min-w-0 items-start justify-between gap-2">
-								<span class="min-w-0 flex-1 truncate text-sm">{item.name}</span>
-								<Button
-									variant="outline"
-									size="sm"
-									class="shrink-0"
-									aria-label={m.add_food_add()}
-									onclick={() => handleFavoriteTap(item)}
-								>
-									<Plus class="size-4 sm:mr-1" />
-									<span class="hidden sm:inline">{m.add_food_add()}</span>
-								</Button>
-							</li>
-						{:else}
-							<li class="text-muted-foreground">{m.add_food_no_favorites()}</li>
-						{/each}
-					</ul>
-				{/if}
-			</Tabs.Content>
-
-			<Tabs.Content value="recent" class="space-y-4">
-				{#if loadingRecent}
-					<p class="text-muted-foreground">{m.add_food_loading()}</p>
-				{:else}
-					<ul class="max-h-60 space-y-2 overflow-auto">
-						{#each recentFoods as food}
+						{#each filtered() as food}
 							<li class="flex min-w-0 items-start justify-between gap-2">
 								<span class="min-w-0 flex-1 truncate text-sm">{food.name}</span>
 								<Button
@@ -230,46 +228,91 @@
 									size="sm"
 									class="shrink-0"
 									aria-label={m.add_food_add()}
-									onclick={() => handleAddFood(food.id)}
+									onclick={() => selectFood(food)}
+								>
+									<Plus class="size-4 sm:mr-1" />
+									<span class="hidden sm:inline">{m.add_food_add()}</span>
+								</Button>
+							</li>
+						{/each}
+					</ul>
+				</Tabs.Content>
+
+				<Tabs.Content value="favorites" class="space-y-4">
+					{#if loadingFavorites}
+						<p class="text-muted-foreground">{m.add_food_loading()}</p>
+					{:else}
+						<ul class="max-h-60 space-y-2 overflow-auto">
+							{#each allFavorites as item (item.id)}
+								<li class="flex min-w-0 items-start justify-between gap-2">
+									<span class="min-w-0 flex-1 truncate text-sm">{item.name}</span>
+									<Button
+										variant="outline"
+										size="sm"
+										class="shrink-0"
+										aria-label={m.add_food_add()}
+										onclick={() => selectFavorite(item)}
+									>
+										<Plus class="size-4 sm:mr-1" />
+										<span class="hidden sm:inline">{m.add_food_add()}</span>
+									</Button>
+								</li>
+							{:else}
+								<li class="text-muted-foreground">{m.add_food_no_favorites()}</li>
+							{/each}
+						</ul>
+					{/if}
+				</Tabs.Content>
+
+				<Tabs.Content value="recent" class="space-y-4">
+					{#if loadingRecent}
+						<p class="text-muted-foreground">{m.add_food_loading()}</p>
+					{:else}
+						<ul class="max-h-60 space-y-2 overflow-auto">
+							{#each recentFoods as food}
+								<li class="flex min-w-0 items-start justify-between gap-2">
+									<span class="min-w-0 flex-1 truncate text-sm">{food.name}</span>
+									<Button
+										variant="outline"
+										size="sm"
+										class="shrink-0"
+										aria-label={m.add_food_add()}
+										onclick={() => selectFood({ ...food, type: 'food' } as any)}
+									>
+										<Plus class="size-4 sm:mr-1" />
+										<span class="hidden sm:inline">{m.add_food_add()}</span>
+									</Button>
+								</li>
+							{:else}
+								<li class="text-muted-foreground">{m.add_food_no_recent()}</li>
+							{/each}
+						</ul>
+					{/if}
+				</Tabs.Content>
+
+				<Tabs.Content value="recipes" class="space-y-4">
+					<Input placeholder={m.add_food_search_recipes_placeholder()} bind:value={query} />
+					<ul class="max-h-60 space-y-2 overflow-auto">
+						{#each filteredRecipes() as recipe}
+							<li class="flex min-w-0 items-start justify-between gap-2">
+								<span class="min-w-0 flex-1 truncate text-sm">{recipe.name}</span>
+								<Button
+									variant="outline"
+									size="sm"
+									class="shrink-0"
+									aria-label={m.add_food_add()}
+									onclick={() => selectRecipe(recipe)}
 								>
 									<Plus class="size-4 sm:mr-1" />
 									<span class="hidden sm:inline">{m.add_food_add()}</span>
 								</Button>
 							</li>
 						{:else}
-							<li class="text-muted-foreground">{m.add_food_no_recent()}</li>
+							<li class="text-muted-foreground">{m.add_food_no_recipes()}</li>
 						{/each}
 					</ul>
-				{/if}
-			</Tabs.Content>
-
-			<Tabs.Content value="recipes" class="space-y-4">
-				<Input placeholder={m.add_food_search_recipes_placeholder()} bind:value={query} />
-				<ul class="max-h-60 space-y-2 overflow-auto">
-					{#each filteredRecipes() as recipe}
-						<li class="flex min-w-0 items-start justify-between gap-2">
-							<span class="min-w-0 flex-1 truncate text-sm">{recipe.name}</span>
-							<Button
-								variant="outline"
-								size="sm"
-								class="shrink-0"
-								aria-label={m.add_food_add()}
-								onclick={() => handleAddRecipe(recipe.id)}
-							>
-								<Plus class="size-4 sm:mr-1" />
-								<span class="hidden sm:inline">{m.add_food_add()}</span>
-							</Button>
-						</li>
-					{:else}
-						<li class="text-muted-foreground">{m.add_food_no_recipes()}</li>
-					{/each}
-				</ul>
-			</Tabs.Content>
-		</Tabs.Root>
-
-		<div class="grid gap-2">
-			<Label for="servings">{m.add_food_servings()}</Label>
-			<Input id="servings" type="number" bind:value={servings} min="0.1" step="0.1" />
-		</div>
+				</Tabs.Content>
+			</Tabs.Root>
+		{/if}
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/entries/AmountInput.svelte
+++ b/src/lib/components/entries/AmountInput.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import * as ToggleGroup from '$lib/components/ui/toggle-group/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as m from '$lib/paraglide/messages';
+
+	type Props = {
+		servings: number;
+		servingSize?: number | null;
+		servingUnit?: string | null;
+		caloriesPerServing?: number | null;
+		onServingsChange: (servings: number) => void;
+	};
+
+	let { servings, servingSize, servingUnit, caloriesPerServing, onServingsChange }: Props =
+		$props();
+
+	let mode: 'servings' | 'unit' = $state('servings');
+	let unitAmount = $state(0);
+
+	const hasServingInfo = $derived(!!servingSize && !!servingUnit);
+
+	$effect(() => {
+		if (hasServingInfo && servingSize) {
+			unitAmount = Math.round(servings * servingSize * 10) / 10;
+		}
+	});
+
+	const previewAmount = $derived.by(() => {
+		if (!hasServingInfo || !servingSize || !servingUnit) return null;
+		const amount = Math.round(servings * servingSize * 10) / 10;
+		return m.amount_preview_equals({ amount: String(amount), unit: servingUnit });
+	});
+
+	const previewKcal = $derived.by(() => {
+		if (!caloriesPerServing) return null;
+		const kcal = Math.round(servings * caloriesPerServing);
+		return m.amount_preview_kcal({ kcal: String(kcal) });
+	});
+
+	const handleServingsInput = (e: Event) => {
+		const val = parseFloat((e.target as HTMLInputElement).value);
+		if (!isNaN(val) && val > 0) {
+			onServingsChange(val);
+		}
+	};
+
+	const handleUnitInput = (e: Event) => {
+		const val = parseFloat((e.target as HTMLInputElement).value);
+		if (!isNaN(val) && val > 0 && servingSize) {
+			unitAmount = val;
+			onServingsChange(Math.round((val / servingSize) * 1000) / 1000);
+		}
+	};
+
+	const handleModeChange = (value: string | undefined) => {
+		if (value === 'servings' || value === 'unit') {
+			mode = value;
+		}
+	};
+</script>
+
+<div class="grid gap-2">
+	{#if hasServingInfo}
+		<div class="flex items-center gap-2">
+			<Label class="shrink-0">{mode === 'servings' ? m.amount_mode_servings() : m.amount_mode_unit()}</Label>
+			<ToggleGroup.Root type="single" value={mode} onValueChange={handleModeChange} class="ml-auto">
+				<ToggleGroup.Item value="servings" class="h-7 px-2 text-xs">{m.amount_mode_servings()}</ToggleGroup.Item>
+				<ToggleGroup.Item value="unit" class="h-7 px-2 text-xs">{m.amount_mode_unit()}</ToggleGroup.Item>
+			</ToggleGroup.Root>
+		</div>
+	{:else}
+		<Label>{m.amount_mode_servings()}</Label>
+	{/if}
+
+	{#if mode === 'servings'}
+		<div class="flex items-center gap-2">
+			<Input type="number" value={servings} oninput={handleServingsInput} min="0.1" step="0.1" class="flex-1" />
+			{#if previewAmount || previewKcal}
+				<span class="shrink-0 text-xs text-muted-foreground">
+					{#if previewAmount}{previewAmount}{/if}
+					{#if previewAmount && previewKcal}{' '}{/if}
+					{#if previewKcal}({previewKcal}){/if}
+				</span>
+			{/if}
+		</div>
+	{:else}
+		<div class="flex items-center gap-2">
+			<Input type="number" value={unitAmount} oninput={handleUnitInput} min="0.1" step="0.1" class="flex-1" />
+			<span class="shrink-0 text-sm text-muted-foreground">{servingUnit}</span>
+		</div>
+		{#if previewKcal}
+			<span class="text-xs text-muted-foreground">
+				{m.amount_preview_equals({ amount: String(Math.round(servings * 100) / 100), unit: ` ${m.amount_mode_servings().toLowerCase()}` })}
+				({previewKcal})
+			</span>
+		{/if}
+	{/if}
+</div>

--- a/src/lib/components/entries/AmountInput.svelte
+++ b/src/lib/components/entries/AmountInput.svelte
@@ -21,7 +21,7 @@
 	const hasServingInfo = $derived(!!servingSize && !!servingUnit);
 
 	$effect(() => {
-		if (hasServingInfo && servingSize) {
+		if (mode === 'servings' && hasServingInfo && servingSize) {
 			unitAmount = Math.round(servings * servingSize * 10) / 10;
 		}
 	});
@@ -33,7 +33,7 @@
 	});
 
 	const previewKcal = $derived.by(() => {
-		if (!caloriesPerServing) return null;
+		if (caloriesPerServing == null) return null;
 		const kcal = Math.round(servings * caloriesPerServing);
 		return m.amount_preview_kcal({ kcal: String(kcal) });
 	});
@@ -63,10 +63,16 @@
 <div class="grid gap-2">
 	{#if hasServingInfo}
 		<div class="flex items-center gap-2">
-			<Label class="shrink-0">{mode === 'servings' ? m.amount_mode_servings() : m.amount_mode_unit()}</Label>
+			<Label class="shrink-0"
+				>{mode === 'servings' ? m.amount_mode_servings() : m.amount_mode_unit()}</Label
+			>
 			<ToggleGroup.Root type="single" value={mode} onValueChange={handleModeChange} class="ml-auto">
-				<ToggleGroup.Item value="servings" class="h-7 px-2 text-xs">{m.amount_mode_servings()}</ToggleGroup.Item>
-				<ToggleGroup.Item value="unit" class="h-7 px-2 text-xs">{m.amount_mode_unit()}</ToggleGroup.Item>
+				<ToggleGroup.Item value="servings" class="h-7 px-2 text-xs"
+					>{m.amount_mode_servings()}</ToggleGroup.Item
+				>
+				<ToggleGroup.Item value="unit" class="h-7 px-2 text-xs"
+					>{m.amount_mode_unit()}</ToggleGroup.Item
+				>
 			</ToggleGroup.Root>
 		</div>
 	{:else}
@@ -75,7 +81,14 @@
 
 	{#if mode === 'servings'}
 		<div class="flex items-center gap-2">
-			<Input type="number" value={servings} oninput={handleServingsInput} min="0.1" step="0.1" class="flex-1" />
+			<Input
+				type="number"
+				value={servings}
+				oninput={handleServingsInput}
+				min="0.1"
+				step="0.1"
+				class="flex-1"
+			/>
 			{#if previewAmount || previewKcal}
 				<span class="shrink-0 text-xs text-muted-foreground">
 					{#if previewAmount}{previewAmount}{/if}
@@ -86,12 +99,22 @@
 		</div>
 	{:else}
 		<div class="flex items-center gap-2">
-			<Input type="number" value={unitAmount} oninput={handleUnitInput} min="0.1" step="0.1" class="flex-1" />
+			<Input
+				type="number"
+				value={unitAmount}
+				oninput={handleUnitInput}
+				min="0.1"
+				step="0.1"
+				class="flex-1"
+			/>
 			<span class="shrink-0 text-sm text-muted-foreground">{servingUnit}</span>
 		</div>
 		{#if previewKcal}
 			<span class="text-xs text-muted-foreground">
-				{m.amount_preview_equals({ amount: String(Math.round(servings * 100) / 100), unit: ` ${m.amount_mode_servings().toLowerCase()}` })}
+				{m.amount_preview_equals({
+					amount: String(Math.round(servings * 100) / 100),
+					unit: ` ${m.amount_mode_servings().toLowerCase()}`
+				})}
 				({previewKcal})
 			</span>
 		{/if}

--- a/src/lib/components/entries/DayLog.svelte
+++ b/src/lib/components/entries/DayLog.svelte
@@ -33,7 +33,7 @@
 	let addModalOpen = $state(false);
 	let editModalOpen = $state(false);
 	let activeMeal = $state('Breakfast');
-	let editingEntry: { id: string; servings: number; mealType: string; foodName?: string } | null =
+	let editingEntry: { id: string; servings: number; mealType: string; foodName?: string; servingSize?: number | null; servingUnit?: string | null; calories?: number | null } | null =
 		$state(null);
 	let scannedFood: any = $state(null);
 	let scannedBarcode = $state('');
@@ -86,6 +86,9 @@
 		servings: number;
 		mealType: string;
 		foodName?: string;
+		servingSize?: number | null;
+		servingUnit?: string | null;
+		calories?: number | null;
 	}) => {
 		editingEntry = entry;
 		editModalOpen = true;

--- a/src/lib/components/entries/DayLog.svelte
+++ b/src/lib/components/entries/DayLog.svelte
@@ -33,8 +33,15 @@
 	let addModalOpen = $state(false);
 	let editModalOpen = $state(false);
 	let activeMeal = $state('Breakfast');
-	let editingEntry: { id: string; servings: number; mealType: string; foodName?: string; servingSize?: number | null; servingUnit?: string | null; calories?: number | null } | null =
-		$state(null);
+	let editingEntry: {
+		id: string;
+		servings: number;
+		mealType: string;
+		foodName?: string;
+		servingSize?: number | null;
+		servingUnit?: string | null;
+		calories?: number | null;
+	} | null = $state(null);
 	let scannedFood: any = $state(null);
 	let scannedBarcode = $state('');
 

--- a/src/lib/components/entries/EditEntryModal.svelte
+++ b/src/lib/components/entries/EditEntryModal.svelte
@@ -2,8 +2,8 @@
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import AmountInput from '$lib/components/entries/AmountInput.svelte';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import Check from '@lucide/svelte/icons/check';
 	import X from '@lucide/svelte/icons/x';
@@ -11,7 +11,7 @@
 
 	type Props = {
 		open?: boolean;
-		entry: { id: string; servings: number; mealType: string; foodName?: string } | null;
+		entry: { id: string; servings: number; mealType: string; foodName?: string; servingSize?: number | null; servingUnit?: string | null; calories?: number | null } | null;
 		onClose: () => void;
 		onSave: (payload: { id: string; servings: number; mealType: string }) => void;
 		onDelete: (id: string) => void;
@@ -59,10 +59,13 @@
 		</Dialog.Header>
 
 		<div class="grid gap-4">
-			<div class="grid gap-2">
-				<Label for="edit-servings">{m.edit_entry_servings()}</Label>
-				<Input id="edit-servings" type="number" bind:value={editServings} min="0.1" step="0.1" />
-			</div>
+			<AmountInput
+				servings={editServings}
+				servingSize={entry?.servingSize}
+				servingUnit={entry?.servingUnit}
+				caloriesPerServing={entry?.calories}
+				onServingsChange={(v) => (editServings = v)}
+			/>
 
 			<div class="grid gap-2">
 				<Label>{m.edit_entry_meal()}</Label>

--- a/src/lib/components/entries/EditEntryModal.svelte
+++ b/src/lib/components/entries/EditEntryModal.svelte
@@ -11,7 +11,15 @@
 
 	type Props = {
 		open?: boolean;
-		entry: { id: string; servings: number; mealType: string; foodName?: string; servingSize?: number | null; servingUnit?: string | null; calories?: number | null } | null;
+		entry: {
+			id: string;
+			servings: number;
+			mealType: string;
+			foodName?: string;
+			servingSize?: number | null;
+			servingUnit?: string | null;
+			calories?: number | null;
+		} | null;
 		onClose: () => void;
 		onSave: (payload: { id: string; servings: number; mealType: string }) => void;
 		onDelete: (id: string) => void;

--- a/src/lib/components/entries/MealSection.svelte
+++ b/src/lib/components/entries/MealSection.svelte
@@ -26,7 +26,15 @@
 		readonly?: boolean;
 		dashboardStyle?: boolean;
 		onAdd?: () => void;
-		onEdit?: (entry: { id: string; servings: number; mealType: string; foodName?: string; servingSize?: number | null; servingUnit?: string | null; calories?: number | null }) => void;
+		onEdit?: (entry: {
+			id: string;
+			servings: number;
+			mealType: string;
+			foodName?: string;
+			servingSize?: number | null;
+			servingUnit?: string | null;
+			calories?: number | null;
+		}) => void;
 		onDelete?: (id: string) => void;
 	};
 
@@ -81,7 +89,12 @@
 										calories: entry.calories
 									})}
 							>
-								{formatEntryLabel(entry.foodName ?? 'Unknown', entry.servings, entry.servingSize, entry.servingUnit)}
+								{formatEntryLabel(
+									entry.foodName ?? 'Unknown',
+									entry.servings,
+									entry.servingSize,
+									entry.servingUnit
+								)}
 							</button>
 							{#if entry.createdAt}
 								<span class="shrink-0 text-xs text-muted-foreground/60"
@@ -102,7 +115,12 @@
 				>
 					<div class="flex min-w-0 flex-1 items-center gap-2">
 						<span class="truncate"
-							>{formatEntryLabel(entry.foodName ?? 'Unknown', entry.servings, entry.servingSize, entry.servingUnit)}</span
+							>{formatEntryLabel(
+								entry.foodName ?? 'Unknown',
+								entry.servings,
+								entry.servingSize,
+								entry.servingUnit
+							)}</span
 						>
 						{#if entry.createdAt}
 							<span class="shrink-0 text-xs text-muted-foreground/60"

--- a/src/lib/components/entries/MealSection.svelte
+++ b/src/lib/components/entries/MealSection.svelte
@@ -20,11 +20,13 @@
 			servings: number;
 			mealType: string;
 			createdAt?: string | null;
+			servingSize?: number | null;
+			servingUnit?: string | null;
 		}>;
 		readonly?: boolean;
 		dashboardStyle?: boolean;
 		onAdd?: () => void;
-		onEdit?: (entry: { id: string; servings: number; mealType: string; foodName?: string }) => void;
+		onEdit?: (entry: { id: string; servings: number; mealType: string; foodName?: string; servingSize?: number | null; servingUnit?: string | null; calories?: number | null }) => void;
 		onDelete?: (id: string) => void;
 	};
 
@@ -73,10 +75,13 @@
 										id: entry.id,
 										servings: entry.servings,
 										mealType: entry.mealType,
-										foodName: entry.foodName ?? undefined
+										foodName: entry.foodName ?? undefined,
+										servingSize: entry.servingSize,
+										servingUnit: entry.servingUnit,
+										calories: entry.calories
 									})}
 							>
-								{formatEntryLabel(entry.foodName ?? 'Unknown', entry.servings)}
+								{formatEntryLabel(entry.foodName ?? 'Unknown', entry.servings, entry.servingSize, entry.servingUnit)}
 							</Button>
 							{#if entry.createdAt}
 								<span class="text-xs text-muted-foreground/60">{formatTime(entry.createdAt)}</span>
@@ -94,7 +99,7 @@
 						: 'flex items-center justify-between text-sm'}
 				>
 					<div class="flex items-center gap-2">
-						<span>{formatEntryLabel(entry.foodName ?? 'Unknown', entry.servings)}</span>
+						<span>{formatEntryLabel(entry.foodName ?? 'Unknown', entry.servings, entry.servingSize, entry.servingUnit)}</span>
 						{#if entry.createdAt}
 							<span class="text-xs text-muted-foreground/60">{formatTime(entry.createdAt)}</span>
 						{/if}

--- a/src/lib/components/ui/responsive-modal/ResponsiveModal.svelte
+++ b/src/lib/components/ui/responsive-modal/ResponsiveModal.svelte
@@ -47,7 +47,11 @@
 					<Drawer.Description class="truncate">{description}</Drawer.Description>
 				{/if}
 			</Drawer.Header>
-			<div class="min-h-[60vh] px-4 pb-4" class:overflow-y-auto={isExpanded} class:overflow-hidden={!isExpanded}>
+			<div
+				class="min-h-[60vh] px-4 pb-4"
+				class:overflow-y-auto={isExpanded}
+				class:overflow-hidden={!isExpanded}
+			>
 				{@render children()}
 			</div>
 		</Drawer.Content>

--- a/src/lib/server/entries.ts
+++ b/src/lib/server/entries.ts
@@ -51,7 +51,9 @@ export const listEntriesByDate = async (
 			>`COALESCE(${foods.fiber}, (SELECT COALESCE(SUM(f2.fiber * ri.quantity / f2.serving_size), 0) / NULLIF(${recipes.totalServings}, 0) FROM recipe_ingredients ri JOIN foods f2 ON f2.id = ri.food_id WHERE ri.recipe_id = ${foodEntries.recipeId}))`.as(
 				'fiber'
 			),
-			createdAt: foodEntries.createdAt
+			createdAt: foodEntries.createdAt,
+			servingSize: foods.servingSize,
+			servingUnit: foods.servingUnit
 		})
 		.from(foodEntries)
 		.leftJoin(foods, eq(foodEntries.foodId, foods.id))

--- a/src/lib/utils/entries-ui.ts
+++ b/src/lib/utils/entries-ui.ts
@@ -6,7 +6,7 @@ export const formatEntryLabel = (
 ) => {
 	if (servingSize && servingUnit) {
 		const amount = Math.round(servings * servingSize * 10) / 10;
-		return `${name} × ${amount}${servingUnit}`;
+		return `${name} × ${amount} ${servingUnit}`;
 	}
 	return `${name} × ${servings}`;
 };

--- a/src/lib/utils/entries-ui.ts
+++ b/src/lib/utils/entries-ui.ts
@@ -1,1 +1,12 @@
-export const formatEntryLabel = (name: string, servings: number) => `${name} × ${servings}`;
+export const formatEntryLabel = (
+	name: string,
+	servings: number,
+	servingSize?: number | null,
+	servingUnit?: string | null
+) => {
+	if (servingSize && servingUnit) {
+		const amount = Math.round(servings * servingSize * 10) / 10;
+		return `${name} × ${amount}${servingUnit}`;
+	}
+	return `${name} × ${servings}`;
+};

--- a/tests/server/entries-db.test.ts
+++ b/tests/server/entries-db.test.ts
@@ -47,7 +47,9 @@ describe('entries-db', () => {
 					carbs: TEST_FOOD.carbs,
 					fat: TEST_FOOD.fat,
 					fiber: TEST_FOOD.fiber,
-					createdAt: TEST_ENTRY.createdAt
+					createdAt: TEST_ENTRY.createdAt,
+					servingSize: TEST_FOOD.servingSize,
+					servingUnit: TEST_FOOD.servingUnit
 				}
 			];
 			setResult(entriesWithFood);


### PR DESCRIPTION
## Summary

Closes #40

- Adds a toggle between "Servings" and unit amount (e.g. grams) when logging food
- Shows live preview of equivalent weight/servings and calories
- New shared `AmountInput` component used in both AddFoodModal and EditEntryModal
- Changed AddFoodModal to a two-step flow: select food → adjust amount → confirm
- No database schema changes — unit amounts are converted to servings before storing

## Changes

- **AmountInput.svelte** — new component with servings/unit toggle via ToggleGroup and live preview
- **AddFoodModal.svelte** — two-step flow with food selection, uses AmountInput
- **EditEntryModal.svelte** — replaced plain input with AmountInput
- **DayLog.svelte / MealSection.svelte** — thread servingSize/servingUnit through to modals
- **entries.ts** — added servingSize/servingUnit to listEntriesByDate query
- **entries-ui.ts** — formatEntryLabel shows unit amounts when available (e.g. "Oats × 75g")
- **i18n** — 4 new message keys (en + de)

## Test plan

- [ ] Open AddFoodModal → select a food → toggle between servings/unit modes
- [ ] Verify live preview shows correct weight and calories
- [ ] Add food in unit mode → verify correct servings stored
- [ ] Edit entry → toggle and preview work correctly
- [ ] Recipe entries → no toggle shown (servings only)
- [ ] Mobile layout renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)