### PR TITLE
feat: allow logging meals for past and future dates

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -24,6 +24,8 @@
 	"dashboard_previous_day": "Vorheriger Tag",
 	"dashboard_next_day": "Nächster Tag",
 	"dashboard_yesterday": "Gestern",
+	"dashboard_tomorrow": "Morgen",
+	"dashboard_go_to_today": "Heute",
 
 	"meal_breakfast": "Frühstück",
 	"meal_lunch": "Mittagessen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -24,6 +24,8 @@
 	"dashboard_previous_day": "Previous day",
 	"dashboard_next_day": "Next day",
 	"dashboard_yesterday": "Yesterday",
+	"dashboard_tomorrow": "Tomorrow",
+	"dashboard_go_to_today": "Today",
 
 	"meal_breakfast": "Breakfast",
 	"meal_lunch": "Lunch",

--- a/src/lib/components/entries/DateNavigator.svelte
+++ b/src/lib/components/entries/DateNavigator.svelte
@@ -49,7 +49,7 @@
 			{/snippet}
 		</Popover.Trigger>
 		<Popover.Content class="w-auto p-0" align="center">
-			<Calendar value={calendarValue} onValueChange={onCalendarChange} />
+			<Calendar type="single" value={calendarValue} onValueChange={onCalendarChange} />
 		</Popover.Content>
 	</Popover.Root>
 

