### PR TITLE
feat: maintenance calorie calculator from weight trend

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -399,9 +399,13 @@
 	"maintenance_surplus": "Überschuss",
 	"maintenance_weight_change": "Gewichtsänderung",
 	"maintenance_breakdown": "Energieaufschlüsselung",
-	"maintenance_fat_loss": "Fett",
-	"maintenance_muscle_loss": "Muskel",
+	"maintenance_fat_component": "Fett",
+	"maintenance_muscle_component": "Muskel",
 	"maintenance_total_energy": "Gesamtenergie",
+	"maintenance_energy_balance_deficit": "Defizit: {value} kcal",
+	"maintenance_energy_balance_surplus": "Überschuss: {value} kcal",
+	"maintenance_calculate_error": "Berechnung der Erhaltungskalorien fehlgeschlagen",
+	"maintenance_low_coverage_warning": "Nur {days} von {total} Tagen haben Ernährungseinträge. Ergebnisse können ungenau sein.",
 	"maintenance_data_note": "Basierend auf {weightEntries} Gewichtseinträgen, {foodDays} Tagen mit Ernährungsprotokoll, über {days} Tage.",
 	"maintenance_weight_range": "Gewicht: {first} kg → {last} kg"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -374,5 +374,34 @@
 	"dashboard_over": "{amount} darüber",
 
 	"delete_related_entries": "Verknüpfte Einträge löschen",
-	"recipes_delete": "Rezept löschen"
+	"recipes_delete": "Rezept löschen",
+
+	"nav_maintenance": "Erhaltung",
+
+	"maintenance_title": "Erhaltungskalorienrechner",
+	"maintenance_description": "Schätze deine Erhaltungskalorien anhand von Gewichtsverlauf und Kalorienaufnahme über einen Zeitraum.",
+	"maintenance_date_range": "Zeitraum",
+	"maintenance_start": "Start",
+	"maintenance_end": "Ende",
+	"maintenance_2_weeks": "2 Wochen",
+	"maintenance_4_weeks": "4 Wochen",
+	"maintenance_8_weeks": "8 Wochen",
+	"maintenance_12_weeks": "12 Wochen",
+	"maintenance_body_composition": "Körperzusammensetzung",
+	"maintenance_muscle": "Muskel",
+	"maintenance_fat": "Fett",
+	"maintenance_ratio_hint": "Standard 30/70 — je nach Trainingsstatus und Proteinzufuhr anpassen.",
+	"maintenance_calculate": "Berechnen",
+	"maintenance_estimated": "Geschätzter Erhaltungsbedarf",
+	"maintenance_kcal_day": "kcal / Tag",
+	"maintenance_avg_intake": "Ø Aufnahme",
+	"maintenance_deficit": "Defizit",
+	"maintenance_surplus": "Überschuss",
+	"maintenance_weight_change": "Gewichtsänderung",
+	"maintenance_breakdown": "Energieaufschlüsselung",
+	"maintenance_fat_loss": "Fett",
+	"maintenance_muscle_loss": "Muskel",
+	"maintenance_total_energy": "Gesamtenergie",
+	"maintenance_data_note": "Basierend auf {weightEntries} Gewichtseinträgen, {foodDays} Tagen mit Ernährungsprotokoll, über {days} Tage.",
+	"maintenance_weight_range": "Gewicht: {first} kg → {last} kg"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -399,9 +399,13 @@
 	"maintenance_surplus": "Surplus",
 	"maintenance_weight_change": "Weight Change",
 	"maintenance_breakdown": "Energy Breakdown",
-	"maintenance_fat_loss": "Fat",
-	"maintenance_muscle_loss": "Muscle",
+	"maintenance_fat_component": "Fat",
+	"maintenance_muscle_component": "Muscle",
 	"maintenance_total_energy": "Total Energy",
+	"maintenance_energy_balance_deficit": "Deficit: {value} kcal",
+	"maintenance_energy_balance_surplus": "Surplus: {value} kcal",
+	"maintenance_calculate_error": "Failed to calculate maintenance calories",
+	"maintenance_low_coverage_warning": "Only {days} of {total} days have food logs. Results may be inaccurate.",
 	"maintenance_data_note": "Based on {weightEntries} weight entries, {foodDays} days with food logs, over {days} days.",
 	"maintenance_weight_range": "Weight: {first} kg → {last} kg"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -374,5 +374,34 @@
 	"dashboard_over": "{amount} over",
 
 	"delete_related_entries": "Delete related entries",
-	"recipes_delete": "Delete recipe"
+	"recipes_delete": "Delete recipe",
+
+	"nav_maintenance": "Maintenance",
+
+	"maintenance_title": "Maintenance Calculator",
+	"maintenance_description": "Estimate your maintenance calories based on weight change and calorie intake over a period.",
+	"maintenance_date_range": "Date Range",
+	"maintenance_start": "Start",
+	"maintenance_end": "End",
+	"maintenance_2_weeks": "2 weeks",
+	"maintenance_4_weeks": "4 weeks",
+	"maintenance_8_weeks": "8 weeks",
+	"maintenance_12_weeks": "12 weeks",
+	"maintenance_body_composition": "Body Composition",
+	"maintenance_muscle": "Muscle",
+	"maintenance_fat": "Fat",
+	"maintenance_ratio_hint": "Default 30/70 — adjust based on training status and protein intake.",
+	"maintenance_calculate": "Calculate",
+	"maintenance_estimated": "Estimated Maintenance",
+	"maintenance_kcal_day": "kcal / day",
+	"maintenance_avg_intake": "Avg Intake",
+	"maintenance_deficit": "Deficit",
+	"maintenance_surplus": "Surplus",
+	"maintenance_weight_change": "Weight Change",
+	"maintenance_breakdown": "Energy Breakdown",
+	"maintenance_fat_loss": "Fat",
+	"maintenance_muscle_loss": "Muscle",
+	"maintenance_total_energy": "Total Energy",
+	"maintenance_data_note": "Based on {weightEntries} weight entries, {foodDays} days with food logs, over {days} days.",
+	"maintenance_weight_range": "Weight: {first} kg → {last} kg"
 }

