### PR TITLE
test: add 250 tests covering weight, MCP handlers, supplements, OAuth, stats, and validation

### DIFF
--- a/tests/api/oauth-register.test.ts
+++ b/tests/api/oauth-register.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect, mock } from 'bun:test';
+
+// Mock DB
+const mockInsert = { values: async () => ({}) };
+mock.module('$lib/server/db', () => ({
+	getDB: () => ({
+		insert: () => mockInsert
+	}),
+	oauthClients: {}
+}));
+
+mock.module('$lib/server/oauth', () => ({
+	generateClientId: () => 'generated-client-id',
+	generateClientSecret: () => 'generated-client-secret',
+	hashToken: (t: string) => `hashed-${t}`
+}));
+
+const { POST } = await import('../../src/routes/api/oauth/register/+server');
+
+function createRegisterRequest(body: unknown) {
+	const request = new Request('http://localhost:5173/api/oauth/register', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+
+	return {
+		request,
+		url: new URL('http://localhost:5173/api/oauth/register'),
+		params: {},
+		locals: {},
+		cookies: { get: () => undefined, set: () => {}, delete: () => {}, serialize: () => '' },
+		fetch: globalThis.fetch,
+		getClientAddress: () => '127.0.0.1',
+		platform: undefined,
+		route: { id: '/api/oauth/register' },
+		setHeaders: () => {},
+		isDataRequest: false,
+		isSubRequest: false
+	} as any;
+}
+
+describe('POST /api/oauth/register', () => {
+	test('registers client with valid redirect URIs', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['https://example.com/callback'],
+			client_name: 'Test App'
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(201);
+		expect(data.client_id).toBe('generated-client-id');
+		expect(data.client_secret).toBe('generated-client-secret');
+		expect(data.client_name).toBe('Test App');
+		expect(data.redirect_uris).toEqual(['https://example.com/callback']);
+		expect(data.grant_types).toEqual(['authorization_code']);
+		expect(data.response_types).toEqual(['code']);
+	});
+
+	test('registers public client (auth method = none)', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['https://example.com/callback'],
+			token_endpoint_auth_method: 'none'
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(201);
+		expect(data.client_id).toBe('generated-client-id');
+		expect(data.client_secret).toBeUndefined();
+	});
+
+	test('accepts localhost redirect URI', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['http://localhost:3000/callback']
+		});
+		const response = await POST(event);
+		expect(response.status).toBe(201);
+	});
+
+	test('accepts 127.0.0.1 redirect URI', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['http://127.0.0.1:8080/callback']
+		});
+		const response = await POST(event);
+		expect(response.status).toBe(201);
+	});
+
+	test('rejects missing redirect_uris', async () => {
+		const event = createRegisterRequest({
+			client_name: 'No URIs'
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('invalid_redirect_uri');
+	});
+
+	test('rejects empty redirect_uris array', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: []
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('invalid_redirect_uri');
+	});
+
+	test('rejects HTTP redirect URI on non-localhost', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['http://example.com/callback']
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('invalid_redirect_uri');
+	});
+
+	test('rejects invalid URI format', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['not-a-url']
+		});
+		const response = await POST(event);
+		expect(response.status).toBe(400);
+	});
+
+	test('rejects invalid grant_types', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['https://example.com/callback'],
+			grant_types: ['client_credentials']
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('invalid_client_metadata');
+		expect(data.error_description).toContain('authorization_code');
+	});
+
+	test('rejects invalid response_types', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['https://example.com/callback'],
+			response_types: ['token']
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('invalid_client_metadata');
+		expect(data.error_description).toContain('code');
+	});
+
+	test('rejects unsupported auth method', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['https://example.com/callback'],
+			token_endpoint_auth_method: 'client_secret_basic'
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('invalid_client_metadata');
+	});
+
+	test('rejects invalid JSON body', async () => {
+		const request = new Request('http://localhost:5173/api/oauth/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: 'not-json'
+		});
+		const event = {
+			request,
+			url: new URL('http://localhost:5173/api/oauth/register'),
+			params: {},
+			locals: {},
+			cookies: { get: () => undefined, set: () => {}, delete: () => {}, serialize: () => '' },
+			fetch: globalThis.fetch,
+			getClientAddress: () => '127.0.0.1',
+			platform: undefined,
+			route: { id: '/api/oauth/register' },
+			setHeaders: () => {},
+			isDataRequest: false,
+			isSubRequest: false
+		} as any;
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(400);
+		expect(data.error).toBe('invalid_client_metadata');
+	});
+
+	test('strips trailing slash from redirect URIs', async () => {
+		const event = createRegisterRequest({
+			redirect_uris: ['https://example.com/callback/']
+		});
+		const response = await POST(event);
+		const data = await response.json();
+		expect(response.status).toBe(201);
+		expect(data.redirect_uris).toEqual(['https://example.com/callback']);
+	});
+});

