### PR TITLE
fix: prevent mobile scroll from freezing goal sliders

### DIFF
--- a/src/lib/components/MacroSliders.svelte
+++ b/src/lib/components/MacroSliders.svelte
@@ -89,7 +89,7 @@
 	{#each macros as macro}
 		{@const pct = getPct(macro.key)}
 		{@const grams = getGrams(macro.key)}
-		<div class="space-y-2">
+		<div class="touch-none space-y-2">
 			<div class="flex items-center justify-between text-sm">
 				<span class={macro.color}>{macro.label()}</span>
 				<span class="text-muted-foreground">{pct}% &middot; {grams}g</span>

--- a/src/routes/(app)/goals/+page.svelte
+++ b/src/routes/(app)/goals/+page.svelte
@@ -79,7 +79,7 @@
 					bind:fatGoal={form.fatGoal}
 				/>
 
-				<div class="space-y-2">
+				<div class="touch-none space-y-2">
 					<div class="flex items-center justify-between text-sm">
 						<span class="text-green-500">{m.goals_fiber()}</span>
 						<span class="text-muted-foreground">{form.fiberGoal}g</span>

--- a/src/routes/(app)/maintenance/+page.svelte
+++ b/src/routes/(app)/maintenance/+page.svelte
@@ -166,7 +166,7 @@
 				<Label class="text-sm font-medium">
 					{m.maintenance_body_composition()}
 				</Label>
-				<div class="space-y-2">
+				<div class="touch-none space-y-2">
 					<div class="flex justify-between text-xs text-muted-foreground">
 						<span>{m.maintenance_muscle()}: {muscleRatio}%</span>
 						<span>{m.maintenance_fat()}: {fatRatio}%</span>


### PR DESCRIPTION
Add touch-none (touch-action: none) to each slider section wrapper so
the browser won't initiate vertical scrolling when a touch starts on
the label or gap around the slider, which was stealing the touch event
and causing the slider to freeze mid-drag.

https://claude.ai/code/session_012XfFfq6TpoLMfdDHCUkb4v