--- a/src/lib/components/entries/DateNavigator.svelte
+++ b/src/lib/components/entries/DateNavigator.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Popover from '$lib/components/ui/popover/index.js';
+	import { Calendar } from '$lib/components/ui/calendar/index.js';
+	import { ChevronLeft, ChevronRight } from '@lucide/svelte';
+	import { today, shiftDate, formatDateLabel } from '$lib/utils/dates';
+	import { goto } from '$app/navigation';
+	import { parseDate, type DateValue } from '@internationalized/date';
+	import * as m from '$lib/paraglide/messages';
+
+	type Props = {
+		date: string;
+	};
+
+	let { date }: Props = $props();
+
+	let calendarOpen = $state(false);
+
+	const isToday = $derived(date === today());
+
+	const calendarValue = $derived(parseDate(date));
+
+	const navigate = (isoDate: string) => {
+		goto(`/?date=${isoDate}`, { replaceState: true });
+	};
+
+	const prevDay = () => navigate(shiftDate(date, -1));
+	const nextDay = () => navigate(shiftDate(date, 1));
+	const goToday = () => goto('/', { replaceState: true });
+
+	const onCalendarChange = (value: DateValue | undefined) => {
+		if (!value) return;
+		navigate(value.toString());
+		calendarOpen = false;
+	};
+</script>
+
+<div class="flex items-center gap-2">
+	<Button variant="ghost" size="icon" onclick={prevDay} aria-label={m.dashboard_previous_day()}>
+		<ChevronLeft class="h-4 w-4" />
+	</Button>
+
+	<Popover.Root bind:open={calendarOpen}>
+		<Popover.Trigger>
+			{#snippet child({ props })}
+				<Button variant="ghost" {...props} class="text-2xl font-semibold">
+					{formatDateLabel(date)}
+				</Button>
+			{/snippet}
+		</Popover.Trigger>
+		<Popover.Content class="w-auto p-0" align="center">
+			<Calendar value={calendarValue} onValueChange={onCalendarChange} />
+		</Popover.Content>
+	</Popover.Root>
+
+	<Button variant="ghost" size="icon" onclick={nextDay} aria-label={m.dashboard_next_day()}>
+		<ChevronRight class="h-4 w-4" />
+	</Button>
+
+	{#if !isToday}
+		<Button variant="outline" size="sm" onclick={goToday}>
+			{m.dashboard_go_to_today()}
+		</Button>
+	{/if}
+</div>

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -10,6 +10,23 @@ export const today = () => new Date().toISOString().slice(0, 10);
 
 export const yesterday = () => shiftDate(today(), -1);
 
+export const tomorrow = () => shiftDate(today(), 1);
+
+export const formatDateLabel = (isoDate: string): string => {
+	if (isoDate === today()) return m.dashboard_today();
+	if (isoDate === yesterday()) return m.dashboard_yesterday();
+	if (isoDate === tomorrow()) return m.dashboard_tomorrow();
+	const date = new Date(isoDate + 'T00:00:00Z');
+	return date.toLocaleDateString(undefined, {
+		weekday: 'short',
+		month: 'short',
+		day: 'numeric'
+	});
+};
+
+export const isValidIsoDate = (s: string): boolean =>
+	/^\d{4}-\d{2}-\d{2}$/.test(s) && !isNaN(new Date(s + 'T00:00:00Z').getTime());
+
 export const getMonthDays = (year: number, month: number) => {
 	const firstDay = new Date(year, month, 1);
 	const lastDay = new Date(year, month + 1, 0);

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -13,19 +13,25 @@ export const yesterday = () => shiftDate(today(), -1);
 export const tomorrow = () => shiftDate(today(), 1);
 
 export const formatDateLabel = (isoDate: string): string => {
-	if (isoDate === today()) return m.dashboard_today();
-	if (isoDate === yesterday()) return m.dashboard_yesterday();
-	if (isoDate === tomorrow()) return m.dashboard_tomorrow();
-	const date = new Date(isoDate + 'T00:00:00Z');
+	const t = today();
+	if (isoDate === t) return m.dashboard_today();
+	if (isoDate === shiftDate(t, -1)) return m.dashboard_yesterday();
+	if (isoDate === shiftDate(t, 1)) return m.dashboard_tomorrow();
+	const [year, month, day] = isoDate.split('-').map(Number);
+	const date = new Date(Date.UTC(year, month - 1, day));
 	return date.toLocaleDateString(undefined, {
 		weekday: 'short',
 		month: 'short',
-		day: 'numeric'
+		day: 'numeric',
+		timeZone: 'UTC'
 	});
 };
 
-export const isValidIsoDate = (s: string): boolean =>
-	/^\d{4}-\d{2}-\d{2}$/.test(s) && !isNaN(new Date(s + 'T00:00:00Z').getTime());
+export const isValidIsoDate = (s: string): boolean => {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+	const d = new Date(s + 'T00:00:00Z');
+	return d.toISOString().startsWith(s);
+};
 
 export const getMonthDays = (year: number, month: number) => {
 	const firstDay = new Date(year, month, 1);

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -4,9 +4,10 @@
 	import DailyMacroChart from '$lib/components/charts/DailyMacroChart.svelte';
 	import GoalProgressRings from '$lib/components/charts/GoalProgressRings.svelte';
 	import DashboardCard from '$lib/components/dashboard/DashboardCard.svelte';
+	import DateNavigator from '$lib/components/entries/DateNavigator.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { type MacroTotals } from '$lib/utils/nutrition';
-	import { today, yesterday, shiftDate } from '$lib/utils/dates';
+	import { today } from '$lib/utils/dates';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { apiFetch } from '$lib/utils/api';
@@ -14,11 +15,12 @@
 	import FavoritesWidget from '$lib/components/favorites/FavoritesWidget.svelte';
 	import WeightWidget from '$lib/components/weight/WeightWidget.svelte';
 	import * as m from '$lib/paraglide/messages';
-	import { ChevronLeft, ChevronRight, ScanBarcode } from '@lucide/svelte';
+	import { ScanBarcode } from '@lucide/svelte';
 	import ChartPie from '@lucide/svelte/icons/chart-pie';
 	import Target from '@lucide/svelte/icons/target';
 
-	let activeDate = $state(today());
+	let { data } = $props();
+	const activeDate = $derived(data.date);
 
 	let refreshKey = $state(0);
 	type ChecklistItem = {
@@ -47,22 +49,6 @@
 	} | null = $state(null);
 
 	const isToday = $derived(activeDate === today());
-
-	const dateLabel = $derived(
-		activeDate === today()
-			? m.dashboard_today()
-			: activeDate === yesterday()
-				? m.dashboard_yesterday()
-				: activeDate
-	);
-
-	const prevDay = () => {
-		activeDate = shiftDate(activeDate, -1);
-	};
-
-	const nextDay = () => {
-		if (!isToday) activeDate = shiftDate(activeDate, 1);
-	};
 
 	$effect(() => {
 		if (ready) loadSupplements(activeDate);
@@ -152,26 +138,7 @@
 {#if ready}
 	<div class="mx-auto max-w-4xl space-y-6">
 		<div class="flex items-center justify-between gap-2">
-			<div class="flex items-center gap-2">
-				<Button
-					variant="ghost"
-					size="icon"
-					onclick={prevDay}
-					aria-label={m.dashboard_previous_day()}
-				>
-					<ChevronLeft class="h-4 w-4" />
-				</Button>
-				<h2 class="text-2xl font-semibold">{dateLabel}</h2>
-				<Button
-					variant="ghost"
-					size="icon"
-					onclick={nextDay}
-					disabled={isToday}
-					aria-label={m.dashboard_next_day()}
-				>
-					<ChevronRight class="h-4 w-4" />
-				</Button>
-			</div>
+			<DateNavigator date={activeDate} />
 			<Button variant="outline" size="sm" onclick={() => (scanModalOpen = true)}>
 				<ScanBarcode class="h-4 w-4" />
 				{m.dashboard_scan()}

--- a/src/routes/(app)/+page.ts
+++ b/src/routes/(app)/+page.ts
@@ -1,1 +1,10 @@
+import { isValidIsoDate, today } from '$lib/utils/dates';
+import type { PageLoad } from './$types';
+
 export const ssr = false;
+
+export const load: PageLoad = ({ url }) => {
+	const dateParam = url.searchParams.get('date');
+	const date = dateParam && isValidIsoDate(dateParam) ? dateParam : today();
+	return { date };
+};


### PR DESCRIPTION
## Summary
- Add URL-based date navigation (`/?date=2026-02-25`) with persistence across page refreshes
- New `DateNavigator` component with prev/next arrows and calendar popover for jumping to any date
- "Today" pill button appears when viewing a non-today date for quick return

Closes #38

## Test Plan
- [ ] Arrow buttons navigate prev/next day (including future dates)
- [ ] Calendar popover opens when tapping date label, selecting a date navigates and closes
- [ ] "Today" button appears on non-today dates and navigates back
- [ ] Page refresh preserves the selected date via URL param
- [ ] Invalid `?date=` param falls back to today
- [ ] Supplement checklist updates when date changes
- [ ] Adding food entries logs to the displayed date

🤖 Generated with [Claude Code](https://claude.com/claude-code)