--- a/tests/api/oauth-token.test.ts
+++ b/tests/api/oauth-token.test.ts
@@ -1,0 +1,256 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { TEST_USER } from '../helpers/fixtures';
+
+let mockVerifyClientResult: any = null;
+let mockPublicClientResult: any = null;
+let mockConsumeCodeResult: string | null = null;
+let mockCreateTokenResult: any = null;
+let mockRefreshResult: any = null;
+
+mock.module('$lib/server/oauth', () => ({
+	verifyOAuthClient: async () => mockVerifyClientResult,
+	getPublicOAuthClient: async () => mockPublicClientResult,
+	consumeAuthorizationCode: async () => mockConsumeCodeResult,
+	createAccessToken: async () => mockCreateTokenResult,
+	refreshAccessToken: async () => mockRefreshResult,
+	ACCESS_TOKEN_LIFETIME_MS: 3600000,
+	isValidCodeVerifier: (v: string) => /^[A-Za-z0-9._~-]{43,128}$/.test(v)
+}));
+
+const { POST } = await import('../../src/routes/api/oauth/token/+server');
+
+// Helper to create a form data request
+function createTokenRequest(fields: Record<string, string>) {
+	const formData = new URLSearchParams();
+	Object.entries(fields).forEach(([key, value]) => {
+		formData.set(key, value);
+	});
+
+	const request = new Request('http://localhost:5173/api/oauth/token', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: formData.toString()
+	});
+
+	return {
+		request,
+		url: new URL('http://localhost:5173/api/oauth/token'),
+		params: {},
+		locals: {},
+		cookies: { get: () => undefined, set: () => {}, delete: () => {}, serialize: () => '' },
+		fetch: globalThis.fetch,
+		getClientAddress: () => '127.0.0.1',
+		platform: undefined,
+		route: { id: '/api/oauth/token' },
+		setHeaders: () => {},
+		isDataRequest: false,
+		isSubRequest: false
+	} as any;
+}
+
+// Valid code verifier (43+ chars, unreserved chars)
+const VALID_VERIFIER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq';
+
+describe('POST /api/oauth/token', () => {
+	beforeEach(() => {
+		mockVerifyClientResult = null;
+		mockPublicClientResult = null;
+		mockConsumeCodeResult = null;
+		mockCreateTokenResult = null;
+		mockRefreshResult = null;
+	});
+
+	describe('validation', () => {
+		test('returns error when grant_type missing', async () => {
+			const event = createTokenRequest({ client_id: 'test' });
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('invalid_request');
+			expect(data.error_description).toContain('grant_type');
+		});
+
+		test('returns error for unsupported grant_type', async () => {
+			const event = createTokenRequest({
+				grant_type: 'client_credentials',
+				client_id: 'test'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('unsupported_grant_type');
+		});
+	});
+
+	describe('authorization_code grant', () => {
+		test('returns error when required params missing', async () => {
+			const event = createTokenRequest({
+				grant_type: 'authorization_code',
+				client_id: 'test'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('invalid_request');
+		});
+
+		test('returns error for invalid code_verifier format', async () => {
+			const event = createTokenRequest({
+				grant_type: 'authorization_code',
+				code: 'auth-code-123',
+				redirect_uri: 'http://localhost:3000/callback',
+				client_id: 'test-client',
+				code_verifier: 'short'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('invalid_request');
+			expect(data.error_description).toContain('code_verifier');
+		});
+
+		test('returns error for invalid client', async () => {
+			mockVerifyClientResult = null;
+			mockPublicClientResult = null;
+			const event = createTokenRequest({
+				grant_type: 'authorization_code',
+				code: 'auth-code-123',
+				redirect_uri: 'http://localhost:3000/callback',
+				client_id: 'unknown-client',
+				code_verifier: VALID_VERIFIER
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('invalid_client');
+		});
+
+		test('returns error for invalid authorization code', async () => {
+			mockPublicClientResult = { clientId: 'test-client' };
+			mockConsumeCodeResult = null;
+			const event = createTokenRequest({
+				grant_type: 'authorization_code',
+				code: 'invalid-code',
+				redirect_uri: 'http://localhost:3000/callback',
+				client_id: 'test-client',
+				code_verifier: VALID_VERIFIER
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('invalid_grant');
+		});
+
+		test('returns tokens on successful code exchange', async () => {
+			mockPublicClientResult = { clientId: 'test-client' };
+			mockConsumeCodeResult = TEST_USER.id;
+			mockCreateTokenResult = {
+				accessToken: 'new-access-token',
+				refreshToken: 'new-refresh-token'
+			};
+			const event = createTokenRequest({
+				grant_type: 'authorization_code',
+				code: 'valid-code',
+				redirect_uri: 'http://localhost:3000/callback',
+				client_id: 'test-client',
+				code_verifier: VALID_VERIFIER
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.access_token).toBe('new-access-token');
+			expect(data.refresh_token).toBe('new-refresh-token');
+			expect(data.token_type).toBe('Bearer');
+			expect(data.expires_in).toBe(3600);
+		});
+
+		test('sets cache-control headers', async () => {
+			mockPublicClientResult = { clientId: 'test-client' };
+			mockConsumeCodeResult = TEST_USER.id;
+			mockCreateTokenResult = {
+				accessToken: 'token',
+				refreshToken: 'refresh'
+			};
+			const event = createTokenRequest({
+				grant_type: 'authorization_code',
+				code: 'valid-code',
+				redirect_uri: 'http://localhost:3000/callback',
+				client_id: 'test-client',
+				code_verifier: VALID_VERIFIER
+			});
+			const response = await POST(event);
+			expect(response.headers.get('Cache-Control')).toBe('no-store');
+			expect(response.headers.get('Pragma')).toBe('no-cache');
+		});
+	});
+
+	describe('refresh_token grant', () => {
+		test('returns error when refresh_token missing', async () => {
+			const event = createTokenRequest({
+				grant_type: 'refresh_token',
+				client_id: 'test-client'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('invalid_request');
+		});
+
+		test('returns error when client_id missing', async () => {
+			const event = createTokenRequest({
+				grant_type: 'refresh_token',
+				refresh_token: 'some-token'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('invalid_request');
+		});
+
+		test('returns error for invalid client', async () => {
+			mockPublicClientResult = null;
+			const event = createTokenRequest({
+				grant_type: 'refresh_token',
+				refresh_token: 'some-token',
+				client_id: 'unknown-client'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('invalid_client');
+		});
+
+		test('returns error for invalid refresh token', async () => {
+			mockPublicClientResult = { clientId: 'test-client' };
+			mockRefreshResult = null;
+			const event = createTokenRequest({
+				grant_type: 'refresh_token',
+				refresh_token: 'expired-token',
+				client_id: 'test-client'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toBe('invalid_grant');
+		});
+
+		test('returns new tokens on successful refresh', async () => {
+			mockPublicClientResult = { clientId: 'test-client' };
+			mockRefreshResult = {
+				accessToken: 'refreshed-access-token',
+				refreshToken: 'refreshed-refresh-token'
+			};
+			const event = createTokenRequest({
+				grant_type: 'refresh_token',
+				refresh_token: 'valid-refresh-token',
+				client_id: 'test-client'
+			});
+			const response = await POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.access_token).toBe('refreshed-access-token');
+			expect(data.refresh_token).toBe('refreshed-refresh-token');
+			expect(data.token_type).toBe('Bearer');
+		});
+	});
+});

--- a/tests/api/stats-extended.test.ts
+++ b/tests/api/stats-extended.test.ts
@@ -1,0 +1,256 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { createMockEvent } from '../helpers/mock-request-event';
+import { TEST_USER, TEST_GOALS } from '../helpers/fixtures';
+
+let mockCalendarResult: any = null;
+let mockDailyBreakdownResult: any = null;
+let mockMealBreakdownResult: any = null;
+let mockTopFoodsResult: any = null;
+let mockStreaksResult: any = null;
+let mockGoalsResult: any = null;
+
+mock.module('$lib/server/stats', () => ({
+	getCalendarStats: async () => mockCalendarResult,
+	getDailyBreakdown: async () => mockDailyBreakdownResult,
+	getMealBreakdown: async () => mockMealBreakdownResult,
+	getTopFoods: async () => mockTopFoodsResult,
+	getStreaks: async () => mockStreaksResult
+}));
+
+mock.module('$lib/server/goals', () => ({
+	getGoals: async () => mockGoalsResult
+}));
+
+const calendarModule = await import('../../src/routes/api/stats/calendar/+server');
+const dailyModule = await import('../../src/routes/api/stats/daily/+server');
+const mealBreakdownModule = await import('../../src/routes/api/stats/meal-breakdown/+server');
+const topFoodsModule = await import('../../src/routes/api/stats/top-foods/+server');
+const streaksModule = await import('../../src/routes/api/stats/streaks/+server');
+
+describe('api/stats - extended endpoints', () => {
+	beforeEach(() => {
+		mockCalendarResult = null;
+		mockDailyBreakdownResult = null;
+		mockMealBreakdownResult = null;
+		mockTopFoodsResult = null;
+		mockStreaksResult = null;
+		mockGoalsResult = null;
+	});
+
+	describe('GET /api/stats/calendar', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				searchParams: { month: '2026-02' }
+			});
+			const response = await calendarModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns calendar stats for valid month', async () => {
+			mockCalendarResult = { days: [{ date: '2026-02-01', calories: 2000 }] };
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { month: '2026-02' }
+			});
+			const response = await calendarModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+		});
+
+		test('returns 400 when month parameter missing', async () => {
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await calendarModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toContain('month');
+		});
+
+		test('returns 400 for invalid month format', async () => {
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { month: '2026-2' }
+			});
+			const response = await calendarModule.GET(event);
+			expect(response.status).toBe(400);
+		});
+
+		test('returns 400 for invalid month value', async () => {
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { month: '2026-13' }
+			});
+			const response = await calendarModule.GET(event);
+			expect(response.status).toBe(400);
+		});
+
+		test('returns 400 for month 00', async () => {
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { month: '2026-00' }
+			});
+			const response = await calendarModule.GET(event);
+			expect(response.status).toBe(400);
+		});
+	});
+
+	describe('GET /api/stats/daily', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				searchParams: { startDate: '2026-02-01', endDate: '2026-02-07' }
+			});
+			const response = await dailyModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns daily breakdown with goals', async () => {
+			mockDailyBreakdownResult = [{ date: '2026-02-01', calories: 2000 }];
+			mockGoalsResult = TEST_GOALS;
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { startDate: '2026-02-01', endDate: '2026-02-07' }
+			});
+			const response = await dailyModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.data).toBeDefined();
+			expect(data.goals).toBeDefined();
+			expect(data.goals.calorieGoal).toBe(2000);
+		});
+
+		test('returns null goals when user has none', async () => {
+			mockDailyBreakdownResult = [];
+			mockGoalsResult = null;
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { startDate: '2026-02-01', endDate: '2026-02-07' }
+			});
+			const response = await dailyModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.goals).toBeNull();
+		});
+
+		test('returns 400 when startDate missing', async () => {
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { endDate: '2026-02-07' }
+			});
+			const response = await dailyModule.GET(event);
+			expect(response.status).toBe(400);
+		});
+
+		test('returns 400 when endDate missing', async () => {
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { startDate: '2026-02-01' }
+			});
+			const response = await dailyModule.GET(event);
+			expect(response.status).toBe(400);
+		});
+
+		test('returns 400 when both dates missing', async () => {
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await dailyModule.GET(event);
+			expect(response.status).toBe(400);
+		});
+	});
+
+	describe('GET /api/stats/meal-breakdown', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				searchParams: { date: '2026-02-10' }
+			});
+			const response = await mealBreakdownModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns meal breakdown for single date', async () => {
+			mockMealBreakdownResult = [{ mealType: 'breakfast', calories: 500 }];
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { date: '2026-02-10' }
+			});
+			const response = await mealBreakdownModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.data).toBeDefined();
+		});
+
+		test('returns meal breakdown for date range', async () => {
+			mockMealBreakdownResult = [];
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { startDate: '2026-02-01', endDate: '2026-02-10' }
+			});
+			const response = await mealBreakdownModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+		});
+
+		test('returns 400 when no date parameters', async () => {
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await mealBreakdownModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(400);
+			expect(data.error).toContain('date');
+		});
+	});
+
+	describe('GET /api/stats/top-foods', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({ user: null });
+			const response = await topFoodsModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns top foods with default params', async () => {
+			mockTopFoodsResult = [{ name: 'Oats', count: 15 }];
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await topFoodsModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.data).toBeDefined();
+		});
+
+		test('accepts custom days and limit params', async () => {
+			mockTopFoodsResult = [];
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { days: '30', limit: '5' }
+			});
+			const response = await topFoodsModule.GET(event);
+			expect(response.status).toBe(200);
+		});
+	});
+
+	describe('GET /api/stats/streaks', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({ user: null });
+			const response = await streaksModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns streak data', async () => {
+			mockStreaksResult = { currentStreak: 5, longestStreak: 14 };
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await streaksModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.currentStreak).toBe(5);
+			expect(data.longestStreak).toBe(14);
+		});
+	});
+});

