### PR TITLE
fix: skip view transitions on mobile to prevent page flash

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,16 +3,18 @@
 	import favicon from '$lib/assets/favicon.svg';
 	import { Toaster } from '$lib/components/ui/sonner/index.js';
 	import { onNavigate } from '$app/navigation';
+	import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
 
 	let { children } = $props();
+
+	const isMobile = new IsMobile();
 
 	onNavigate((navigation) => {
 		if (!document.startViewTransition) return;
 
 		// Skip view transitions on mobile — the sidebar sheet close animation
 		// conflicts with the view transition snapshot, causing a visible flash.
-		const isMobile = window.matchMedia('(max-width: 767px)').matches;
-		if (isMobile) return;
+		if (isMobile.current) return;
 
 		return new Promise((resolve) => {
 			document.startViewTransition(async () => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,11 @@
 	onNavigate((navigation) => {
 		if (!document.startViewTransition) return;
 
+		// Skip view transitions on mobile — the sidebar sheet close animation
+		// conflicts with the view transition snapshot, causing a visible flash.
+		const isMobile = window.matchMedia('(max-width: 767px)').matches;
+		if (isMobile) return;
+
 		return new Promise((resolve) => {
 			document.startViewTransition(async () => {
 				resolve();


### PR DESCRIPTION
The View Transition API was capturing a snapshot that included the
sidebar sheet overlay (dark backdrop), causing a visible flash when
navigating via the mobile sidebar. The sheet close animation and
view transition fade were stacking on top of each other.

https://claude.ai/code/session_01EoyaaoafyPYfXLraQRHh5Z