--- a/src/lib/config/navigation.ts
+++ b/src/lib/config/navigation.ts
@@ -5,6 +5,7 @@ import CookingPot from '@lucide/svelte/icons/cooking-pot';
 import Pill from '@lucide/svelte/icons/pill';
 import Weight from '@lucide/svelte/icons/weight';
 import Target from '@lucide/svelte/icons/target';
+import Calculator from '@lucide/svelte/icons/calculator';
 import Calendar from '@lucide/svelte/icons/calendar';
 import Settings from '@lucide/svelte/icons/settings';
 import * as m from '$lib/paraglide/messages';
@@ -68,6 +69,13 @@ export function getNavItems(): NavItem[] {
 			icon: Target,
 			badgeColor: 'bg-amber-100 text-amber-600',
 			activeRing: 'ring-2 ring-inset ring-amber-300/80 dark:ring-amber-700/80'
+		},
+		{
+			title: () => m.nav_maintenance(),
+			href: '/maintenance',
+			icon: Calculator,
+			badgeColor: 'bg-cyan-100 text-cyan-600',
+			activeRing: 'ring-2 ring-inset ring-cyan-300/80 dark:ring-cyan-700/80'
 		},
 		{
 			title: () => m.nav_history(),

--- a/src/lib/config/navigation.ts
+++ b/src/lib/config/navigation.ts
@@ -71,18 +71,18 @@ export function getNavItems(): NavItem[] {
 			activeRing: 'ring-2 ring-inset ring-amber-300/80 dark:ring-amber-700/80'
 		},
 		{
-			title: () => m.nav_maintenance(),
-			href: '/maintenance',
-			icon: Calculator,
-			badgeColor: 'bg-cyan-100 text-cyan-600',
-			activeRing: 'ring-2 ring-inset ring-cyan-300/80 dark:ring-cyan-700/80'
-		},
-		{
 			title: () => m.nav_history(),
 			href: '/history',
 			icon: Calendar,
 			badgeColor: 'bg-indigo-100 text-indigo-600',
 			activeRing: 'ring-2 ring-inset ring-indigo-300/80 dark:ring-indigo-700/80'
+		},
+		{
+			title: () => m.nav_maintenance(),
+			href: '/maintenance',
+			icon: Calculator,
+			badgeColor: 'bg-cyan-100 text-cyan-600',
+			activeRing: 'ring-2 ring-inset ring-cyan-300/80 dark:ring-cyan-700/80'
 		},
 		{
 			title: () => m.nav_settings(),

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -36,6 +36,12 @@ export const getMonthName = (month: number) =>
 		m.month_december
 	][month]();
 
+export const daysBetween = (startDate: string, endDate: string): number => {
+	const start = new Date(startDate + 'T00:00:00Z');
+	const end = new Date(endDate + 'T00:00:00Z');
+	return Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+};
+
 export const getDayOfWeek = (isoDate: string) => new Date(isoDate + 'T00:00:00Z').getUTCDay();
 
 export const daysAgo = (days: number) => shiftDate(today(), -(days - 1));

--- a/src/lib/utils/maintenance.ts
+++ b/src/lib/utils/maintenance.ts
@@ -12,7 +12,7 @@ export type MaintenanceInput = {
 export type MaintenanceResult = {
 	maintenanceCalories: number;
 	dailyDeficit: number;
-	totalDeficit: number;
+	totalEnergyBalance: number;
 	fatMassKg: number;
 	muscleMassKg: number;
 	fatCalories: number;
@@ -37,15 +37,15 @@ export function calculateMaintenance(input: MaintenanceInput): MaintenanceResult
 	const totalEnergy = fatCalories + muscleCalories;
 
 	const sign = weightChangeKg < 0 ? 1 : weightChangeKg > 0 ? -1 : 0;
-	const totalDeficit = totalEnergy * sign;
-	const dailyDeficit = days > 0 ? totalDeficit / days : 0;
+	const totalEnergyBalance = totalEnergy * sign;
+	const dailyDeficit = days > 0 ? totalEnergyBalance / days : 0;
 
 	const maintenanceCalories = Math.round(avgDailyCalories + dailyDeficit);
 
 	return {
 		maintenanceCalories,
 		dailyDeficit: Math.round(dailyDeficit),
-		totalDeficit: Math.round(totalDeficit),
+		totalEnergyBalance: Math.round(totalEnergyBalance),
 		fatMassKg: Math.round(fatMassKg * 100) / 100,
 		muscleMassKg: Math.round(muscleMassKg * 100) / 100,
 		fatCalories: Math.round(fatCalories),

--- a/src/lib/utils/maintenance.ts
+++ b/src/lib/utils/maintenance.ts
@@ -1,0 +1,58 @@
+export const KCAL_PER_KG_FAT = 7700;
+export const KCAL_PER_KG_MUSCLE = 1800;
+export const DEFAULT_MUSCLE_RATIO = 0.3;
+
+export type MaintenanceInput = {
+	weightChangeKg: number;
+	avgDailyCalories: number;
+	days: number;
+	muscleRatio?: number;
+};
+
+export type MaintenanceResult = {
+	maintenanceCalories: number;
+	dailyDeficit: number;
+	totalDeficit: number;
+	fatMassKg: number;
+	muscleMassKg: number;
+	fatCalories: number;
+	muscleCalories: number;
+	avgDailyCalories: number;
+	weightChangeKg: number;
+	days: number;
+	muscleRatio: number;
+};
+
+export function calculateMaintenance(input: MaintenanceInput): MaintenanceResult | null {
+	const { weightChangeKg, avgDailyCalories, days, muscleRatio = DEFAULT_MUSCLE_RATIO } = input;
+
+	if (days <= 0 || avgDailyCalories < 0) return null;
+
+	const fatRatio = 1 - muscleRatio;
+	const fatMassKg = Math.abs(weightChangeKg) * fatRatio;
+	const muscleMassKg = Math.abs(weightChangeKg) * muscleRatio;
+
+	const fatCalories = fatMassKg * KCAL_PER_KG_FAT;
+	const muscleCalories = muscleMassKg * KCAL_PER_KG_MUSCLE;
+	const totalEnergy = fatCalories + muscleCalories;
+
+	const sign = weightChangeKg < 0 ? 1 : weightChangeKg > 0 ? -1 : 0;
+	const totalDeficit = totalEnergy * sign;
+	const dailyDeficit = days > 0 ? totalDeficit / days : 0;
+
+	const maintenanceCalories = Math.round(avgDailyCalories + dailyDeficit);
+
+	return {
+		maintenanceCalories,
+		dailyDeficit: Math.round(dailyDeficit),
+		totalDeficit: Math.round(totalDeficit),
+		fatMassKg: Math.round(fatMassKg * 100) / 100,
+		muscleMassKg: Math.round(muscleMassKg * 100) / 100,
+		fatCalories: Math.round(fatCalories),
+		muscleCalories: Math.round(muscleCalories),
+		avgDailyCalories: Math.round(avgDailyCalories),
+		weightChangeKg,
+		days,
+		muscleRatio
+	};
+}

--- a/src/routes/(app)/maintenance/+page.svelte
+++ b/src/routes/(app)/maintenance/+page.svelte
@@ -11,13 +11,14 @@
 	import TrendingUp from '@lucide/svelte/icons/trending-up';
 	import Scale from '@lucide/svelte/icons/scale';
 	import Info from '@lucide/svelte/icons/info';
+	import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
 	import Loader from '@lucide/svelte/icons/loader';
 	import * as m from '$lib/paraglide/messages';
 
 	type MaintenanceResult = {
 		maintenanceCalories: number;
 		dailyDeficit: number;
-		totalDeficit: number;
+		totalEnergyBalance: number;
 		fatMassKg: number;
 		muscleMassKg: number;
 		fatCalories: number;
@@ -31,6 +32,8 @@
 	type Meta = {
 		weightEntries: number;
 		foodEntryDays: number;
+		totalDays: number;
+		coverage: number;
 		firstWeight: number;
 		lastWeight: number;
 		startDate: string;
@@ -50,6 +53,7 @@
 	const dailyDeficit = $derived(result?.dailyDeficit ?? 0);
 	const isDeficit = $derived(dailyDeficit > 0);
 	const isGain = $derived(dailyDeficit < 0);
+	const lowCoverage = $derived(meta != null && meta.coverage < 0.7);
 
 	const presets = [
 		{ label: () => m.maintenance_2_weeks(), days: 13 },
@@ -84,7 +88,7 @@
 			result = data.result;
 			meta = data.meta;
 		} catch {
-			error = 'Failed to calculate';
+			error = m.maintenance_calculate_error();
 		} finally {
 			loading = false;
 		}
@@ -199,6 +203,20 @@
 	{/if}
 
 	{#if result && meta}
+		{#if lowCoverage}
+			<Card.Root class="border-amber-500/50 bg-amber-50/50 dark:bg-amber-950/10">
+				<Card.Content class="flex items-start gap-3 p-4">
+					<TriangleAlert class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+					<p class="text-sm text-amber-700 dark:text-amber-300">
+						{m.maintenance_low_coverage_warning({
+							days: meta.foodEntryDays,
+							total: meta.totalDays
+						})}
+					</p>
+				</Card.Content>
+			</Card.Root>
+		{/if}
+
 		<Card.Root
 			class="overflow-hidden border-border/60 bg-linear-to-br from-blue-50/80 via-background to-emerald-50/60 dark:from-blue-950/20 dark:via-background dark:to-emerald-950/10"
 		>
@@ -285,13 +303,13 @@
 			<Card.Content class="space-y-3 p-4 pt-0 sm:p-5 sm:pt-0">
 				<div class="space-y-2">
 					<div class="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2">
-						<span class="text-sm">{m.maintenance_fat_loss()}</span>
+						<span class="text-sm">{m.maintenance_fat_component()}</span>
 						<span class="font-mono text-sm font-semibold">
 							{formatKg(result.fatMassKg)} kg = {formatKcal(result.fatCalories)} kcal
 						</span>
 					</div>
 					<div class="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2">
-						<span class="text-sm">{m.maintenance_muscle_loss()}</span>
+						<span class="text-sm">{m.maintenance_muscle_component()}</span>
 						<span class="font-mono text-sm font-semibold">
 							{formatKg(result.muscleMassKg)} kg = {formatKcal(result.muscleCalories)} kcal
 						</span>
@@ -301,7 +319,13 @@
 					>
 						<span class="text-sm font-medium">{m.maintenance_total_energy()}</span>
 						<span class="font-mono text-sm font-bold">
-							{formatKcal(result.totalDeficit)} kcal
+							{#if result.totalEnergyBalance > 0}
+								{m.maintenance_energy_balance_deficit({ value: formatKcal(result.totalEnergyBalance) })}
+							{:else if result.totalEnergyBalance < 0}
+								{m.maintenance_energy_balance_surplus({ value: formatKcal(result.totalEnergyBalance) })}
+							{:else}
+								{formatKcal(result.totalEnergyBalance)} kcal
+							{/if}
 						</span>
 					</div>
 				</div>
@@ -311,7 +335,7 @@
 						{m.maintenance_data_note({
 							weightEntries: meta.weightEntries,
 							foodDays: meta.foodEntryDays,
-							days: result.days
+							days: meta.totalDays
 						})}
 					</p>
 					<p>

--- a/src/routes/(app)/maintenance/+page.svelte
+++ b/src/routes/(app)/maintenance/+page.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+	import { today, shiftDate } from '$lib/utils/dates';
+	import { DEFAULT_MUSCLE_RATIO } from '$lib/utils/maintenance';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Slider } from '$lib/components/ui/slider/index.js';
+	import Calculator from '@lucide/svelte/icons/calculator';
+	import Flame from '@lucide/svelte/icons/flame';
+	import TrendingDown from '@lucide/svelte/icons/trending-down';
+	import TrendingUp from '@lucide/svelte/icons/trending-up';
+	import Scale from '@lucide/svelte/icons/scale';
+	import Info from '@lucide/svelte/icons/info';
+	import Loader from '@lucide/svelte/icons/loader';
+	import * as m from '$lib/paraglide/messages';
+
+	type MaintenanceResult = {
+		maintenanceCalories: number;
+		dailyDeficit: number;
+		totalDeficit: number;
+		fatMassKg: number;
+		muscleMassKg: number;
+		fatCalories: number;
+		muscleCalories: number;
+		avgDailyCalories: number;
+		weightChangeKg: number;
+		days: number;
+		muscleRatio: number;
+	};
+
+	type Meta = {
+		weightEntries: number;
+		foodEntryDays: number;
+		firstWeight: number;
+		lastWeight: number;
+		startDate: string;
+		endDate: string;
+	};
+
+	let endDate = $state(today());
+	let startDate = $state(shiftDate(endDate, -27));
+	let muscleRatio = $state(DEFAULT_MUSCLE_RATIO * 100);
+
+	let result = $state<MaintenanceResult | null>(null);
+	let meta = $state<Meta | null>(null);
+	let loading = $state(false);
+	let error: string | null = $state(null);
+
+	const fatRatio = $derived(100 - muscleRatio);
+	const dailyDeficit = $derived(result?.dailyDeficit ?? 0);
+	const isDeficit = $derived(dailyDeficit > 0);
+	const isGain = $derived(dailyDeficit < 0);
+
+	const presets = [
+		{ label: () => m.maintenance_2_weeks(), days: 13 },
+		{ label: () => m.maintenance_4_weeks(), days: 27 },
+		{ label: () => m.maintenance_8_weeks(), days: 55 },
+		{ label: () => m.maintenance_12_weeks(), days: 83 }
+	];
+
+	function selectPreset(days: number) {
+		endDate = today();
+		startDate = shiftDate(endDate, -days);
+	}
+
+	async function calculate() {
+		loading = true;
+		error = null;
+		result = null;
+		meta = null;
+
+		try {
+			const ratio = muscleRatio / 100;
+			const res = await fetch(
+				`/api/maintenance?startDate=${startDate}&endDate=${endDate}&muscleRatio=${ratio}`
+			);
+			const data = await res.json();
+
+			if (!res.ok) {
+				error = data.message || data.error;
+				return;
+			}
+
+			result = data.result;
+			meta = data.meta;
+		} catch {
+			error = 'Failed to calculate';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function formatKcal(value: number): string {
+		return Math.abs(value).toLocaleString();
+	}
+
+	function formatKg(value: number): string {
+		return Math.abs(value).toFixed(2);
+	}
+</script>
+
+<div class="mx-auto max-w-2xl space-y-6 pb-8">
+	<Card.Root class="overflow-hidden">
+		<Card.Header class="pb-3">
+			<div class="flex items-center gap-2">
+				<div
+					class="flex size-8 items-center justify-center rounded-lg bg-blue-500/10 text-blue-600 dark:text-blue-400"
+				>
+					<Calculator class="size-4" />
+				</div>
+				<Card.Title class="text-base tracking-tight">
+					{m.maintenance_title()}
+				</Card.Title>
+			</div>
+			<Card.Description>
+				{m.maintenance_description()}
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-5 p-4 pt-0 sm:p-5 sm:pt-0">
+			<div class="space-y-3">
+				<Label class="text-sm font-medium">{m.maintenance_date_range()}</Label>
+				<div class="flex flex-wrap gap-2">
+					{#each presets as preset}
+						<Button
+							variant="outline"
+							size="sm"
+							class="text-xs"
+							onclick={() => selectPreset(preset.days)}
+						>
+							{preset.label()}
+						</Button>
+					{/each}
+				</div>
+				<div class="grid grid-cols-2 gap-3">
+					<div>
+						<Label for="start-date" class="text-muted-foreground text-xs">
+							{m.maintenance_start()}
+						</Label>
+						<input
+							id="start-date"
+							type="date"
+							bind:value={startDate}
+							class="border-input bg-background mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+						/>
+					</div>
+					<div>
+						<Label for="end-date" class="text-muted-foreground text-xs">
+							{m.maintenance_end()}
+						</Label>
+						<input
+							id="end-date"
+							type="date"
+							bind:value={endDate}
+							class="border-input bg-background mt-1 block w-full rounded-md border px-3 py-2 text-sm"
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div class="space-y-3">
+				<Label class="text-sm font-medium">
+					{m.maintenance_body_composition()}
+				</Label>
+				<div class="space-y-2">
+					<div class="flex justify-between text-xs text-muted-foreground">
+						<span>{m.maintenance_muscle()}: {muscleRatio}%</span>
+						<span>{m.maintenance_fat()}: {fatRatio}%</span>
+					</div>
+					<Slider
+						type="single"
+						bind:value={muscleRatio}
+						min={0}
+						max={100}
+						step={5}
+						class="w-full"
+					/>
+					<p class="text-xs text-muted-foreground">
+						{m.maintenance_ratio_hint()}
+					</p>
+				</div>
+			</div>
+
+			<Button class="w-full" onclick={calculate} disabled={loading}>
+				{#if loading}
+					<Loader class="size-4 animate-spin" />
+				{/if}
+				{m.maintenance_calculate()}
+			</Button>
+		</Card.Content>
+	</Card.Root>
+
+	{#if error}
+		<Card.Root class="border-destructive/50">
+			<Card.Content class="flex items-start gap-3 p-4">
+				<Info class="mt-0.5 size-4 shrink-0 text-destructive" />
+				<p class="text-sm text-destructive">{error}</p>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
+	{#if result && meta}
+		<Card.Root
+			class="overflow-hidden border-border/60 bg-linear-to-br from-blue-50/80 via-background to-emerald-50/60 dark:from-blue-950/20 dark:via-background dark:to-emerald-950/10"
+		>
+			<Card.Content class="relative p-4 sm:p-6">
+				<div
+					class="absolute -top-14 -right-10 h-36 w-36 rounded-full bg-blue-500/10 blur-2xl"
+				></div>
+				<div class="relative space-y-4">
+					<div class="text-center">
+						<p class="text-muted-foreground mb-1 text-xs font-semibold uppercase tracking-wider">
+							{m.maintenance_estimated()}
+						</p>
+						<p class="text-4xl font-bold tabular-nums text-blue-600 dark:text-blue-400">
+							{formatKcal(result.maintenanceCalories)}
+						</p>
+						<p class="text-muted-foreground text-sm">{m.maintenance_kcal_day()}</p>
+					</div>
+
+					<div class="grid grid-cols-3 gap-2">
+						<div
+							class="rounded-xl border border-border/60 bg-background/85 p-3 text-center backdrop-blur"
+						>
+							<div
+								class="text-muted-foreground mb-1 text-[11px] font-semibold uppercase tracking-wider"
+							>
+								{m.maintenance_avg_intake()}
+							</div>
+							<div class="text-sm font-semibold tabular-nums">
+								{formatKcal(result.avgDailyCalories)}
+							</div>
+						</div>
+						<div
+							class="rounded-xl border border-border/60 bg-background/85 p-3 text-center backdrop-blur"
+						>
+							<div
+								class="text-muted-foreground mb-1 text-[11px] font-semibold uppercase tracking-wider"
+							>
+								{isDeficit ? m.maintenance_deficit() : m.maintenance_surplus()}
+							</div>
+							<div
+								class="flex items-center justify-center gap-1 text-sm font-semibold tabular-nums"
+							>
+								{#if isDeficit}
+									<TrendingDown class="size-3.5 text-emerald-500" />
+								{:else if isGain}
+									<TrendingUp class="size-3.5 text-amber-500" />
+								{/if}
+								{formatKcal(result.dailyDeficit)}/d
+							</div>
+						</div>
+						<div
+							class="rounded-xl border border-border/60 bg-background/85 p-3 text-center backdrop-blur"
+						>
+							<div
+								class="text-muted-foreground mb-1 text-[11px] font-semibold uppercase tracking-wider"
+							>
+								{m.maintenance_weight_change()}
+							</div>
+							<div
+								class="flex items-center justify-center gap-1 text-sm font-semibold tabular-nums"
+							>
+								<Scale class="size-3.5" />
+								{result.weightChangeKg > 0 ? '+' : ''}{result.weightChangeKg.toFixed(1)} kg
+							</div>
+						</div>
+					</div>
+				</div>
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root class="overflow-hidden">
+			<Card.Header class="pb-3">
+				<div class="flex items-center gap-2">
+					<div
+						class="flex size-8 items-center justify-center rounded-lg bg-amber-500/10 text-amber-600 dark:text-amber-400"
+					>
+						<Flame class="size-4" />
+					</div>
+					<Card.Title class="text-base tracking-tight">
+						{m.maintenance_breakdown()}
+					</Card.Title>
+				</div>
+			</Card.Header>
+			<Card.Content class="space-y-3 p-4 pt-0 sm:p-5 sm:pt-0">
+				<div class="space-y-2">
+					<div class="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2">
+						<span class="text-sm">{m.maintenance_fat_loss()}</span>
+						<span class="font-mono text-sm font-semibold">
+							{formatKg(result.fatMassKg)} kg = {formatKcal(result.fatCalories)} kcal
+						</span>
+					</div>
+					<div class="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-2">
+						<span class="text-sm">{m.maintenance_muscle_loss()}</span>
+						<span class="font-mono text-sm font-semibold">
+							{formatKg(result.muscleMassKg)} kg = {formatKcal(result.muscleCalories)} kcal
+						</span>
+					</div>
+					<div
+						class="flex items-center justify-between rounded-lg border border-border/60 px-3 py-2"
+					>
+						<span class="text-sm font-medium">{m.maintenance_total_energy()}</span>
+						<span class="font-mono text-sm font-bold">
+							{formatKcal(result.totalDeficit)} kcal
+						</span>
+					</div>
+				</div>
+
+				<div class="mt-4 space-y-1 text-xs text-muted-foreground">
+					<p>
+						{m.maintenance_data_note({
+							weightEntries: meta.weightEntries,
+							foodDays: meta.foodEntryDays,
+							days: result.days
+						})}
+					</p>
+					<p>
+						{m.maintenance_weight_range({
+							first: meta.firstWeight.toFixed(1),
+							last: meta.lastWeight.toFixed(1)
+						})}
+					</p>
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+</div>

--- a/src/routes/api/maintenance/+server.ts
+++ b/src/routes/api/maintenance/+server.ts
@@ -7,22 +7,43 @@ import { weightEntries } from '$lib/server/schema';
 import { and, eq, gte, lte, asc } from 'drizzle-orm';
 import { calculateMaintenance, DEFAULT_MUSCLE_RATIO } from '$lib/utils/maintenance';
 import { calculateEntryMacros } from '$lib/utils/nutrition';
+import { daysBetween } from '$lib/utils/dates';
+import { z } from 'zod';
+
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const muscleRatioSchema = z.coerce.number().min(0).max(1);
 
 export const GET: RequestHandler = async ({ locals, url }) => {
 	try {
 		const userId = requireAuth(locals);
-		const startDate = url.searchParams.get('startDate');
-		const endDate = url.searchParams.get('endDate');
+		const startDateRaw = url.searchParams.get('startDate');
+		const endDateRaw = url.searchParams.get('endDate');
 		const muscleRatioParam = url.searchParams.get('muscleRatio');
 
-		if (!startDate || !endDate) {
+		if (!startDateRaw || !endDateRaw) {
 			throw new ApiError(400, 'startDate and endDate parameters are required');
 		}
 
-		const muscleRatio = muscleRatioParam ? parseFloat(muscleRatioParam) : DEFAULT_MUSCLE_RATIO;
+		const startDateResult = dateSchema.safeParse(startDateRaw);
+		if (!startDateResult.success) {
+			throw new ApiError(400, 'startDate must be in YYYY-MM-DD format');
+		}
 
-		if (isNaN(muscleRatio) || muscleRatio < 0 || muscleRatio > 1) {
-			throw new ApiError(400, 'muscleRatio must be between 0 and 1');
+		const endDateResult = dateSchema.safeParse(endDateRaw);
+		if (!endDateResult.success) {
+			throw new ApiError(400, 'endDate must be in YYYY-MM-DD format');
+		}
+
+		const startDate = startDateResult.data;
+		const endDate = endDateResult.data;
+
+		let muscleRatio = DEFAULT_MUSCLE_RATIO;
+		if (muscleRatioParam) {
+			const ratioResult = muscleRatioSchema.safeParse(muscleRatioParam);
+			if (!ratioResult.success) {
+				throw new ApiError(400, 'muscleRatio must be a number between 0 and 1');
+			}
+			muscleRatio = ratioResult.data;
 		}
 
 		const db = getDB();
@@ -72,20 +93,19 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 			);
 		}
 
-		const totalCalories = Object.values(dailyTotals).reduce((sum, cal) => sum + cal, 0);
-		const avgDailyCalories = totalCalories / daysWithEntries.length;
-
-		const firstWeight = weights[0];
-		const lastWeight = weights[weights.length - 1];
-		const weightChangeKg = lastWeight.weightKg - firstWeight.weightKg;
-
-		const start = new Date(startDate + 'T00:00:00Z');
-		const end = new Date(endDate + 'T00:00:00Z');
-		const days = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+		const days = daysBetween(startDate, endDate);
 
 		if (days <= 0) {
 			throw new ApiError(400, 'End date must be after start date');
 		}
+
+		const totalCalories = Object.values(dailyTotals).reduce((sum, cal) => sum + cal, 0);
+		const avgDailyCalories = totalCalories / days;
+		const coverage = daysWithEntries.length / days;
+
+		const firstWeight = weights[0];
+		const lastWeight = weights[weights.length - 1];
+		const weightChangeKg = lastWeight.weightKg - firstWeight.weightKg;
 
 		const result = calculateMaintenance({
 			weightChangeKg,
@@ -103,6 +123,8 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 			meta: {
 				weightEntries: weights.length,
 				foodEntryDays: daysWithEntries.length,
+				totalDays: days,
+				coverage,
 				firstWeight: firstWeight.weightKg,
 				lastWeight: lastWeight.weightKg,
 				startDate,

--- a/src/routes/api/maintenance/+server.ts
+++ b/src/routes/api/maintenance/+server.ts
@@ -1,0 +1,115 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { handleApiError, requireAuth, ApiError } from '$lib/server/errors';
+import { listEntriesByDateRange } from '$lib/server/entries';
+import { getDB } from '$lib/server/db';
+import { weightEntries } from '$lib/server/schema';
+import { and, eq, gte, lte, asc } from 'drizzle-orm';
+import { calculateMaintenance, DEFAULT_MUSCLE_RATIO } from '$lib/utils/maintenance';
+import { calculateEntryMacros } from '$lib/utils/nutrition';
+
+export const GET: RequestHandler = async ({ locals, url }) => {
+	try {
+		const userId = requireAuth(locals);
+		const startDate = url.searchParams.get('startDate');
+		const endDate = url.searchParams.get('endDate');
+		const muscleRatioParam = url.searchParams.get('muscleRatio');
+
+		if (!startDate || !endDate) {
+			throw new ApiError(400, 'startDate and endDate parameters are required');
+		}
+
+		const muscleRatio = muscleRatioParam ? parseFloat(muscleRatioParam) : DEFAULT_MUSCLE_RATIO;
+
+		if (isNaN(muscleRatio) || muscleRatio < 0 || muscleRatio > 1) {
+			throw new ApiError(400, 'muscleRatio must be between 0 and 1');
+		}
+
+		const db = getDB();
+
+		const [entries, weights] = await Promise.all([
+			listEntriesByDateRange(userId, startDate, endDate),
+			db
+				.select({
+					entryDate: weightEntries.entryDate,
+					weightKg: weightEntries.weightKg
+				})
+				.from(weightEntries)
+				.where(
+					and(
+						eq(weightEntries.userId, userId),
+						gte(weightEntries.entryDate, startDate),
+						lte(weightEntries.entryDate, endDate)
+					)
+				)
+				.orderBy(asc(weightEntries.entryDate))
+		]);
+
+		if (weights.length < 2) {
+			return json(
+				{
+					error: 'insufficient_data',
+					message: 'At least 2 weight entries are required in the selected range'
+				},
+				{ status: 400 }
+			);
+		}
+
+		const dailyTotals: Record<string, number> = {};
+		for (const entry of entries) {
+			const macros = calculateEntryMacros(entry);
+			dailyTotals[entry.date] = (dailyTotals[entry.date] ?? 0) + macros.calories;
+		}
+
+		const daysWithEntries = Object.keys(dailyTotals);
+		if (daysWithEntries.length === 0) {
+			return json(
+				{
+					error: 'insufficient_data',
+					message: 'No food entries found in the selected range'
+				},
+				{ status: 400 }
+			);
+		}
+
+		const totalCalories = Object.values(dailyTotals).reduce((sum, cal) => sum + cal, 0);
+		const avgDailyCalories = totalCalories / daysWithEntries.length;
+
+		const firstWeight = weights[0];
+		const lastWeight = weights[weights.length - 1];
+		const weightChangeKg = lastWeight.weightKg - firstWeight.weightKg;
+
+		const start = new Date(startDate + 'T00:00:00Z');
+		const end = new Date(endDate + 'T00:00:00Z');
+		const days = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+
+		if (days <= 0) {
+			throw new ApiError(400, 'End date must be after start date');
+		}
+
+		const result = calculateMaintenance({
+			weightChangeKg,
+			avgDailyCalories,
+			days,
+			muscleRatio
+		});
+
+		if (!result) {
+			throw new ApiError(400, 'Could not calculate maintenance calories');
+		}
+
+		return json({
+			result,
+			meta: {
+				weightEntries: weights.length,
+				foodEntryDays: daysWithEntries.length,
+				firstWeight: firstWeight.weightKg,
+				lastWeight: lastWeight.weightKg,
+				startDate,
+				endDate
+			}
+		});
+	} catch (error) {
+		return handleApiError(error);
+	}
+};

--- a/tests/api/maintenance.test.ts
+++ b/tests/api/maintenance.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, mock } from 'bun:test';
+import { createMockEvent } from '../helpers/mock-request-event';
+import { TEST_USER } from '../helpers/fixtures';
+
+mock.module('$lib/paraglide/messages', () => new Proxy({}, { get: () => () => '' }));
+
+const mockWeights = [
+	{ entryDate: '2026-02-01', weightKg: 80.0 },
+	{ entryDate: '2026-02-14', weightKg: 79.0 }
+];
+
+const mockEntries = [
+	{ date: '2026-02-01', calories: 2000, protein: 100, carbs: 200, fat: 80, fiber: 25, servings: 1 },
+	{ date: '2026-02-02', calories: 1800, protein: 90, carbs: 180, fat: 70, fiber: 20, servings: 1 },
+	{ date: '2026-02-03', calories: 2100, protein: 110, carbs: 210, fat: 85, fiber: 28, servings: 1 }
+];
+
+mock.module('$lib/server/entries', () => ({
+	listEntriesByDateRange: async () => mockEntries
+}));
+
+mock.module('$lib/server/db', () => ({
+	getDB: () => ({
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					orderBy: async () => mockWeights
+				})
+			})
+		})
+	})
+}));
+
+const { GET } = await import('../../src/routes/api/maintenance/+server');
+
+describe('api/maintenance', () => {
+	test('returns 401 when not authenticated', async () => {
+		const event = createMockEvent({
+			user: null,
+			url: 'http://localhost/api/maintenance?startDate=2026-02-01&endDate=2026-02-14'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(data.error).toBe('Unauthorized');
+	});
+
+	test('returns 400 when date params are missing', async () => {
+		const event = createMockEvent({
+			user: TEST_USER,
+			url: 'http://localhost/api/maintenance'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.error).toBeTruthy();
+	});
+
+	test('returns 400 when startDate format is invalid', async () => {
+		const event = createMockEvent({
+			user: TEST_USER,
+			url: 'http://localhost/api/maintenance?startDate=not-a-date&endDate=2026-02-14'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.error).toBeTruthy();
+	});
+
+	test('returns 400 when endDate format is invalid', async () => {
+		const event = createMockEvent({
+			user: TEST_USER,
+			url: 'http://localhost/api/maintenance?startDate=2026-02-01&endDate=14-02-2026'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.error).toBeTruthy();
+	});
+
+	test('returns 400 when muscleRatio is out of range', async () => {
+		const event = createMockEvent({
+			user: TEST_USER,
+			url: 'http://localhost/api/maintenance?startDate=2026-02-01&endDate=2026-02-14&muscleRatio=1.5'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.error).toBeTruthy();
+	});
+
+	test('returns 400 when muscleRatio is not a number', async () => {
+		const event = createMockEvent({
+			user: TEST_USER,
+			url: 'http://localhost/api/maintenance?startDate=2026-02-01&endDate=2026-02-14&muscleRatio=abc'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(400);
+		expect(data.error).toBeTruthy();
+	});
+
+	test('returns successful calculation with valid params', async () => {
+		const event = createMockEvent({
+			user: TEST_USER,
+			url: 'http://localhost/api/maintenance?startDate=2026-02-01&endDate=2026-02-14'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.result).toBeTruthy();
+		expect(data.result.maintenanceCalories).toBeGreaterThan(0);
+		expect(data.result.totalEnergyBalance).toBeDefined();
+		expect(data.meta).toBeTruthy();
+		expect(data.meta.coverage).toBeDefined();
+		expect(data.meta.totalDays).toBeDefined();
+	});
+
+	test('includes coverage in meta', async () => {
+		const event = createMockEvent({
+			user: TEST_USER,
+			url: 'http://localhost/api/maintenance?startDate=2026-02-01&endDate=2026-02-14'
+		});
+
+		const response = await GET(event);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.meta.coverage).toBeGreaterThan(0);
+		expect(data.meta.coverage).toBeLessThanOrEqual(1);
+		expect(data.meta.foodEntryDays).toBe(3);
+		expect(data.meta.totalDays).toBe(13);
+	});
+});

--- a/tests/utils/maintenance.test.ts
+++ b/tests/utils/maintenance.test.ts
@@ -19,7 +19,7 @@ describe('calculateMaintenance', () => {
 		expect(result!.muscleMassKg).toBe(0.6);
 		expect(result!.fatCalories).toBe(10780);
 		expect(result!.muscleCalories).toBe(1080);
-		expect(result!.totalDeficit).toBe(11860);
+		expect(result!.totalEnergyBalance).toBe(11860);
 		expect(result!.dailyDeficit).toBe(424);
 		expect(result!.maintenanceCalories).toBe(2224);
 	});
@@ -33,7 +33,7 @@ describe('calculateMaintenance', () => {
 		});
 
 		expect(result).not.toBeNull();
-		expect(result!.totalDeficit).toBeLessThan(0);
+		expect(result!.totalEnergyBalance).toBeLessThan(0);
 		expect(result!.maintenanceCalories).toBeLessThan(2500);
 	});
 

--- a/tests/utils/maintenance.test.ts
+++ b/tests/utils/maintenance.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	calculateMaintenance,
+	KCAL_PER_KG_FAT,
+	KCAL_PER_KG_MUSCLE
+} from '../../src/lib/utils/maintenance';
+
+describe('calculateMaintenance', () => {
+	test('calculates maintenance from weight loss (issue example)', () => {
+		const result = calculateMaintenance({
+			weightChangeKg: -2,
+			avgDailyCalories: 1800,
+			days: 28,
+			muscleRatio: 0.3
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.fatMassKg).toBe(1.4);
+		expect(result!.muscleMassKg).toBe(0.6);
+		expect(result!.fatCalories).toBe(10780);
+		expect(result!.muscleCalories).toBe(1080);
+		expect(result!.totalDeficit).toBe(11860);
+		expect(result!.dailyDeficit).toBe(424);
+		expect(result!.maintenanceCalories).toBe(2224);
+	});
+
+	test('calculates maintenance from weight gain', () => {
+		const result = calculateMaintenance({
+			weightChangeKg: 1,
+			avgDailyCalories: 2500,
+			days: 14,
+			muscleRatio: 0.3
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.totalDeficit).toBeLessThan(0);
+		expect(result!.maintenanceCalories).toBeLessThan(2500);
+	});
+
+	test('handles zero weight change', () => {
+		const result = calculateMaintenance({
+			weightChangeKg: 0,
+			avgDailyCalories: 2000,
+			days: 28
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.maintenanceCalories).toBe(2000);
+		expect(result!.dailyDeficit).toBe(0);
+	});
+
+	test('uses default muscle ratio of 0.3', () => {
+		const result = calculateMaintenance({
+			weightChangeKg: -1,
+			avgDailyCalories: 2000,
+			days: 7
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.muscleRatio).toBe(0.3);
+		expect(result!.fatMassKg).toBe(0.7);
+		expect(result!.muscleMassKg).toBe(0.3);
+	});
+
+	test('returns null for zero days', () => {
+		const result = calculateMaintenance({
+			weightChangeKg: -1,
+			avgDailyCalories: 2000,
+			days: 0
+		});
+
+		expect(result).toBeNull();
+	});
+
+	test('returns null for negative calories', () => {
+		const result = calculateMaintenance({
+			weightChangeKg: -1,
+			avgDailyCalories: -100,
+			days: 7
+		});
+
+		expect(result).toBeNull();
+	});
+
+	test('custom muscle ratio', () => {
+		const result = calculateMaintenance({
+			weightChangeKg: -1,
+			avgDailyCalories: 2000,
+			days: 7,
+			muscleRatio: 0.5
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.fatMassKg).toBe(0.5);
+		expect(result!.muscleMassKg).toBe(0.5);
+		expect(result!.fatCalories).toBe(KCAL_PER_KG_FAT * 0.5);
+		expect(result!.muscleCalories).toBe(KCAL_PER_KG_MUSCLE * 0.5);
+	});
+
+	test('energy constants are correct', () => {
+		expect(KCAL_PER_KG_FAT).toBe(7700);
+		expect(KCAL_PER_KG_MUSCLE).toBe(1800);
+	});
+});


### PR DESCRIPTION
## Summary
- Add maintenance calorie calculator that estimates daily maintenance calories based on weight change and average calorie intake over a configurable date range
- Supports adjustable muscle/fat body composition ratio (default 30/70) with energy conversion: fat at 7,700 kcal/kg, muscle at 1,800 kcal/kg
- Full UI page at `/maintenance` with date range presets (2/4/8/12 weeks), slider for composition ratio, and detailed energy breakdown

## Changes
- `src/lib/utils/maintenance.ts` — Pure calculation logic with exported types and constants
- `src/routes/api/maintenance/+server.ts` — API endpoint fetching weight + food entry data, computing maintenance
- `src/routes/(app)/maintenance/+page.svelte` — UI page with input controls and result display
- `src/lib/config/navigation.ts` — Added sidebar navigation entry
- `messages/en.json` / `messages/de.json` — i18n messages (en + de)
- `tests/utils/maintenance.test.ts` — 8 unit tests for the calculation function

## Test plan
- [x] Unit tests pass (`bun test tests/utils/maintenance.test.ts` — 8/8)
- [x] Type checking passes (`bun run check` — 0 errors)
- [ ] Manual: Navigate to /maintenance, select a date range, calculate with weight + food data
- [ ] Manual: Verify slider adjusts muscle/fat ratio and recalculates correctly
- [ ] Manual: Verify error states (insufficient weight entries, no food entries)

Closes #39