--- a/tests/api/supplements.test.ts
+++ b/tests/api/supplements.test.ts
@@ -1,0 +1,272 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { ZodError } from 'zod';
+import { createMockEvent } from '../helpers/mock-request-event';
+import { TEST_USER, TEST_SUPPLEMENT, TEST_SUPPLEMENT_LOG, VALID_SUPPLEMENT_PAYLOAD } from '../helpers/fixtures';
+
+let mockListResult: any[] = [];
+let mockCreateResult: any = null;
+let mockGetByIdResult: any = null;
+let mockUpdateResult: any = null;
+let mockLogResult: any = null;
+
+const mockValidationError = new ZodError([
+	{ code: 'invalid_type', expected: 'string', path: ['name'], message: 'Required' } as any
+]);
+
+mock.module('$lib/server/supplements', () => ({
+	listSupplements: async () => mockListResult,
+	createSupplement: async () =>
+		mockCreateResult
+			? { success: true, data: mockCreateResult }
+			: { success: false, error: mockValidationError },
+	getSupplementById: async () => mockGetByIdResult,
+	updateSupplement: async () =>
+		mockUpdateResult !== undefined
+			? { success: true, data: mockUpdateResult }
+			: { success: false, error: mockValidationError },
+	deleteSupplement: async () => true,
+	logSupplement: async () =>
+		mockLogResult
+			? { success: true, data: mockLogResult }
+			: { success: false, error: new Error('Supplement not found') },
+	getLogsForDate: async () => []
+}));
+
+mock.module('$lib/utils/supplements', () => ({
+	isSupplementDue: () => true
+}));
+
+mock.module('$lib/utils/dates', () => ({
+	today: () => '2026-02-27'
+}));
+
+mock.module('$lib/server/validation', () => ({
+	supplementLogSchema: {
+		safeParse: (data: any) => ({ success: true, data: data ?? {} })
+	}
+}));
+
+const supplementsModule = await import('../../src/routes/api/supplements/+server');
+const supplementIdModule = await import('../../src/routes/api/supplements/[id]/+server');
+const supplementLogModule = await import('../../src/routes/api/supplements/[id]/log/+server');
+const supplementTodayModule = await import('../../src/routes/api/supplements/today/+server');
+
+describe('api/supplements', () => {
+	beforeEach(() => {
+		mockListResult = [];
+		mockCreateResult = null;
+		mockGetByIdResult = null;
+		mockUpdateResult = undefined;
+		mockLogResult = null;
+	});
+
+	describe('GET /api/supplements', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({ user: null });
+			const response = await supplementsModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns supplements for user', async () => {
+			mockListResult = [TEST_SUPPLEMENT];
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await supplementsModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.supplements).toHaveLength(1);
+			expect(data.supplements[0].name).toBe('Vitamin D3');
+		});
+
+		test('returns empty array when no supplements', async () => {
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await supplementsModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.supplements).toEqual([]);
+		});
+	});
+
+	describe('POST /api/supplements', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				body: VALID_SUPPLEMENT_PAYLOAD
+			});
+			const response = await supplementsModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('creates supplement with valid payload', async () => {
+			mockCreateResult = TEST_SUPPLEMENT;
+			const event = createMockEvent({
+				user: TEST_USER,
+				body: VALID_SUPPLEMENT_PAYLOAD
+			});
+			const response = await supplementsModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(201);
+			expect(data.supplement.name).toBe('Vitamin D3');
+		});
+
+		test('returns 400 for invalid payload', async () => {
+			mockCreateResult = null;
+			const event = createMockEvent({
+				user: TEST_USER,
+				body: {}
+			});
+			const response = await supplementsModule.POST(event);
+			expect(response.status).toBe(400);
+		});
+	});
+
+	describe('GET /api/supplements/:id', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				params: { id: TEST_SUPPLEMENT.id }
+			});
+			const response = await supplementIdModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns supplement when found', async () => {
+			mockGetByIdResult = TEST_SUPPLEMENT;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: TEST_SUPPLEMENT.id }
+			});
+			const response = await supplementIdModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.supplement.name).toBe('Vitamin D3');
+		});
+
+		test('returns 404 when not found', async () => {
+			mockGetByIdResult = null;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: 'nonexistent' }
+			});
+			const response = await supplementIdModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(404);
+			expect(data.error).toBe('Supplement not found');
+		});
+	});
+
+	describe('PUT /api/supplements/:id', () => {
+		test('updates supplement with valid payload', async () => {
+			mockUpdateResult = { ...TEST_SUPPLEMENT, name: 'Updated D3' };
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: TEST_SUPPLEMENT.id },
+				body: { name: 'Updated D3' }
+			});
+			const response = await supplementIdModule.PUT(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.supplement.name).toBe('Updated D3');
+		});
+
+		test('returns 404 when supplement not found', async () => {
+			mockUpdateResult = null;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: 'nonexistent' },
+				body: { name: 'Updated' }
+			});
+			const response = await supplementIdModule.PUT(event);
+			const data = await response.json();
+			expect(response.status).toBe(404);
+			expect(data.error).toBe('Supplement not found');
+		});
+	});
+
+	describe('DELETE /api/supplements/:id', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				params: { id: TEST_SUPPLEMENT.id }
+			});
+			const response = await supplementIdModule.DELETE(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('deletes supplement', async () => {
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: TEST_SUPPLEMENT.id }
+			});
+			const response = await supplementIdModule.DELETE(event);
+			expect(response.status).toBe(204);
+		});
+	});
+
+	describe('POST /api/supplements/:id/log', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				params: { id: TEST_SUPPLEMENT.id },
+				body: {}
+			});
+			const response = await supplementLogModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('logs supplement for today', async () => {
+			mockLogResult = TEST_SUPPLEMENT_LOG;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: TEST_SUPPLEMENT.id },
+				body: {}
+			});
+			const response = await supplementLogModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(201);
+			expect(data.log).toBeDefined();
+		});
+
+		test('returns 404 when supplement not found', async () => {
+			mockLogResult = null;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: 'nonexistent' },
+				body: {}
+			});
+			const response = await supplementLogModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(404);
+			expect(data.error).toBe('Supplement not found');
+		});
+	});
+
+	describe('GET /api/supplements/today', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({ user: null });
+			const response = await supplementTodayModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns checklist for today', async () => {
+			mockListResult = [TEST_SUPPLEMENT];
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await supplementTodayModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.checklist).toBeDefined();
+			expect(data.date).toBeDefined();
+		});
+	});
+});

--- a/tests/api/weight.test.ts
+++ b/tests/api/weight.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { ZodError } from 'zod';
+import { createMockEvent } from '../helpers/mock-request-event';
+import { TEST_USER } from '../helpers/fixtures';
+
+const TEST_WEIGHT_ENTRY = {
+	id: '10000000-0000-4000-8000-000000000080',
+	userId: TEST_USER.id,
+	weightKg: 75.5,
+	entryDate: '2026-02-10',
+	loggedAt: new Date('2026-02-10T08:00:00Z'),
+	notes: null,
+	updatedAt: null
+};
+
+let mockGetEntriesResult: any = [];
+let mockGetTrendResult: any = [];
+let mockCreateResult: any = null;
+let mockLatestResult: any = null;
+let mockUpdateResult: any = null;
+let mockDeleteResult: any = false;
+
+mock.module('$lib/server/weight', () => ({
+	getWeightEntries: async () => mockGetEntriesResult,
+	getWeightWithTrend: async () => mockGetTrendResult,
+	createWeightEntry: async (_userId: string, payload: unknown) =>
+		mockCreateResult
+			? { success: true, data: mockCreateResult }
+			: {
+					success: false,
+					error: new ZodError([
+						{ code: 'invalid_type', expected: 'number', path: ['weightKg'], message: 'Required' } as any
+					])
+				},
+	getLatestWeight: async () => mockLatestResult,
+	updateWeightEntry: async () =>
+		mockUpdateResult !== undefined
+			? { success: true, data: mockUpdateResult }
+			: {
+					success: false,
+					error: new ZodError([
+						{ code: 'invalid_type', expected: 'number', path: ['weightKg'], message: 'Required' } as any
+					])
+				},
+	deleteWeightEntry: async () => mockDeleteResult
+}));
+
+const weightModule = await import('../../src/routes/api/weight/+server');
+const weightIdModule = await import('../../src/routes/api/weight/[id]/+server');
+const weightLatestModule = await import('../../src/routes/api/weight/latest/+server');
+
+describe('api/weight', () => {
+	beforeEach(() => {
+		mockGetEntriesResult = [];
+		mockGetTrendResult = [];
+		mockCreateResult = null;
+		mockLatestResult = null;
+		mockUpdateResult = undefined;
+		mockDeleteResult = false;
+	});
+
+	describe('GET /api/weight', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({ user: null });
+			const response = await weightModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns weight entries for user', async () => {
+			mockGetEntriesResult = [TEST_WEIGHT_ENTRY];
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await weightModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.entries).toHaveLength(1);
+			expect(data.entries[0].weightKg).toBe(75.5);
+		});
+
+		test('returns empty entries array when no weight data', async () => {
+			mockGetEntriesResult = [];
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await weightModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.entries).toEqual([]);
+		});
+
+		test('returns trend data when from and to params provided', async () => {
+			mockGetTrendResult = [
+				{ entry_date: '2026-02-01', weight_kg: 75.0, moving_avg: 75.0 },
+				{ entry_date: '2026-02-10', weight_kg: 75.5, moving_avg: 75.25 }
+			];
+			const event = createMockEvent({
+				user: TEST_USER,
+				searchParams: { from: '2026-02-01', to: '2026-02-10' }
+			});
+			const response = await weightModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.data).toHaveLength(2);
+		});
+	});
+
+	describe('POST /api/weight', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				body: { weightKg: 75.5, entryDate: '2026-02-10' }
+			});
+			const response = await weightModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('creates weight entry with valid payload', async () => {
+			mockCreateResult = TEST_WEIGHT_ENTRY;
+			const event = createMockEvent({
+				user: TEST_USER,
+				body: { weightKg: 75.5, entryDate: '2026-02-10' }
+			});
+			const response = await weightModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(201);
+			expect(data.entry.weightKg).toBe(75.5);
+		});
+
+		test('returns 400 for invalid payload', async () => {
+			mockCreateResult = null;
+			const event = createMockEvent({
+				user: TEST_USER,
+				body: { weightKg: -5, entryDate: '2026-02-10' }
+			});
+			const response = await weightModule.POST(event);
+			expect(response.status).toBe(400);
+		});
+
+		test('creates entry with notes', async () => {
+			mockCreateResult = { ...TEST_WEIGHT_ENTRY, notes: 'Before breakfast' };
+			const event = createMockEvent({
+				user: TEST_USER,
+				body: { weightKg: 75.5, entryDate: '2026-02-10', notes: 'Before breakfast' }
+			});
+			const response = await weightModule.POST(event);
+			const data = await response.json();
+			expect(response.status).toBe(201);
+			expect(data.entry.notes).toBe('Before breakfast');
+		});
+	});
+
+	describe('PATCH /api/weight/:id', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				params: { id: TEST_WEIGHT_ENTRY.id },
+				body: { weightKg: 76.0 }
+			});
+			const response = await weightIdModule.PATCH(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('updates weight entry', async () => {
+			mockUpdateResult = { ...TEST_WEIGHT_ENTRY, weightKg: 76.0 };
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: TEST_WEIGHT_ENTRY.id },
+				body: { weightKg: 76.0 }
+			});
+			const response = await weightIdModule.PATCH(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.entry.weightKg).toBe(76.0);
+		});
+
+		test('returns 404 when entry not found', async () => {
+			mockUpdateResult = null;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: 'nonexistent-id' },
+				body: { weightKg: 76.0 }
+			});
+			const response = await weightIdModule.PATCH(event);
+			const data = await response.json();
+			expect(response.status).toBe(404);
+			expect(data.error).toBe('Weight entry not found');
+		});
+	});
+
+	describe('DELETE /api/weight/:id', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({
+				user: null,
+				params: { id: TEST_WEIGHT_ENTRY.id }
+			});
+			const response = await weightIdModule.DELETE(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('deletes weight entry', async () => {
+			mockDeleteResult = true;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: TEST_WEIGHT_ENTRY.id }
+			});
+			const response = await weightIdModule.DELETE(event);
+			expect(response.status).toBe(204);
+		});
+
+		test('returns 404 when entry not found', async () => {
+			mockDeleteResult = false;
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: 'nonexistent-id' }
+			});
+			const response = await weightIdModule.DELETE(event);
+			const data = await response.json();
+			expect(response.status).toBe(404);
+			expect(data.error).toBe('Weight entry not found');
+		});
+	});
+
+	describe('GET /api/weight/latest', () => {
+		test('returns 401 when not authenticated', async () => {
+			const event = createMockEvent({ user: null });
+			const response = await weightLatestModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(401);
+			expect(data.error).toBe('Unauthorized');
+		});
+
+		test('returns latest weight entry', async () => {
+			mockLatestResult = TEST_WEIGHT_ENTRY;
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await weightLatestModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.entry.weightKg).toBe(75.5);
+		});
+
+		test('returns null when no weight entries', async () => {
+			mockLatestResult = null;
+			const event = createMockEvent({ user: TEST_USER });
+			const response = await weightLatestModule.GET(event);
+			const data = await response.json();
+			expect(response.status).toBe(200);
+			expect(data.entry).toBeNull();
+		});
+	});
+});

--- a/tests/server/entries-validation.test.ts
+++ b/tests/server/entries-validation.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect } from 'bun:test';
+import { entryCreateSchema, entryUpdateSchema } from '../../src/lib/server/validation';
+
+describe('entryCreateSchema', () => {
+	// Use valid RFC 4122 v4 UUIDs (version=4, variant=8/9/a/b)
+	const VALID_UUID_1 = '10000000-0000-4000-8000-000000000001';
+	const VALID_UUID_2 = '10000000-0000-4000-8000-000000000002';
+
+	const validEntry = {
+		foodId: VALID_UUID_1,
+		mealType: 'breakfast',
+		servings: 1.5,
+		date: '2026-02-10'
+	};
+
+	test('validates entry with foodId', () => {
+		const result = entryCreateSchema.safeParse(validEntry);
+		expect(result.success).toBe(true);
+	});
+
+	test('validates entry with recipeId', () => {
+		const result = entryCreateSchema.safeParse({
+			recipeId: VALID_UUID_2,
+			mealType: 'lunch',
+			servings: 1,
+			date: '2026-02-10'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects entry with neither foodId nor recipeId', () => {
+		const result = entryCreateSchema.safeParse({
+			mealType: 'breakfast',
+			servings: 1,
+			date: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts entry with both foodId and recipeId (schema level)', () => {
+		// The schema's refine only requires at least one, not mutual exclusivity
+		const result = entryCreateSchema.safeParse({
+			foodId: VALID_UUID_1,
+			recipeId: VALID_UUID_2,
+			mealType: 'breakfast',
+			servings: 1,
+			date: '2026-02-10'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects missing mealType', () => {
+		const result = entryCreateSchema.safeParse({
+			foodId: VALID_UUID_1,
+			servings: 1,
+			date: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty mealType', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			mealType: ''
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing servings', () => {
+		const result = entryCreateSchema.safeParse({
+			foodId: VALID_UUID_1,
+			mealType: 'breakfast',
+			date: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects zero servings', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			servings: 0
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects negative servings', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			servings: -1
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing date', () => {
+		const result = entryCreateSchema.safeParse({
+			foodId: VALID_UUID_1,
+			mealType: 'breakfast',
+			servings: 1
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects invalid date format', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			date: '02-10-2026'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects date with time suffix', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			date: '2026-02-10T08:00:00Z'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects invalid UUID for foodId', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			foodId: 'not-a-uuid'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts fractional servings', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			servings: 0.5
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts optional notes', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			notes: 'With honey'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts null notes', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			notes: null
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('coerces string servings to number', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			servings: '2'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('normalizes mealType via transform', () => {
+		const result = entryCreateSchema.safeParse({
+			...validEntry,
+			mealType: 'breakfast'
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			// normalizeMealType maps 'breakfast' -> 'Breakfast'
+			expect(result.data.mealType).toBe('Breakfast');
+		}
+	});
+});
+
+describe('entryUpdateSchema', () => {
+	test('allows updating servings only', () => {
+		const result = entryUpdateSchema.safeParse({ servings: 2 });
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating mealType only', () => {
+		const result = entryUpdateSchema.safeParse({ mealType: 'lunch' });
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating notes only', () => {
+		const result = entryUpdateSchema.safeParse({ notes: 'Updated note' });
+		expect(result.success).toBe(true);
+	});
+
+	test('allows empty update', () => {
+		const result = entryUpdateSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects negative servings in update', () => {
+		const result = entryUpdateSchema.safeParse({ servings: -1 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects zero servings in update', () => {
+		const result = entryUpdateSchema.safeParse({ servings: 0 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects invalid date format in update', () => {
+		const result = entryUpdateSchema.safeParse({ date: 'bad' });
+		expect(result.success).toBe(false);
+	});
+});

--- a/tests/server/mcp-handlers.test.ts
+++ b/tests/server/mcp-handlers.test.ts
@@ -1,0 +1,553 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { TEST_USER, TEST_FOOD, TEST_RECIPE, TEST_ENTRY, TEST_GOALS, TEST_SUPPLEMENT } from '../helpers/fixtures';
+
+// Mock paraglide (generated at build time, not available in tests)
+mock.module('$lib/paraglide/messages', () => new Proxy({}, { get: () => () => '' }));
+
+// Mock state
+let mockFoods: any[] = [];
+let mockCreateFoodResult: any = null;
+let mockRecipes: any[] = [];
+let mockCreateRecipeResult: any = null;
+let mockCreateEntryResult: any = null;
+let mockEntries: any[] = [];
+let mockUpdateEntryResult: any = null;
+let mockGoals: any = null;
+let mockUpsertGoalsResult: any = null;
+let mockFood: any = null;
+let mockRecipe: any = null;
+let mockFavFoods: any[] = [];
+let mockFavRecipes: any[] = [];
+let mockCreateWeightResult: any = null;
+let mockLatestWeight: any = null;
+let mockWeightTrend: any = [];
+let mockWeeklyStats: any = null;
+let mockMonthlyStats: any = null;
+let mockCopyResult: any[] = [];
+let mockBarcodeFood: any = null;
+let mockSupplements: any[] = [];
+let mockSupplementLogs: any[] = [];
+let mockLogSupplementResult: any = null;
+let mockSupplementById: any = null;
+
+// Mock all service modules
+mock.module('$lib/server/foods', () => ({
+	listFoods: async () => mockFoods,
+	createFood: async (_userId: string, payload: unknown) =>
+		mockCreateFoodResult
+			? { success: true, data: mockCreateFoodResult }
+			: { success: false, error: new Error('Validation failed') },
+	getFood: async () => mockFood,
+	findFoodByBarcode: async () => mockBarcodeFood
+}));
+
+mock.module('$lib/server/recipes', () => ({
+	listRecipes: async () => mockRecipes,
+	createRecipe: async () =>
+		mockCreateRecipeResult
+			? { success: true, data: mockCreateRecipeResult }
+			: { success: false, error: new Error('Validation failed') },
+	getRecipe: async () => mockRecipe
+}));
+
+mock.module('$lib/server/entries', () => ({
+	createEntry: async () =>
+		mockCreateEntryResult
+			? { success: true, data: mockCreateEntryResult }
+			: { success: false, error: new Error('Validation failed') },
+	listEntriesByDate: async () => mockEntries,
+	updateEntry: async () =>
+		mockUpdateEntryResult
+			? { success: true, data: mockUpdateEntryResult }
+			: { success: false, error: new Error('Update failed') },
+	deleteEntry: async () => true,
+	copyEntries: async () => mockCopyResult
+}));
+
+mock.module('$lib/server/goals', () => ({
+	getGoals: async () => mockGoals,
+	upsertGoals: async () =>
+		mockUpsertGoalsResult
+			? { success: true, data: mockUpsertGoalsResult }
+			: { success: false, error: new Error('Validation failed') }
+}));
+
+mock.module('$lib/server/favorites', () => ({
+	listFavoriteFoods: async () => mockFavFoods,
+	listFavoriteRecipes: async () => mockFavRecipes
+}));
+
+mock.module('$lib/server/weight', () => ({
+	createWeightEntry: async () =>
+		mockCreateWeightResult
+			? { success: true, data: mockCreateWeightResult }
+			: { success: false, error: new Error('Validation failed') },
+	getLatestWeight: async () => mockLatestWeight,
+	getWeightWithTrend: async () => mockWeightTrend
+}));
+
+mock.module('$lib/server/stats', () => ({
+	getWeeklyStats: async () => mockWeeklyStats,
+	getMonthlyStats: async () => mockMonthlyStats
+}));
+
+mock.module('$lib/server/supplements', () => ({
+	listSupplements: async () => mockSupplements,
+	getLogsForDate: async () => mockSupplementLogs,
+	logSupplement: async () =>
+		mockLogSupplementResult
+			? { success: true, data: mockLogSupplementResult }
+			: { success: false, error: new Error('Supplement not found') },
+	getSupplementById: async () => mockSupplementById
+}));
+
+mock.module('$lib/utils/supplements', () => ({
+	isSupplementDue: () => true
+}));
+
+// Import handlers after mocking
+const {
+	handleSearchFoods,
+	handleCreateFood,
+	handleCreateRecipe,
+	handleLogFood,
+	handleGetDailyStatus,
+	handleListEntries,
+	handleUpdateEntry,
+	handleDeleteEntry,
+	handleGetGoals,
+	handleUpdateGoals,
+	handleListRecipes,
+	handleGetRecipe,
+	handleGetFood,
+	handleListFavorites,
+	handleLogWeight,
+	handleGetWeight,
+	handleGetWeeklyStats,
+	handleGetMonthlyStats,
+	handleCopyEntries,
+	handleFindFoodByBarcode,
+	handleGetSupplementStatus,
+	handleLogSupplement
+} = await import('$lib/server/mcp/handlers');
+
+describe('MCP handlers', () => {
+	beforeEach(() => {
+		mockFoods = [];
+		mockCreateFoodResult = null;
+		mockRecipes = [];
+		mockCreateRecipeResult = null;
+		mockCreateEntryResult = null;
+		mockEntries = [];
+		mockUpdateEntryResult = null;
+		mockGoals = null;
+		mockUpsertGoalsResult = null;
+		mockFood = null;
+		mockRecipe = null;
+		mockFavFoods = [];
+		mockFavRecipes = [];
+		mockCreateWeightResult = null;
+		mockLatestWeight = null;
+		mockWeightTrend = [];
+		mockWeeklyStats = null;
+		mockMonthlyStats = null;
+		mockCopyResult = [];
+		mockBarcodeFood = null;
+		mockSupplements = [];
+		mockSupplementLogs = [];
+		mockLogSupplementResult = null;
+		mockSupplementById = null;
+	});
+
+	describe('handleSearchFoods', () => {
+		test('returns matching foods', async () => {
+			mockFoods = [TEST_FOOD];
+			const result = await handleSearchFoods(TEST_USER.id, 'Oats');
+			expect(result.foods).toHaveLength(1);
+			expect(result.foods[0].name).toBe('Oats');
+		});
+
+		test('returns empty array when no match', async () => {
+			mockFoods = [];
+			const result = await handleSearchFoods(TEST_USER.id, 'nonexistent');
+			expect(result.foods).toHaveLength(0);
+		});
+	});
+
+	describe('handleCreateFood', () => {
+		test('returns foodId on success', async () => {
+			mockCreateFoodResult = { ...TEST_FOOD, id: 'new-food-id' };
+			const result = await handleCreateFood(TEST_USER.id, {
+				name: 'Oats',
+				servingSize: 100,
+				servingUnit: 'g',
+				calories: 389,
+				protein: 13.2,
+				carbs: 66.3,
+				fat: 6.9,
+				fiber: 10.6
+			});
+			expect(result.success).toBe(true);
+			expect(result.foodId).toBe('new-food-id');
+		});
+
+		test('returns error on validation failure', async () => {
+			mockCreateFoodResult = null;
+			const result = await handleCreateFood(TEST_USER.id, {});
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleCreateRecipe', () => {
+		test('returns recipeId on success', async () => {
+			mockCreateRecipeResult = { ...TEST_RECIPE, id: 'new-recipe-id' };
+			const result = await handleCreateRecipe(TEST_USER.id, {
+				name: 'Shake',
+				totalServings: 2,
+				ingredients: [{ foodId: TEST_FOOD.id, quantity: 1, servingUnit: 'cup' }]
+			});
+			expect(result.success).toBe(true);
+			expect(result.recipeId).toBe('new-recipe-id');
+		});
+
+		test('returns error on failure', async () => {
+			mockCreateRecipeResult = null;
+			const result = await handleCreateRecipe(TEST_USER.id, {});
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleLogFood', () => {
+		test('returns entryId on success', async () => {
+			mockCreateEntryResult = { ...TEST_ENTRY, id: 'new-entry-id' };
+			const result = await handleLogFood(TEST_USER.id, {
+				foodId: TEST_FOOD.id,
+				mealType: 'breakfast',
+				servings: 1,
+				date: '2026-02-10'
+			});
+			expect(result.success).toBe(true);
+			expect(result.entryId).toBe('new-entry-id');
+		});
+
+		test('returns error on failure', async () => {
+			mockCreateEntryResult = null;
+			const result = await handleLogFood(TEST_USER.id, {});
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleGetDailyStatus', () => {
+		test('returns totals and goals', async () => {
+			mockEntries = [];
+			mockGoals = TEST_GOALS;
+			const result = await handleGetDailyStatus(TEST_USER.id, '2026-02-10');
+			expect(result.totals).toBeDefined();
+			expect(result.goals).toBeDefined();
+			expect(result.goals?.calorieGoal).toBe(2000);
+		});
+
+		test('returns null goals when user has none', async () => {
+			mockEntries = [];
+			mockGoals = null;
+			const result = await handleGetDailyStatus(TEST_USER.id, '2026-02-10');
+			expect(result.goals).toBeNull();
+		});
+	});
+
+	describe('handleListEntries', () => {
+		test('returns entries for date', async () => {
+			mockEntries = [TEST_ENTRY];
+			const result = await handleListEntries(TEST_USER.id, '2026-02-10');
+			expect(result.date).toBe('2026-02-10');
+			expect(result.entries).toHaveLength(1);
+		});
+
+		test('defaults to today when no date', async () => {
+			mockEntries = [];
+			const result = await handleListEntries(TEST_USER.id);
+			expect(result.date).toBeDefined();
+			expect(result.entries).toEqual([]);
+		});
+	});
+
+	describe('handleUpdateEntry', () => {
+		test('returns success on valid update', async () => {
+			mockUpdateEntryResult = { ...TEST_ENTRY, servings: 2 };
+			const result = await handleUpdateEntry(TEST_USER.id, {
+				entryId: TEST_ENTRY.id,
+				servings: 2
+			});
+			expect(result.success).toBe(true);
+			expect(result.entryId).toBe(TEST_ENTRY.id);
+		});
+
+		test('returns error on failure', async () => {
+			mockUpdateEntryResult = null;
+			const result = await handleUpdateEntry(TEST_USER.id, {
+				entryId: 'nonexistent',
+				servings: 2
+			});
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleDeleteEntry', () => {
+		test('returns success', async () => {
+			const result = await handleDeleteEntry(TEST_USER.id, TEST_ENTRY.id);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('handleGetGoals', () => {
+		test('returns goals when set', async () => {
+			mockGoals = TEST_GOALS;
+			const result = await handleGetGoals(TEST_USER.id);
+			expect(result.goals).toEqual(TEST_GOALS);
+		});
+
+		test('returns null when no goals', async () => {
+			mockGoals = null;
+			const result = await handleGetGoals(TEST_USER.id);
+			expect(result.goals).toBeNull();
+		});
+	});
+
+	describe('handleUpdateGoals', () => {
+		test('returns success on valid update', async () => {
+			mockUpsertGoalsResult = TEST_GOALS;
+			const result = await handleUpdateGoals(TEST_USER.id, {
+				calorieGoal: 2000,
+				proteinGoal: 150,
+				carbGoal: 200,
+				fatGoal: 67,
+				fiberGoal: 30
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('returns error on failure', async () => {
+			mockUpsertGoalsResult = null;
+			const result = await handleUpdateGoals(TEST_USER.id, {});
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleListRecipes', () => {
+		test('returns recipes', async () => {
+			mockRecipes = [TEST_RECIPE];
+			const result = await handleListRecipes(TEST_USER.id);
+			expect(result.recipes).toHaveLength(1);
+		});
+	});
+
+	describe('handleGetRecipe', () => {
+		test('returns recipe when found', async () => {
+			mockRecipe = TEST_RECIPE;
+			const result = await handleGetRecipe(TEST_USER.id, TEST_RECIPE.id);
+			expect(result.name).toBe('Oatmeal Bowl');
+		});
+
+		test('returns error when not found', async () => {
+			mockRecipe = null;
+			const result = await handleGetRecipe(TEST_USER.id, 'nonexistent');
+			expect(result.error).toBe('Recipe not found');
+		});
+	});
+
+	describe('handleGetFood', () => {
+		test('returns food when found', async () => {
+			mockFood = TEST_FOOD;
+			const result = await handleGetFood(TEST_USER.id, TEST_FOOD.id);
+			expect(result.name).toBe('Oats');
+		});
+
+		test('returns error when not found', async () => {
+			mockFood = null;
+			const result = await handleGetFood(TEST_USER.id, 'nonexistent');
+			expect(result.error).toBe('Food not found');
+		});
+	});
+
+	describe('handleListFavorites', () => {
+		test('returns both foods and recipes', async () => {
+			mockFavFoods = [TEST_FOOD];
+			mockFavRecipes = [TEST_RECIPE];
+			const result = await handleListFavorites(TEST_USER.id);
+			expect(result.foods).toHaveLength(1);
+			expect(result.recipes).toHaveLength(1);
+		});
+
+		test('returns empty arrays when no favorites', async () => {
+			const result = await handleListFavorites(TEST_USER.id);
+			expect(result.foods).toEqual([]);
+			expect(result.recipes).toEqual([]);
+		});
+	});
+
+	describe('handleLogWeight', () => {
+		test('returns success with entryId', async () => {
+			mockCreateWeightResult = { id: 'weight-1', weightKg: 75.5 };
+			const result = await handleLogWeight(TEST_USER.id, { weightKg: 75.5 });
+			expect(result.success).toBe(true);
+			expect(result.entryId).toBe('weight-1');
+		});
+
+		test('returns error on failure', async () => {
+			mockCreateWeightResult = null;
+			const result = await handleLogWeight(TEST_USER.id, { weightKg: -5 });
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleGetWeight', () => {
+		test('returns latest weight when no date range', async () => {
+			mockLatestWeight = { weightKg: 75.5, entryDate: '2026-02-10' };
+			const result = await handleGetWeight(TEST_USER.id, {});
+			expect(result.weightKg).toBe(75.5);
+		});
+
+		test('returns error when no entries and no range', async () => {
+			mockLatestWeight = null;
+			const result = await handleGetWeight(TEST_USER.id, {});
+			expect(result.error).toBe('No weight entries found');
+		});
+
+		test('returns error when only from provided', async () => {
+			const result = await handleGetWeight(TEST_USER.id, { from: '2026-02-01' });
+			expect(result.error).toContain('Provide both');
+		});
+
+		test('returns error when only to provided', async () => {
+			const result = await handleGetWeight(TEST_USER.id, { to: '2026-02-10' });
+			expect(result.error).toContain('Provide both');
+		});
+
+		test('returns trend data with from and to', async () => {
+			mockWeightTrend = [{ entry_date: '2026-02-01', weight_kg: 75 }];
+			const result = await handleGetWeight(TEST_USER.id, {
+				from: '2026-02-01',
+				to: '2026-02-10'
+			});
+			expect(Array.isArray(result)).toBe(true);
+		});
+	});
+
+	describe('handleGetWeeklyStats', () => {
+		test('returns weekly stats', async () => {
+			mockWeeklyStats = { calories: 2000, protein: 150 };
+			const result = await handleGetWeeklyStats(TEST_USER.id);
+			expect(result.calories).toBe(2000);
+		});
+	});
+
+	describe('handleGetMonthlyStats', () => {
+		test('returns monthly stats', async () => {
+			mockMonthlyStats = { calories: 1800, protein: 140 };
+			const result = await handleGetMonthlyStats(TEST_USER.id);
+			expect(result.calories).toBe(1800);
+		});
+	});
+
+	describe('handleCopyEntries', () => {
+		test('returns copied count', async () => {
+			mockCopyResult = [TEST_ENTRY, { ...TEST_ENTRY, id: 'entry-2' }];
+			const result = await handleCopyEntries(TEST_USER.id, {
+				fromDate: '2026-02-09',
+				toDate: '2026-02-10'
+			});
+			expect(result.success).toBe(true);
+			expect(result.copiedCount).toBe(2);
+		});
+
+		test('returns zero when no entries to copy', async () => {
+			mockCopyResult = [];
+			const result = await handleCopyEntries(TEST_USER.id, {
+				fromDate: '2026-02-09'
+			});
+			expect(result.success).toBe(true);
+			expect(result.copiedCount).toBe(0);
+		});
+	});
+
+	describe('handleFindFoodByBarcode', () => {
+		test('returns food when found', async () => {
+			mockBarcodeFood = TEST_FOOD;
+			const result = await handleFindFoodByBarcode(TEST_USER.id, '1234567890123');
+			expect(result.found).toBe(true);
+			expect(result.name).toBe('Oats');
+		});
+
+		test('returns not found when no match', async () => {
+			mockBarcodeFood = null;
+			const result = await handleFindFoodByBarcode(TEST_USER.id, '0000000000000');
+			expect(result.found).toBe(false);
+		});
+	});
+
+	describe('handleGetSupplementStatus', () => {
+		test('returns checklist with taken status', async () => {
+			mockSupplements = [TEST_SUPPLEMENT];
+			mockSupplementLogs = [{ supplementId: TEST_SUPPLEMENT.id, takenAt: new Date() }];
+			const result = await handleGetSupplementStatus(TEST_USER.id);
+			expect(result.total).toBe(1);
+			expect(result.taken).toBe(1);
+			expect(result.pending).toBe(0);
+			expect(result.supplements).toHaveLength(1);
+			expect(result.supplements[0].taken).toBe(true);
+		});
+
+		test('returns pending supplements', async () => {
+			mockSupplements = [TEST_SUPPLEMENT];
+			mockSupplementLogs = [];
+			const result = await handleGetSupplementStatus(TEST_USER.id);
+			expect(result.total).toBe(1);
+			expect(result.taken).toBe(0);
+			expect(result.pending).toBe(1);
+			expect(result.supplements[0].taken).toBe(false);
+		});
+
+		test('returns empty checklist when no supplements', async () => {
+			const result = await handleGetSupplementStatus(TEST_USER.id);
+			expect(result.total).toBe(0);
+			expect(result.supplements).toEqual([]);
+		});
+	});
+
+	describe('handleLogSupplement', () => {
+		test('logs supplement by ID', async () => {
+			mockLogSupplementResult = { id: 'log-1' };
+			mockSupplementById = TEST_SUPPLEMENT;
+			const result = await handleLogSupplement(TEST_USER.id, {
+				supplementId: TEST_SUPPLEMENT.id
+			});
+			expect(result.success).toBe(true);
+			expect(result.logged?.name).toBe('Vitamin D3');
+		});
+
+		test('logs supplement by name search', async () => {
+			mockSupplements = [TEST_SUPPLEMENT];
+			mockLogSupplementResult = { id: 'log-1' };
+			mockSupplementById = TEST_SUPPLEMENT;
+			const result = await handleLogSupplement(TEST_USER.id, {
+				name: 'vitamin d'
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('returns error when name not found', async () => {
+			mockSupplements = [];
+			const result = await handleLogSupplement(TEST_USER.id, {
+				name: 'nonexistent'
+			});
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('No supplement found');
+		});
+
+		test('returns error when neither name nor id provided', async () => {
+			const result = await handleLogSupplement(TEST_USER.id, {});
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Provide either');
+		});
+	});
+});

--- a/tests/server/recipes-validation-extended.test.ts
+++ b/tests/server/recipes-validation-extended.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect } from 'bun:test';
+import { recipeCreateSchema, recipeUpdateSchema } from '../../src/lib/server/validation';
+
+describe('recipeCreateSchema - extended', () => {
+	const validRecipe = {
+		name: 'Protein Shake',
+		totalServings: 2,
+		ingredients: [
+			{ foodId: '00000000-0000-0000-0000-000000000000', quantity: 1, servingUnit: 'cup' }
+		]
+	};
+
+	test('validates complete recipe', () => {
+		const result = recipeCreateSchema.safeParse(validRecipe);
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects missing name', () => {
+		const result = recipeCreateSchema.safeParse({
+			totalServings: 2,
+			ingredients: validRecipe.ingredients
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty name', () => {
+		const result = recipeCreateSchema.safeParse({
+			...validRecipe,
+			name: ''
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing ingredients', () => {
+		const result = recipeCreateSchema.safeParse({
+			name: 'Shake'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty ingredients array', () => {
+		const result = recipeCreateSchema.safeParse({
+			name: 'Shake',
+			totalServings: 2,
+			ingredients: []
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects ingredient with invalid foodId format', () => {
+		const result = recipeCreateSchema.safeParse({
+			name: 'Shake',
+			totalServings: 2,
+			ingredients: [{ foodId: 'not-a-uuid', quantity: 1, servingUnit: 'g' }]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects ingredient with zero quantity', () => {
+		const result = recipeCreateSchema.safeParse({
+			name: 'Shake',
+			totalServings: 2,
+			ingredients: [
+				{ foodId: '00000000-0000-0000-0000-000000000000', quantity: 0, servingUnit: 'g' }
+			]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects ingredient with negative quantity', () => {
+		const result = recipeCreateSchema.safeParse({
+			name: 'Shake',
+			totalServings: 2,
+			ingredients: [
+				{ foodId: '00000000-0000-0000-0000-000000000000', quantity: -1, servingUnit: 'g' }
+			]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects zero totalServings', () => {
+		const result = recipeCreateSchema.safeParse({
+			...validRecipe,
+			totalServings: 0
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects negative totalServings', () => {
+		const result = recipeCreateSchema.safeParse({
+			...validRecipe,
+			totalServings: -1
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts multiple ingredients', () => {
+		const result = recipeCreateSchema.safeParse({
+			name: 'Shake',
+			totalServings: 2,
+			ingredients: [
+				{ foodId: '10000000-0000-4000-8000-000000000001', quantity: 100, servingUnit: 'g' },
+				{ foodId: '10000000-0000-4000-8000-000000000002', quantity: 200, servingUnit: 'ml' },
+				{ foodId: '10000000-0000-4000-8000-000000000003', quantity: 1, servingUnit: 'tsp' }
+			]
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('coerces string totalServings to number', () => {
+		const result = recipeCreateSchema.safeParse({
+			...validRecipe,
+			totalServings: '4'
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.totalServings).toBe(4);
+		}
+	});
+
+	test('coerces string ingredient quantity to number', () => {
+		const result = recipeCreateSchema.safeParse({
+			name: 'Shake',
+			totalServings: 2,
+			ingredients: [
+				{ foodId: '00000000-0000-0000-0000-000000000000', quantity: '50', servingUnit: 'g' }
+			]
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects empty object', () => {
+		const result = recipeCreateSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('recipeUpdateSchema', () => {
+	test('allows updating name only', () => {
+		const result = recipeUpdateSchema.safeParse({ name: 'Updated Shake' });
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating totalServings only', () => {
+		const result = recipeUpdateSchema.safeParse({ totalServings: 4 });
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating ingredients', () => {
+		const result = recipeUpdateSchema.safeParse({
+			ingredients: [
+				{ foodId: '00000000-0000-0000-0000-000000000000', quantity: 100, servingUnit: 'g' }
+			]
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('allows empty update', () => {
+		const result = recipeUpdateSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects empty name in update', () => {
+		const result = recipeUpdateSchema.safeParse({ name: '' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects zero totalServings in update', () => {
+		const result = recipeUpdateSchema.safeParse({ totalServings: 0 });
+		expect(result.success).toBe(false);
+	});
+});

--- a/tests/server/supplements-validation.test.ts
+++ b/tests/server/supplements-validation.test.ts
@@ -1,0 +1,287 @@
+import { describe, test, expect } from 'bun:test';
+import {
+	supplementCreateSchema,
+	supplementUpdateSchema
+} from '../../src/lib/server/validation';
+
+describe('supplementCreateSchema', () => {
+	test('validates minimal daily supplement', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin D3',
+			dosage: 1000,
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('validates supplement with ingredients', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Multivitamin',
+			dosage: 1,
+			dosageUnit: 'capsule',
+			scheduleType: 'daily',
+			ingredients: [
+				{ name: 'Vitamin A', dosage: 800, dosageUnit: 'mcg' },
+				{ name: 'Vitamin C', dosage: 80, dosageUnit: 'mg' }
+			]
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('validates weekly schedule with days', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin K',
+			dosage: 100,
+			dosageUnit: 'mcg',
+			scheduleType: 'weekly',
+			scheduleDays: [0, 3, 6]
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('validates specific_days schedule with days', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Iron',
+			dosage: 25,
+			dosageUnit: 'mg',
+			scheduleType: 'specific_days',
+			scheduleDays: [1, 3, 5]
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects weekly schedule without scheduleDays', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin K',
+			dosage: 100,
+			dosageUnit: 'mcg',
+			scheduleType: 'weekly'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects specific_days schedule without scheduleDays', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Iron',
+			dosage: 25,
+			dosageUnit: 'mg',
+			scheduleType: 'specific_days'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects weekly schedule with empty scheduleDays', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin K',
+			dosage: 100,
+			dosageUnit: 'mcg',
+			scheduleType: 'weekly',
+			scheduleDays: []
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts daily schedule without scheduleDays', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin D',
+			dosage: 1000,
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects missing name', () => {
+		const result = supplementCreateSchema.safeParse({
+			dosage: 1000,
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty name', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: '',
+			dosage: 1000,
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing dosage', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin D',
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects negative dosage', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin D',
+			dosage: -10,
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects zero dosage', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin D',
+			dosage: 0,
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects invalid scheduleType', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin D',
+			dosage: 1000,
+			dosageUnit: 'IU',
+			scheduleType: 'biweekly'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects scheduleDays values outside 0-6', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin K',
+			dosage: 100,
+			dosageUnit: 'mcg',
+			scheduleType: 'weekly',
+			scheduleDays: [7]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects negative scheduleDays', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin K',
+			dosage: 100,
+			dosageUnit: 'mcg',
+			scheduleType: 'weekly',
+			scheduleDays: [-1]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts optional timeOfDay', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Melatonin',
+			dosage: 3,
+			dosageUnit: 'mg',
+			scheduleType: 'daily',
+			timeOfDay: 'evening'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts all timeOfDay values', () => {
+		for (const time of ['morning', 'noon', 'evening']) {
+			const result = supplementCreateSchema.safeParse({
+				name: 'Test',
+				dosage: 1,
+				dosageUnit: 'mg',
+				scheduleType: 'daily',
+				timeOfDay: time
+			});
+			expect(result.success).toBe(true);
+		}
+	});
+
+	test('rejects invalid timeOfDay', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Test',
+			dosage: 1,
+			dosageUnit: 'mg',
+			scheduleType: 'daily',
+			timeOfDay: 'midnight'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts null timeOfDay', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Test',
+			dosage: 1,
+			dosageUnit: 'mg',
+			scheduleType: 'daily',
+			timeOfDay: null
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects ingredients with empty name', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Multi',
+			dosage: 1,
+			dosageUnit: 'capsule',
+			scheduleType: 'daily',
+			ingredients: [{ name: '', dosage: 100, dosageUnit: 'mg' }]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects ingredients with negative dosage', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Multi',
+			dosage: 1,
+			dosageUnit: 'capsule',
+			scheduleType: 'daily',
+			ingredients: [{ name: 'Zinc', dosage: -10, dosageUnit: 'mg' }]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('coerces string dosage to number', () => {
+		const result = supplementCreateSchema.safeParse({
+			name: 'Vitamin D',
+			dosage: '1000',
+			dosageUnit: 'IU',
+			scheduleType: 'daily'
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.dosage).toBe(1000);
+		}
+	});
+});
+
+describe('supplementUpdateSchema', () => {
+	test('allows partial update of name only', () => {
+		const result = supplementUpdateSchema.safeParse({ name: 'Vitamin D3 Updated' });
+		expect(result.success).toBe(true);
+	});
+
+	test('allows empty update', () => {
+		const result = supplementUpdateSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating dosage', () => {
+		const result = supplementUpdateSchema.safeParse({ dosage: 2000 });
+		expect(result.success).toBe(true);
+	});
+
+	test('allows setting ingredients to null (remove all)', () => {
+		const result = supplementUpdateSchema.safeParse({ ingredients: null });
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects negative dosage in update', () => {
+		const result = supplementUpdateSchema.safeParse({ dosage: -5 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty name in update', () => {
+		const result = supplementUpdateSchema.safeParse({ name: '' });
+		expect(result.success).toBe(false);
+	});
+});

--- a/tests/server/weight-db.test.ts
+++ b/tests/server/weight-db.test.ts
@@ -1,0 +1,267 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { createMockDB } from '../helpers/mock-db';
+import { TEST_USER } from '../helpers/fixtures';
+
+// Create mock DB
+const { db, setResult, setError, reset } = createMockDB();
+
+// Import schema for re-export in mock
+const schema = await import('$lib/server/schema');
+
+// Mock modules
+mock.module('$lib/server/db', () => ({
+	getDB: () => db,
+	...Object.fromEntries(Object.entries(schema).map(([key, value]) => [key, value]))
+}));
+
+// Import after mocking
+const { createWeightEntry, getWeightEntries, getLatestWeight, updateWeightEntry, deleteWeightEntry } =
+	await import('$lib/server/weight');
+
+const TEST_WEIGHT_ENTRY = {
+	id: '10000000-0000-4000-8000-000000000080',
+	userId: TEST_USER.id,
+	weightKg: 75.5,
+	entryDate: '2026-02-10',
+	loggedAt: new Date('2026-02-10T08:00:00Z'),
+	notes: null,
+	updatedAt: null
+};
+
+const VALID_WEIGHT_PAYLOAD = {
+	weightKg: 75.5,
+	entryDate: '2026-02-10'
+};
+
+describe('weight-db', () => {
+	beforeEach(() => {
+		reset();
+	});
+
+	describe('createWeightEntry', () => {
+		test('creates entry with valid payload', async () => {
+			setResult([TEST_WEIGHT_ENTRY]);
+
+			const result = await createWeightEntry(TEST_USER.id, VALID_WEIGHT_PAYLOAD);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.weightKg).toBe(75.5);
+				expect(result.data.entryDate).toBe('2026-02-10');
+			}
+		});
+
+		test('creates entry with notes', async () => {
+			const entryWithNotes = { ...TEST_WEIGHT_ENTRY, notes: 'Morning weigh-in' };
+			setResult([entryWithNotes]);
+
+			const result = await createWeightEntry(TEST_USER.id, {
+				...VALID_WEIGHT_PAYLOAD,
+				notes: 'Morning weigh-in'
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.notes).toBe('Morning weigh-in');
+			}
+		});
+
+		test('returns validation error for negative weight', async () => {
+			const result = await createWeightEntry(TEST_USER.id, {
+				weightKg: -5,
+				entryDate: '2026-02-10'
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.name).toBe('ZodError');
+			}
+		});
+
+		test('returns validation error for weight exceeding 500', async () => {
+			const result = await createWeightEntry(TEST_USER.id, {
+				weightKg: 501,
+				entryDate: '2026-02-10'
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.name).toBe('ZodError');
+			}
+		});
+
+		test('returns validation error for zero weight', async () => {
+			const result = await createWeightEntry(TEST_USER.id, {
+				weightKg: 0,
+				entryDate: '2026-02-10'
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.name).toBe('ZodError');
+			}
+		});
+
+		test('returns validation error for invalid date format', async () => {
+			const result = await createWeightEntry(TEST_USER.id, {
+				weightKg: 75,
+				entryDate: '02-10-2026'
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.name).toBe('ZodError');
+			}
+		});
+
+		test('returns validation error for missing entryDate', async () => {
+			const result = await createWeightEntry(TEST_USER.id, {
+				weightKg: 75
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.name).toBe('ZodError');
+			}
+		});
+
+		test('returns validation error for missing weightKg', async () => {
+			const result = await createWeightEntry(TEST_USER.id, {
+				entryDate: '2026-02-10'
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.name).toBe('ZodError');
+			}
+		});
+
+		test('coerces string weight to number', async () => {
+			setResult([{ ...TEST_WEIGHT_ENTRY, weightKg: 80 }]);
+
+			const result = await createWeightEntry(TEST_USER.id, {
+				weightKg: '80',
+				entryDate: '2026-02-10'
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('accepts null notes', async () => {
+			setResult([TEST_WEIGHT_ENTRY]);
+
+			const result = await createWeightEntry(TEST_USER.id, {
+				...VALID_WEIGHT_PAYLOAD,
+				notes: null
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('returns error when DB insert fails', async () => {
+			setError(new Error('DB connection failed'));
+
+			const result = await createWeightEntry(TEST_USER.id, VALID_WEIGHT_PAYLOAD);
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.message).toBe('DB connection failed');
+			}
+		});
+	});
+
+	describe('getWeightEntries', () => {
+		test('returns entries for user', async () => {
+			setResult([TEST_WEIGHT_ENTRY]);
+			const entries = await getWeightEntries(TEST_USER.id);
+			expect(entries).toEqual([TEST_WEIGHT_ENTRY]);
+		});
+
+		test('returns empty array when no entries', async () => {
+			setResult([]);
+			const entries = await getWeightEntries(TEST_USER.id);
+			expect(entries).toEqual([]);
+		});
+	});
+
+	describe('getLatestWeight', () => {
+		test('returns latest entry when it exists', async () => {
+			setResult([TEST_WEIGHT_ENTRY]);
+			const entry = await getLatestWeight(TEST_USER.id);
+			expect(entry).toEqual(TEST_WEIGHT_ENTRY);
+		});
+
+		test('returns null when no entries exist', async () => {
+			setResult([]);
+			const entry = await getLatestWeight(TEST_USER.id);
+			expect(entry).toBeNull();
+		});
+	});
+
+	describe('updateWeightEntry', () => {
+		test('updates entry with valid payload', async () => {
+			const updated = { ...TEST_WEIGHT_ENTRY, weightKg: 76.0 };
+			setResult([updated]);
+
+			const result = await updateWeightEntry(TEST_USER.id, TEST_WEIGHT_ENTRY.id, {
+				weightKg: 76.0
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data?.weightKg).toBe(76.0);
+			}
+		});
+
+		test('updates entry date', async () => {
+			const updated = { ...TEST_WEIGHT_ENTRY, entryDate: '2026-02-11' };
+			setResult([updated]);
+
+			const result = await updateWeightEntry(TEST_USER.id, TEST_WEIGHT_ENTRY.id, {
+				entryDate: '2026-02-11'
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('updates notes', async () => {
+			const updated = { ...TEST_WEIGHT_ENTRY, notes: 'After gym' };
+			setResult([updated]);
+
+			const result = await updateWeightEntry(TEST_USER.id, TEST_WEIGHT_ENTRY.id, {
+				notes: 'After gym'
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('returns validation error for negative weight', async () => {
+			const result = await updateWeightEntry(TEST_USER.id, TEST_WEIGHT_ENTRY.id, {
+				weightKg: -1
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.name).toBe('ZodError');
+			}
+		});
+
+		test('returns validation error for invalid date format', async () => {
+			const result = await updateWeightEntry(TEST_USER.id, TEST_WEIGHT_ENTRY.id, {
+				entryDate: 'not-a-date'
+			});
+			expect(result.success).toBe(false);
+		});
+
+		test('returns undefined data when entry not found', async () => {
+			setResult([]);
+
+			const result = await updateWeightEntry(TEST_USER.id, 'nonexistent-id', {
+				weightKg: 76.0
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).toBeUndefined();
+			}
+		});
+	});
+
+	describe('deleteWeightEntry', () => {
+		test('returns true when entry deleted', async () => {
+			setResult([TEST_WEIGHT_ENTRY]);
+			const deleted = await deleteWeightEntry(TEST_USER.id, TEST_WEIGHT_ENTRY.id);
+			expect(deleted).toBe(true);
+		});
+
+		test('returns false when entry not found', async () => {
+			setResult([]);
+			const deleted = await deleteWeightEntry(TEST_USER.id, 'nonexistent-id');
+			expect(deleted).toBe(false);
+		});
+	});
+});

--- a/tests/server/weight-validation.test.ts
+++ b/tests/server/weight-validation.test.ts
@@ -1,0 +1,197 @@
+import { describe, test, expect } from 'bun:test';
+import { weightCreateSchema, weightUpdateSchema } from '../../src/lib/server/validation';
+
+describe('weightCreateSchema', () => {
+	test('validates complete payload', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 75.5,
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts optional notes', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 75.5,
+			entryDate: '2026-02-10',
+			notes: 'Morning weigh-in'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts null notes', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 75.5,
+			entryDate: '2026-02-10',
+			notes: null
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects missing weightKg', () => {
+		const result = weightCreateSchema.safeParse({
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing entryDate', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 75.5
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects zero weight', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 0,
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects negative weight', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: -10,
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects weight above 500', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 501,
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts weight at boundary (500)', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 500,
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts small positive weight', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 0.1,
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('coerces string weight to number', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: '80.5',
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.weightKg).toBe(80.5);
+		}
+	});
+
+	test('rejects invalid date format (MM-DD-YYYY)', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 75,
+			entryDate: '02-10-2026'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects invalid date format (no dashes)', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 75,
+			entryDate: '20260210'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects date with time', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 75,
+			entryDate: '2026-02-10T08:00:00Z'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-numeric weight string', () => {
+		const result = weightCreateSchema.safeParse({
+			weightKg: 'heavy',
+			entryDate: '2026-02-10'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty object', () => {
+		const result = weightCreateSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('weightUpdateSchema', () => {
+	test('allows updating only weightKg', () => {
+		const result = weightUpdateSchema.safeParse({
+			weightKg: 76.0
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating only entryDate', () => {
+		const result = weightUpdateSchema.safeParse({
+			entryDate: '2026-02-11'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating only notes', () => {
+		const result = weightUpdateSchema.safeParse({
+			notes: 'Updated note'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('allows empty update (all fields optional)', () => {
+		const result = weightUpdateSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects negative weight in update', () => {
+		const result = weightUpdateSchema.safeParse({
+			weightKg: -5
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects weight above 500 in update', () => {
+		const result = weightUpdateSchema.safeParse({
+			weightKg: 600
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects invalid date format in update', () => {
+		const result = weightUpdateSchema.safeParse({
+			entryDate: 'bad-date'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('allows setting notes to null', () => {
+		const result = weightUpdateSchema.safeParse({
+			notes: null
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('allows updating all fields at once', () => {
+		const result = weightUpdateSchema.safeParse({
+			weightKg: 77.3,
+			entryDate: '2026-02-15',
+			notes: 'After lunch'
+		});
+		expect(result.success).toBe(true);
+	});
+});


### PR DESCRIPTION
Add comprehensive test coverage for previously untested areas:
- Weight tracking: DB operations, validation schema, API routes (65 tests)
- MCP handlers: all 22 tool handlers with success/error paths (46 tests)
- Supplement API routes: CRUD, logging, today checklist (18 tests)
- Supplement validation: create/update schemas with schedule logic (29 tests)
- OAuth API routes: token exchange, refresh, client registration (26 tests)
- Stats endpoints: calendar, daily, meal-breakdown, top-foods, streaks (21 tests)
- Entry validation: create/update schemas with UUID, date, refine checks (25 tests)
- Recipe validation: extended coverage for ingredients, boundaries (20 tests)

https://claude.ai/code/session_0145BKQFGtULCKUQUnQCVxih