### PR TITLE
Add eaten_at timestamp to food entries

### DIFF
--- a/drizzle/0023_tidy_gambit.sql
+++ b/drizzle/0023_tidy_gambit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "food_entries" ADD COLUMN "eaten_at" timestamp with time zone;

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,2659 @@
+{
+  "id": "ad6ba0db-ae25-43d8-ad61-3867dc51cdfa",
+  "prevId": "3437995d-fd4d-4c42-b43b-4b7537167a9c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.custom_meal_types": {
+      "name": "custom_meal_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_meal_types_user_id": {
+          "name": "idx_custom_meal_types_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_meal_types_user_id_users_id_fk": {
+          "name": "custom_meal_types_user_id_users_id_fk",
+          "tableFrom": "custom_meal_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorite_meal_timeframes": {
+      "name": "favorite_meal_timeframes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_meal_type_id": {
+          "name": "custom_meal_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_favorite_meal_timeframes_user_id": {
+          "name": "idx_favorite_meal_timeframes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_favorite_meal_timeframes_custom_meal_type_id": {
+          "name": "idx_favorite_meal_timeframes_custom_meal_type_id",
+          "columns": [
+            {
+              "expression": "custom_meal_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorite_meal_timeframes_user_id_users_id_fk": {
+          "name": "favorite_meal_timeframes_user_id_users_id_fk",
+          "tableFrom": "favorite_meal_timeframes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorite_meal_timeframes_custom_meal_type_id_custom_meal_types_id_fk": {
+          "name": "favorite_meal_timeframes_custom_meal_type_id_custom_meal_types_id_fk",
+          "tableFrom": "favorite_meal_timeframes",
+          "tableTo": "custom_meal_types",
+          "columnsFrom": [
+            "custom_meal_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorite_meal_timeframes_minute_bounds": {
+          "name": "favorite_meal_timeframes_minute_bounds",
+          "value": "\"favorite_meal_timeframes\".\"start_minute\" >= 0 AND \"favorite_meal_timeframes\".\"start_minute\" <= 1439 AND \"favorite_meal_timeframes\".\"end_minute\" >= 1 AND \"favorite_meal_timeframes\".\"end_minute\" <= 1439"
+        },
+        "favorite_meal_timeframes_valid_range": {
+          "name": "favorite_meal_timeframes_valid_range",
+          "value": "\"favorite_meal_timeframes\".\"start_minute\" < \"favorite_meal_timeframes\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.food_entries": {
+      "name": "food_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_name": {
+          "name": "quick_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_calories": {
+          "name": "quick_calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_protein": {
+          "name": "quick_protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_carbs": {
+          "name": "quick_carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_fat": {
+          "name": "quick_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_fiber": {
+          "name": "quick_fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eaten_at": {
+          "name": "eaten_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_food_entries_user_date": {
+          "name": "idx_food_entries_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_food_id": {
+          "name": "idx_food_entries_food_id",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_recipe_id": {
+          "name": "idx_food_entries_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_created_at": {
+          "name": "idx_food_entries_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "food_entries_user_id_users_id_fk": {
+          "name": "food_entries_user_id_users_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "food_entries_food_id_foods_id_fk": {
+          "name": "food_entries_food_id_foods_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "food_entries_recipe_id_recipes_id_fk": {
+          "name": "food_entries_recipe_id_recipes_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "food_entries_servings_positive": {
+          "name": "food_entries_servings_positive",
+          "value": "\"food_entries\".\"servings\" > 0"
+        },
+        "food_entries_has_source": {
+          "name": "food_entries_has_source",
+          "value": "\"food_entries\".\"food_id\" IS NOT NULL OR \"food_entries\".\"recipe_id\" IS NOT NULL OR \"food_entries\".\"quick_calories\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.foods": {
+      "name": "foods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "serving_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saturated_fat": {
+          "name": "saturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monounsaturated_fat": {
+          "name": "monounsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polyunsaturated_fat": {
+          "name": "polyunsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trans_fat": {
+          "name": "trans_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cholesterol": {
+          "name": "cholesterol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega3": {
+          "name": "omega3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega6": {
+          "name": "omega6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_sugars": {
+          "name": "added_sugars",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar_alcohols": {
+          "name": "sugar_alcohols",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starch": {
+          "name": "starch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sodium": {
+          "name": "sodium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "potassium": {
+          "name": "potassium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calcium": {
+          "name": "calcium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iron": {
+          "name": "iron",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magnesium": {
+          "name": "magnesium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phosphorus": {
+          "name": "phosphorus",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zinc": {
+          "name": "zinc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copper": {
+          "name": "copper",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manganese": {
+          "name": "manganese",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selenium": {
+          "name": "selenium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iodine": {
+          "name": "iodine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fluoride": {
+          "name": "fluoride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chromium": {
+          "name": "chromium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "molybdenum": {
+          "name": "molybdenum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chloride": {
+          "name": "chloride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_a": {
+          "name": "vitamin_a",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_c": {
+          "name": "vitamin_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_d": {
+          "name": "vitamin_d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_e": {
+          "name": "vitamin_e",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_k": {
+          "name": "vitamin_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b1": {
+          "name": "vitamin_b1",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b2": {
+          "name": "vitamin_b2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b3": {
+          "name": "vitamin_b3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b5": {
+          "name": "vitamin_b5",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b6": {
+          "name": "vitamin_b6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b7": {
+          "name": "vitamin_b7",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b9": {
+          "name": "vitamin_b9",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b12": {
+          "name": "vitamin_b12",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caffeine": {
+          "name": "caffeine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alcohol": {
+          "name": "alcohol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "water": {
+          "name": "water",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nutri_score": {
+          "name": "nutri_score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nova_group": {
+          "name": "nova_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additives": {
+          "name": "additives",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingredients_text": {
+          "name": "ingredients_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_foods_user_id": {
+          "name": "idx_foods_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_barcode": {
+          "name": "idx_foods_barcode",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "barcode IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_user_name": {
+          "name": "idx_foods_user_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_image_url": {
+          "name": "idx_foods_image_url",
+          "columns": [
+            {
+              "expression": "image_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foods_user_id_users_id_fk": {
+          "name": "foods_user_id_users_id_fk",
+          "tableFrom": "foods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "foods_serving_positive": {
+          "name": "foods_serving_positive",
+          "value": "\"foods\".\"serving_size\" > 0"
+        },
+        "foods_nutrition_nonnegative": {
+          "name": "foods_nutrition_nonnegative",
+          "value": "\"foods\".\"calories\" >= 0 AND \"foods\".\"protein\" >= 0 AND \"foods\".\"carbs\" >= 0 AND \"foods\".\"fat\" >= 0 AND \"foods\".\"fiber\" >= 0"
+        },
+        "foods_fat_breakdown_nonneg": {
+          "name": "foods_fat_breakdown_nonneg",
+          "value": "(\"foods\".\"saturated_fat\" IS NULL OR \"foods\".\"saturated_fat\" >= 0) AND (\"foods\".\"monounsaturated_fat\" IS NULL OR \"foods\".\"monounsaturated_fat\" >= 0) AND (\"foods\".\"polyunsaturated_fat\" IS NULL OR \"foods\".\"polyunsaturated_fat\" >= 0) AND (\"foods\".\"trans_fat\" IS NULL OR \"foods\".\"trans_fat\" >= 0) AND (\"foods\".\"cholesterol\" IS NULL OR \"foods\".\"cholesterol\" >= 0) AND (\"foods\".\"omega3\" IS NULL OR \"foods\".\"omega3\" >= 0) AND (\"foods\".\"omega6\" IS NULL OR \"foods\".\"omega6\" >= 0)"
+        },
+        "foods_sugar_carb_nonneg": {
+          "name": "foods_sugar_carb_nonneg",
+          "value": "(\"foods\".\"sugar\" IS NULL OR \"foods\".\"sugar\" >= 0) AND (\"foods\".\"added_sugars\" IS NULL OR \"foods\".\"added_sugars\" >= 0) AND (\"foods\".\"sugar_alcohols\" IS NULL OR \"foods\".\"sugar_alcohols\" >= 0) AND (\"foods\".\"starch\" IS NULL OR \"foods\".\"starch\" >= 0)"
+        },
+        "foods_minerals_nonneg": {
+          "name": "foods_minerals_nonneg",
+          "value": "(\"foods\".\"sodium\" IS NULL OR \"foods\".\"sodium\" >= 0) AND (\"foods\".\"potassium\" IS NULL OR \"foods\".\"potassium\" >= 0) AND (\"foods\".\"calcium\" IS NULL OR \"foods\".\"calcium\" >= 0) AND (\"foods\".\"iron\" IS NULL OR \"foods\".\"iron\" >= 0) AND (\"foods\".\"magnesium\" IS NULL OR \"foods\".\"magnesium\" >= 0) AND (\"foods\".\"phosphorus\" IS NULL OR \"foods\".\"phosphorus\" >= 0) AND (\"foods\".\"zinc\" IS NULL OR \"foods\".\"zinc\" >= 0) AND (\"foods\".\"copper\" IS NULL OR \"foods\".\"copper\" >= 0) AND (\"foods\".\"manganese\" IS NULL OR \"foods\".\"manganese\" >= 0) AND (\"foods\".\"selenium\" IS NULL OR \"foods\".\"selenium\" >= 0) AND (\"foods\".\"iodine\" IS NULL OR \"foods\".\"iodine\" >= 0) AND (\"foods\".\"fluoride\" IS NULL OR \"foods\".\"fluoride\" >= 0) AND (\"foods\".\"chromium\" IS NULL OR \"foods\".\"chromium\" >= 0) AND (\"foods\".\"molybdenum\" IS NULL OR \"foods\".\"molybdenum\" >= 0) AND (\"foods\".\"chloride\" IS NULL OR \"foods\".\"chloride\" >= 0)"
+        },
+        "foods_vitamins_nonneg": {
+          "name": "foods_vitamins_nonneg",
+          "value": "(\"foods\".\"vitamin_a\" IS NULL OR \"foods\".\"vitamin_a\" >= 0) AND (\"foods\".\"vitamin_c\" IS NULL OR \"foods\".\"vitamin_c\" >= 0) AND (\"foods\".\"vitamin_d\" IS NULL OR \"foods\".\"vitamin_d\" >= 0) AND (\"foods\".\"vitamin_e\" IS NULL OR \"foods\".\"vitamin_e\" >= 0) AND (\"foods\".\"vitamin_k\" IS NULL OR \"foods\".\"vitamin_k\" >= 0) AND (\"foods\".\"vitamin_b1\" IS NULL OR \"foods\".\"vitamin_b1\" >= 0) AND (\"foods\".\"vitamin_b2\" IS NULL OR \"foods\".\"vitamin_b2\" >= 0) AND (\"foods\".\"vitamin_b3\" IS NULL OR \"foods\".\"vitamin_b3\" >= 0) AND (\"foods\".\"vitamin_b5\" IS NULL OR \"foods\".\"vitamin_b5\" >= 0) AND (\"foods\".\"vitamin_b6\" IS NULL OR \"foods\".\"vitamin_b6\" >= 0) AND (\"foods\".\"vitamin_b7\" IS NULL OR \"foods\".\"vitamin_b7\" >= 0) AND (\"foods\".\"vitamin_b9\" IS NULL OR \"foods\".\"vitamin_b9\" >= 0) AND (\"foods\".\"vitamin_b12\" IS NULL OR \"foods\".\"vitamin_b12\" >= 0)"
+        },
+        "foods_other_nutrients_nonneg": {
+          "name": "foods_other_nutrients_nonneg",
+          "value": "(\"foods\".\"caffeine\" IS NULL OR \"foods\".\"caffeine\" >= 0) AND (\"foods\".\"alcohol\" IS NULL OR \"foods\".\"alcohol\" >= 0) AND (\"foods\".\"water\" IS NULL OR \"foods\".\"water\" >= 0) AND (\"foods\".\"salt\" IS NULL OR \"foods\".\"salt\" >= 0)"
+        },
+        "foods_nutri_score_valid": {
+          "name": "foods_nutri_score_valid",
+          "value": "\"foods\".\"nutri_score\" IS NULL OR \"foods\".\"nutri_score\" IN ('a', 'b', 'c', 'd', 'e')"
+        },
+        "foods_nova_group_valid": {
+          "name": "foods_nova_group_valid",
+          "value": "\"foods\".\"nova_group\" IS NULL OR (\"foods\".\"nova_group\" >= 1 AND \"foods\".\"nova_group\" <= 4)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_codes_client_id": {
+          "name": "idx_oauth_codes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_codes_expires_at": {
+          "name": "idx_oauth_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_codes_method_check": {
+          "name": "oauth_codes_method_check",
+          "value": "code_challenge_method = 'S256'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorizations": {
+      "name": "oauth_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_authorizations_user_id": {
+          "name": "idx_oauth_authorizations_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_authorizations_client_id": {
+          "name": "idx_oauth_authorizations_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_authorizations_user_client": {
+          "name": "idx_oauth_authorizations_user_client",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorizations_user_id_users_id_fk": {
+          "name": "oauth_authorizations_user_id_users_id_fk",
+          "tableFrom": "oauth_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorizations_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorizations_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorizations",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_redirect_uris": {
+          "name": "allowed_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_user_id": {
+          "name": "idx_oauth_clients_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['mcp:access']::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_tokens_client_id": {
+          "name": "idx_oauth_tokens_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_user_id": {
+          "name": "idx_oauth_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_expires_at": {
+          "name": "idx_oauth_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_access_token_hash": {
+          "name": "idx_oauth_tokens_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_tokens_user_id_users_id_fk": {
+          "name": "oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_ingredients": {
+      "name": "recipe_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "serving_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recipe_ingredients_recipe_id": {
+          "name": "idx_recipe_ingredients_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_ingredients_food_id": {
+          "name": "idx_recipe_ingredients_food_id",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_ingredients_recipe_id_recipes_id_fk": {
+          "name": "recipe_ingredients_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_ingredients_food_id_foods_id_fk": {
+          "name": "recipe_ingredients_food_id_foods_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recipe_ingredients_quantity_positive": {
+          "name": "recipe_ingredients_quantity_positive",
+          "value": "\"recipe_ingredients\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_servings": {
+          "name": "total_servings",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_recipes_user_id": {
+          "name": "idx_recipes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_created_at": {
+          "name": "idx_recipes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_image_url": {
+          "name": "idx_recipes_image_url",
+          "columns": [
+            {
+              "expression": "image_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_user_id_users_id_fk": {
+          "name": "recipes_user_id_users_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recipes_servings_positive": {
+          "name": "recipes_servings_positive",
+          "value": "\"recipes\".\"total_servings\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplement_ingredients": {
+      "name": "supplement_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "supplement_id": {
+          "name": "supplement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage_unit": {
+          "name": "dosage_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_supplement_ingredients_supplement_id": {
+          "name": "idx_supplement_ingredients_supplement_id",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplement_ingredients_supplement_id_supplements_id_fk": {
+          "name": "supplement_ingredients_supplement_id_supplements_id_fk",
+          "tableFrom": "supplement_ingredients",
+          "tableTo": "supplements",
+          "columnsFrom": [
+            "supplement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplement_ingredients_dosage_positive": {
+          "name": "supplement_ingredients_dosage_positive",
+          "value": "\"supplement_ingredients\".\"dosage\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplement_logs": {
+      "name": "supplement_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "supplement_id": {
+          "name": "supplement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supplement_logs_unique": {
+          "name": "idx_supplement_logs_unique",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplement_logs_user_date": {
+          "name": "idx_supplement_logs_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplement_logs_supplement_id": {
+          "name": "idx_supplement_logs_supplement_id",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplement_logs_supplement_id_supplements_id_fk": {
+          "name": "supplement_logs_supplement_id_supplements_id_fk",
+          "tableFrom": "supplement_logs",
+          "tableTo": "supplements",
+          "columnsFrom": [
+            "supplement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "supplement_logs_user_id_users_id_fk": {
+          "name": "supplement_logs_user_id_users_id_fk",
+          "tableFrom": "supplement_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplements": {
+      "name": "supplements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage_unit": {
+          "name": "dosage_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_days": {
+          "name": "schedule_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_start_date": {
+          "name": "schedule_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supplements_user_id": {
+          "name": "idx_supplements_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplements_user_active": {
+          "name": "idx_supplements_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplements_user_id_users_id_fk": {
+          "name": "supplements_user_id_users_id_fk",
+          "tableFrom": "supplements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplements_dosage_positive": {
+          "name": "supplements_dosage_positive",
+          "value": "\"supplements\".\"dosage\" > 0"
+        },
+        "supplements_schedule_days_required": {
+          "name": "supplements_schedule_days_required",
+          "value": "\"supplements\".\"schedule_type\" NOT IN ('weekly', 'specific_days') OR (\"supplements\".\"schedule_days\" IS NOT NULL AND array_length(\"supplements\".\"schedule_days\", 1) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_goals": {
+      "name": "user_goals",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calorie_goal": {
+          "name": "calorie_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_goal": {
+          "name": "protein_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carb_goal": {
+          "name": "carb_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fat_goal": {
+          "name": "fat_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiber_goal": {
+          "name": "fiber_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sodium_goal": {
+          "name": "sodium_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar_goal": {
+          "name": "sugar_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_goals_user_id_users_id_fk": {
+          "name": "user_goals_user_id_users_id_fk",
+          "tableFrom": "user_goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_goals_positive": {
+          "name": "user_goals_positive",
+          "value": "\"user_goals\".\"calorie_goal\" > 0 AND \"user_goals\".\"protein_goal\" >= 0 AND \"user_goals\".\"carb_goal\" >= 0 AND \"user_goals\".\"fat_goal\" >= 0 AND \"user_goals\".\"fiber_goal\" >= 0"
+        },
+        "user_goals_optional_nonnegative": {
+          "name": "user_goals_optional_nonnegative",
+          "value": "(\"user_goals\".\"sodium_goal\" IS NULL OR \"user_goals\".\"sodium_goal\" >= 0) AND (\"user_goals\".\"sugar_goal\" IS NULL OR \"user_goals\".\"sugar_goal\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_chart_widget": {
+          "name": "show_chart_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_favorites_widget": {
+          "name": "show_favorites_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_supplements_widget": {
+          "name": "show_supplements_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_weight_widget": {
+          "name": "show_weight_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_meal_breakdown_widget": {
+          "name": "show_meal_breakdown_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_top_foods_widget": {
+          "name": "show_top_foods_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "widget_order": {
+          "name": "widget_order",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['chart', 'favorites', 'supplements', 'weight', 'daylog']::text[]"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dashboard'"
+        },
+        "favorite_tap_action": {
+          "name": "favorite_tap_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instant'"
+        },
+        "favorite_meal_assignment_mode": {
+          "name": "favorite_meal_assignment_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_based'"
+        },
+        "visible_nutrients": {
+          "name": "visible_nutrients",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['sodium', 'sugar', 'saturatedFat', 'cholesterol']::text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "infomaniak_sub": {
+          "name": "infomaniak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_infomaniak_sub_unique": {
+          "name": "users_infomaniak_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "infomaniak_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_entries": {
+      "name": "weight_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_weight_entries_user_date": {
+          "name": "idx_weight_entries_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weight_entries_user_logged": {
+          "name": "idx_weight_entries_user_logged",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_user_id_users_id_fk": {
+          "name": "weight_entries_user_id_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "weight_entries_valid": {
+          "name": "weight_entries_valid",
+          "value": "\"weight_entries\".\"weight_kg\" > 0 AND \"weight_entries\".\"weight_kg\" <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "daily",
+        "every_other_day",
+        "weekly",
+        "specific_days"
+      ]
+    },
+    "public.serving_unit": {
+      "name": "serving_unit",
+      "schema": "public",
+      "values": [
+        "g",
+        "kg",
+        "ml",
+        "l",
+        "oz",
+        "lb",
+        "fl_oz",
+        "cup",
+        "tbsp",
+        "tsp"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1772495433595,
       "tag": "0022_harsh_mariko_yashida",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1772628765232,
+      "tag": "0023_tidy_gambit",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -62,6 +62,9 @@
 	"amount_preview_equals": "= {amount} {unit}",
 	"amount_preview_kcal": "{kcal} kcal",
 
+	"add_food_time": "Uhrzeit (optional)",
+	"edit_entry_time": "Uhrzeit",
+
 	"edit_entry_title": "Eintrag bearbeiten",
 	"edit_entry_servings": "Portionen",
 	"edit_entry_meal": "Mahlzeit",

--- a/messages/en.json
+++ b/messages/en.json
@@ -62,6 +62,9 @@
 	"amount_preview_equals": "= {amount} {unit}",
 	"amount_preview_kcal": "{kcal} kcal",
 
+	"add_food_time": "Time (optional)",
+	"edit_entry_time": "Time",
+
 	"edit_entry_title": "Edit Entry",
 	"edit_entry_servings": "Servings",
 	"edit_entry_meal": "Meal",

--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="%lang%">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 		<meta name="apple-mobile-web-app-title" content="Bissbilanz" />

--- a/src/lib/components/entries/AddFoodModal.svelte
+++ b/src/lib/components/entries/AddFoodModal.svelte
@@ -12,6 +12,7 @@
 	import ChevronUp from '@lucide/svelte/icons/chevron-up';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { apiFetch } from '$lib/utils/api';
+	import { timeToIsoString } from '$lib/utils/dates';
 	import * as m from '$lib/paraglide/messages';
 
 	type FoodItem = {
@@ -45,6 +46,7 @@
 		foods?: FoodItem[];
 		recipes?: Array<{ id: string; name: string; isFavorite?: boolean }>;
 		mealType?: string;
+		date: string;
 		onClose: () => void;
 		onSave: (payload: {
 			foodId?: string;
@@ -66,6 +68,7 @@
 		foods = [],
 		recipes = [],
 		mealType = 'Breakfast',
+		date,
 		onClose,
 		onSave
 	}: Props = $props();
@@ -163,17 +166,10 @@
 		servings = 1;
 	};
 
-	const buildEatenAt = (): string | undefined => {
-		if (!eatenTime) return undefined;
-		const now = new Date();
-		const [h, min] = eatenTime.split(':').map(Number);
-		const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, min);
-		return d.toISOString();
-	};
-
 	const confirmAdd = () => {
 		if (!selectedFood) return;
-		const base = { mealType, servings, eatenAt: buildEatenAt() };
+		const eatenAt = timeToIsoString(eatenTime, date) ?? undefined;
+		const base = { mealType, servings, eatenAt };
 		if (selectedFood.type === 'food') {
 			onSave({ foodId: selectedFood.id, ...base });
 		} else {
@@ -189,7 +185,7 @@
 		onSave({
 			mealType,
 			servings: 1,
-			eatenAt: buildEatenAt(),
+			eatenAt: timeToIsoString(eatenTime, date) ?? undefined,
 			quickName: quickName.trim() || undefined,
 			quickCalories: cal,
 			quickProtein: quickProtein ? Number(quickProtein) : undefined,

--- a/src/lib/components/entries/AddFoodModal.svelte
+++ b/src/lib/components/entries/AddFoodModal.svelte
@@ -51,6 +51,7 @@
 			recipeId?: string;
 			mealType: string;
 			servings: number;
+			eatenAt?: string;
 			quickName?: string;
 			quickCalories?: number;
 			quickProtein?: number;
@@ -71,6 +72,7 @@
 
 	let query = $state('');
 	let servings = $state(1);
+	let eatenTime = $state('');
 	let tab: 'search' | 'favorites' | 'recent' | 'recipes' | 'quick' = $state('search');
 	let recentFoods: Array<{ id: string; name: string }> = $state([]);
 
@@ -161,14 +163,24 @@
 		servings = 1;
 	};
 
+	const buildEatenAt = (): string | undefined => {
+		if (!eatenTime) return undefined;
+		const now = new Date();
+		const [h, min] = eatenTime.split(':').map(Number);
+		const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, min);
+		return d.toISOString();
+	};
+
 	const confirmAdd = () => {
 		if (!selectedFood) return;
+		const base = { mealType, servings, eatenAt: buildEatenAt() };
 		if (selectedFood.type === 'food') {
-			onSave({ foodId: selectedFood.id, mealType, servings });
+			onSave({ foodId: selectedFood.id, ...base });
 		} else {
-			onSave({ recipeId: selectedFood.id, mealType, servings });
+			onSave({ recipeId: selectedFood.id, ...base });
 		}
 		selectedFood = null;
+		eatenTime = '';
 	};
 
 	const confirmQuickLog = () => {
@@ -177,6 +189,7 @@
 		onSave({
 			mealType,
 			servings: 1,
+			eatenAt: buildEatenAt(),
 			quickName: quickName.trim() || undefined,
 			quickCalories: cal,
 			quickProtein: quickProtein ? Number(quickProtein) : undefined,
@@ -190,6 +203,7 @@
 		quickCarbs = '';
 		quickFat = '';
 		quickFiber = '';
+		eatenTime = '';
 	};
 
 	const goBack = () => {
@@ -267,6 +281,11 @@
 					caloriesPerServing={selectedFood.calories}
 					onServingsChange={(v) => (servings = v)}
 				/>
+
+				<div class="grid gap-1.5">
+					<Label class="text-xs">{m.add_food_time()}</Label>
+					<Input type="time" bind:value={eatenTime} />
+				</div>
 
 				<Button class="w-full" onclick={confirmAdd}>
 					<Check class="mr-1 size-4" />
@@ -450,6 +469,10 @@
 								</div>
 							</div>
 						{/if}
+						<div class="grid gap-1.5">
+							<Label class="text-xs">{m.add_food_time()}</Label>
+							<Input type="time" bind:value={eatenTime} />
+						</div>
 						<Button class="w-full" disabled={!quickCalories || Number(quickCalories) <= 0} onclick={confirmQuickLog}>
 							<Check class="mr-1 size-4" />
 							{m.quick_log_add()}

--- a/src/lib/components/entries/DayLog.svelte
+++ b/src/lib/components/entries/DayLog.svelte
@@ -178,6 +178,7 @@
 		bind:open={addModalOpen}
 		{foods}
 		{recipes}
+		{date}
 		mealType={activeMeal}
 		onClose={() => {
 			addModalOpen = false;
@@ -186,6 +187,7 @@
 	/>
 	<EditEntryModal
 		bind:open={editModalOpen}
+		{date}
 		entry={editingEntry}
 		onClose={() => {
 			editModalOpen = false;

--- a/src/lib/components/entries/DayLog.svelte
+++ b/src/lib/components/entries/DayLog.svelte
@@ -41,6 +41,7 @@
 		servingSize?: number | null;
 		servingUnit?: string | null;
 		calories?: number | null;
+		eatenAt?: string | null;
 		quickCalories?: number | null;
 		quickProtein?: number | null;
 		quickCarbs?: number | null;
@@ -82,6 +83,7 @@
 		id: string;
 		servings: number;
 		mealType: string;
+		eatenAt?: string | null;
 		quickName?: string | null;
 		quickCalories?: number | null;
 		quickProtein?: number | null;
@@ -117,6 +119,7 @@
 		servingSize?: number | null;
 		servingUnit?: string | null;
 		calories?: number | null;
+		eatenAt?: string | null;
 		quickCalories?: number | null;
 		quickProtein?: number | null;
 		quickCarbs?: number | null;

--- a/src/lib/components/entries/EditEntryModal.svelte
+++ b/src/lib/components/entries/EditEntryModal.svelte
@@ -9,10 +9,12 @@
 	import Check from '@lucide/svelte/icons/check';
 	import X from '@lucide/svelte/icons/x';
 	import { round2 } from '$lib/utils/number';
+	import { timeToIsoString, formatTime24h } from '$lib/utils/dates';
 	import * as m from '$lib/paraglide/messages';
 
 	type Props = {
 		open?: boolean;
+		date: string;
 		entry: {
 			id: string;
 			servings: number;
@@ -45,7 +47,7 @@
 		onDelete: (id: string) => void;
 	};
 
-	let { open = $bindable(false), entry, onClose, onSave, onDelete }: Props = $props();
+	let { open = $bindable(false), date, entry, onClose, onSave, onDelete }: Props = $props();
 
 	let wasOpen = $state(false);
 	$effect(() => {
@@ -68,17 +70,11 @@
 
 	const isQuickEntry = $derived(entry?.quickCalories != null);
 
-	const formatTimeFromIso = (iso: string | null | undefined): string => {
-		if (!iso) return '';
-		const d = new Date(iso);
-		return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
-	};
-
 	$effect(() => {
 		if (entry) {
 			editServings = round2(entry.servings);
 			editMealType = entry.mealType;
-			editTime = formatTimeFromIso(entry.eatenAt);
+			editTime = formatTime24h(entry.eatenAt);
 			if (entry.quickCalories != null) {
 				editQuickName = entry.quickName ?? '';
 				editQuickCalories = String(entry.quickCalories);
@@ -90,17 +86,9 @@
 		}
 	});
 
-	const buildEatenAt = (): string | null => {
-		if (!editTime) return null;
-		const now = new Date();
-		const [h, min] = editTime.split(':').map(Number);
-		const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, min);
-		return d.toISOString();
-	};
-
 	const handleSave = () => {
 		if (!entry) return;
-		const eatenAt = buildEatenAt();
+		const eatenAt = timeToIsoString(editTime, date);
 		if (isQuickEntry) {
 			const cal = Number(editQuickCalories);
 			if (!cal || cal < 0) return;

--- a/src/lib/components/entries/EditEntryModal.svelte
+++ b/src/lib/components/entries/EditEntryModal.svelte
@@ -21,6 +21,7 @@
 			servingSize?: number | null;
 			servingUnit?: string | null;
 			calories?: number | null;
+			eatenAt?: string | null;
 			quickCalories?: number | null;
 			quickProtein?: number | null;
 			quickCarbs?: number | null;
@@ -33,6 +34,7 @@
 			id: string;
 			servings: number;
 			mealType: string;
+			eatenAt?: string | null;
 			quickName?: string | null;
 			quickCalories?: number | null;
 			quickProtein?: number | null;
@@ -55,6 +57,7 @@
 
 	let editServings = $state(1);
 	let editMealType = $state('');
+	let editTime = $state('');
 
 	let editQuickName = $state('');
 	let editQuickCalories = $state('');
@@ -65,10 +68,17 @@
 
 	const isQuickEntry = $derived(entry?.quickCalories != null);
 
+	const formatTimeFromIso = (iso: string | null | undefined): string => {
+		if (!iso) return '';
+		const d = new Date(iso);
+		return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+	};
+
 	$effect(() => {
 		if (entry) {
 			editServings = round2(entry.servings);
 			editMealType = entry.mealType;
+			editTime = formatTimeFromIso(entry.eatenAt);
 			if (entry.quickCalories != null) {
 				editQuickName = entry.quickName ?? '';
 				editQuickCalories = String(entry.quickCalories);
@@ -80,8 +90,17 @@
 		}
 	});
 
+	const buildEatenAt = (): string | null => {
+		if (!editTime) return null;
+		const now = new Date();
+		const [h, min] = editTime.split(':').map(Number);
+		const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, min);
+		return d.toISOString();
+	};
+
 	const handleSave = () => {
 		if (!entry) return;
+		const eatenAt = buildEatenAt();
 		if (isQuickEntry) {
 			const cal = Number(editQuickCalories);
 			if (!cal || cal < 0) return;
@@ -89,6 +108,7 @@
 				id: entry.id,
 				servings: 1,
 				mealType: editMealType,
+				eatenAt,
 				quickName: editQuickName.trim() || null,
 				quickCalories: cal,
 				quickProtein: editQuickProtein ? Number(editQuickProtein) : null,
@@ -97,7 +117,7 @@
 				quickFiber: editQuickFiber ? Number(editQuickFiber) : null
 			});
 		} else {
-			onSave({ id: entry.id, servings: editServings, mealType: editMealType });
+			onSave({ id: entry.id, servings: editServings, mealType: editMealType, eatenAt });
 		}
 	};
 
@@ -168,6 +188,11 @@
 					{/each}
 				</Select.Content>
 			</Select.Root>
+		</div>
+
+		<div class="grid gap-2">
+			<Label>{m.edit_entry_time()}</Label>
+			<Input type="time" bind:value={editTime} />
 		</div>
 
 		<div class="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/src/lib/components/entries/MealSection.svelte
+++ b/src/lib/components/entries/MealSection.svelte
@@ -19,6 +19,7 @@
 			calories: number | null;
 			servings: number;
 			mealType: string;
+			eatenAt?: string | null;
 			createdAt?: string | null;
 			servingSize?: number | null;
 			servingUnit?: string | null;
@@ -40,6 +41,7 @@
 			servingSize?: number | null;
 			servingUnit?: string | null;
 			calories?: number | null;
+			eatenAt?: string | null;
 			quickCalories?: number | null;
 			quickProtein?: number | null;
 			quickCarbs?: number | null;
@@ -89,6 +91,7 @@
 						servingSize: entry.servingSize,
 						servingUnit: entry.servingUnit,
 						calories: entry.calories,
+						eatenAt: entry.eatenAt,
 						quickCalories: entry.quickCalories,
 						quickProtein: entry.quickProtein,
 						quickCarbs: entry.quickCarbs,
@@ -120,9 +123,9 @@
 									entry.servingUnit
 								)}
 							</span>
-							{#if entry.createdAt}
+							{#if entry.eatenAt || entry.createdAt}
 								<span class="shrink-0 text-xs text-muted-foreground/60"
-									>{formatTime(entry.createdAt)}</span
+									>{formatTime(entry.eatenAt ?? entry.createdAt)}</span
 								>
 							{/if}
 						</div>

--- a/src/lib/components/entries/MealSection.svelte
+++ b/src/lib/components/entries/MealSection.svelte
@@ -145,9 +145,9 @@
 								entry.servingUnit
 							)}</span
 						>
-						{#if entry.createdAt}
+						{#if entry.eatenAt || entry.createdAt}
 							<span class="shrink-0 text-xs text-muted-foreground/60"
-								>{formatTime(entry.createdAt)}</span
+								>{formatTime(entry.eatenAt ?? entry.createdAt)}</span
 							>
 						{/if}
 					</div>

--- a/src/lib/components/entries/MealSection.svelte
+++ b/src/lib/components/entries/MealSection.svelte
@@ -9,6 +9,7 @@
 	import Sunset from '@lucide/svelte/icons/sunset';
 	import UtensilsCrossed from '@lucide/svelte/icons/utensils-crossed';
 	import SwipeableEntry from '$lib/components/entries/SwipeableEntry.svelte';
+	import { formatTime } from '$lib/utils/dates';
 	import * as m from '$lib/paraglide/messages';
 
 	type Props = {
@@ -62,11 +63,6 @@
 		onDelete
 	}: Props = $props();
 
-	const formatTime = (iso: string | null | undefined) => {
-		if (!iso) return '';
-		const d = new Date(iso);
-		return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-	};
 
 	const mealVisual = $derived.by(() => {
 		const key = title.trim().toLowerCase();

--- a/src/lib/components/weight/WeightHistoryList.svelte
+++ b/src/lib/components/weight/WeightHistoryList.svelte
@@ -7,6 +7,7 @@
 	import X from '@lucide/svelte/icons/x';
 	import { apiFetch } from '$lib/utils/api';
 	import { round2 } from '$lib/utils/number';
+	import { formatTime } from '$lib/utils/dates';
 	import * as m from '$lib/paraglide/messages';
 
 	type WeightEntry = {
@@ -58,8 +59,7 @@
 			month: 'short'
 		});
 
-	const formatTime = (iso: string) =>
-		new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+
 </script>
 
 <div class="space-y-2">

--- a/src/lib/server/entries.ts
+++ b/src/lib/server/entries.ts
@@ -51,6 +51,7 @@ export const listEntriesByDate = async (
 			quickFat: foodEntries.quickFat,
 			quickFiber: foodEntries.quickFiber,
 			...entryMacroColumns(),
+			eatenAt: foodEntries.eatenAt,
 			createdAt: foodEntries.createdAt,
 			servingSize: foods.servingSize,
 			servingUnit: foods.servingUnit
@@ -89,7 +90,8 @@ export const createEntry = async (
 				quickProtein: result.data.quickProtein ?? null,
 				quickCarbs: result.data.quickCarbs ?? null,
 				quickFat: result.data.quickFat ?? null,
-				quickFiber: result.data.quickFiber ?? null
+				quickFiber: result.data.quickFiber ?? null,
+				eatenAt: result.data.eatenAt ? new Date(result.data.eatenAt) : null
 			})
 			.returning();
 		if (!created) {
@@ -103,10 +105,14 @@ export const createEntry = async (
 
 type EntryUpdateInput = typeof entryUpdateSchema._output;
 
-export const toEntryUpdate = (input: EntryUpdateInput) => ({
-	...input,
-	notes: input.notes ?? null
-});
+export const toEntryUpdate = (input: EntryUpdateInput) => {
+	const { eatenAt, ...rest } = input;
+	return {
+		...rest,
+		notes: input.notes ?? null,
+		...(eatenAt !== undefined ? { eatenAt: eatenAt ? new Date(eatenAt) : null } : {})
+	};
+};
 
 export const updateEntry = async (
 	userId: string,

--- a/src/lib/server/mcp/create-handlers.ts
+++ b/src/lib/server/mcp/create-handlers.ts
@@ -187,7 +187,19 @@ export function createHandlers(d: HandlerDeps) {
 
 	const handleUpdateEntry = async (
 		userId: string,
-		args: { entryId: string; servings?: number; mealType?: string; notes?: string }
+		args: {
+			entryId: string;
+			servings?: number;
+			mealType?: string;
+			notes?: string;
+			eatenAt?: string | null;
+			quickName?: string | null;
+			quickCalories?: number | null;
+			quickProtein?: number | null;
+			quickCarbs?: number | null;
+			quickFat?: number | null;
+			quickFiber?: number | null;
+		}
 	) => {
 		const { entryId, ...rest } = args;
 		const result = await d.updateEntry(userId, entryId, rest);

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -178,7 +178,7 @@ export function createMcpServer(userId: string): McpServer {
 				quickCarbs: z.number().nonnegative().optional().describe('Carbs in grams for quick log'),
 				quickFat: z.number().nonnegative().optional().describe('Fat in grams for quick log'),
 				quickFiber: z.number().nonnegative().optional().describe('Fiber in grams for quick log'),
-				eatenAt: z.string().optional().describe('When the food was eaten, as ISO 8601 datetime with timezone (e.g., "2025-01-15T12:30:00+01:00"). Defaults to creation time.')
+				eatenAt: z.string().datetime({ offset: true }).optional().describe('When the food was eaten, as ISO 8601 datetime with timezone (e.g., "2025-01-15T12:30:00+01:00"). Defaults to creation time.')
 			}
 		},
 		safe((args) => handleLogFood(userId, { ...args, date: args.date ?? today() }))
@@ -237,7 +237,8 @@ export function createMcpServer(userId: string): McpServer {
 				quickProtein: z.number().nonnegative().optional().nullable().describe('New protein for quick log'),
 				quickCarbs: z.number().nonnegative().optional().nullable().describe('New carbs for quick log'),
 				quickFat: z.number().nonnegative().optional().nullable().describe('New fat for quick log'),
-				quickFiber: z.number().nonnegative().optional().nullable().describe('New fiber for quick log')
+				quickFiber: z.number().nonnegative().optional().nullable().describe('New fiber for quick log'),
+				eatenAt: z.string().datetime({ offset: true }).optional().nullable().describe('When the food was eaten, as ISO 8601 datetime with timezone. Set to null to clear.')
 			}
 		},
 		safe((args) => handleUpdateEntry(userId, args))

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -177,7 +177,8 @@ export function createMcpServer(userId: string): McpServer {
 				quickProtein: z.number().nonnegative().optional().describe('Protein in grams for quick log'),
 				quickCarbs: z.number().nonnegative().optional().describe('Carbs in grams for quick log'),
 				quickFat: z.number().nonnegative().optional().describe('Fat in grams for quick log'),
-				quickFiber: z.number().nonnegative().optional().describe('Fiber in grams for quick log')
+				quickFiber: z.number().nonnegative().optional().describe('Fiber in grams for quick log'),
+				eatenAt: z.string().optional().describe('When the food was eaten, as ISO 8601 datetime with timezone (e.g., "2025-01-15T12:30:00+01:00"). Defaults to creation time.')
 			}
 		},
 		safe((args) => handleLogFood(userId, { ...args, date: args.date ?? today() }))

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -194,6 +194,7 @@ export const foodEntries = pgTable(
 		quickCarbs: real('quick_carbs'),
 		quickFat: real('quick_fat'),
 		quickFiber: real('quick_fiber'),
+		eatenAt: timestamp('eaten_at', { withTimezone: true }),
 		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow()
 	},

--- a/src/lib/server/validation/entries.ts
+++ b/src/lib/server/validation/entries.ts
@@ -13,7 +13,8 @@ const entryBaseSchema = z.object({
 	quickProtein: z.coerce.number().nonnegative().optional().nullable(),
 	quickCarbs: z.coerce.number().nonnegative().optional().nullable(),
 	quickFat: z.coerce.number().nonnegative().optional().nullable(),
-	quickFiber: z.coerce.number().nonnegative().optional().nullable()
+	quickFiber: z.coerce.number().nonnegative().optional().nullable(),
+	eatenAt: z.string().datetime({ offset: true }).optional().nullable()
 });
 
 export const entryCreateSchema = entryBaseSchema.refine(

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -68,3 +68,34 @@ export const daysBetween = (startDate: string, endDate: string): number => {
 export const getDayOfWeek = (isoDate: string) => new Date(isoDate + 'T00:00:00Z').getUTCDay();
 
 export const daysAgo = (days: number) => shiftDate(today(), -(days - 1));
+
+/**
+ * Convert an HH:MM time string to an ISO 8601 datetime for the given date.
+ * Returns null if the time string is empty/falsy.
+ */
+export const timeToIsoString = (time: string, isoDate: string): string | null => {
+	if (!time) return null;
+	const [h, min] = time.split(':').map(Number);
+	const [y, mo, d] = isoDate.split('-').map(Number);
+	return new Date(y, mo - 1, d, h, min).toISOString();
+};
+
+/**
+ * Format an ISO datetime string to a locale HH:MM time string for display.
+ */
+export const formatTime = (iso: string | null | undefined): string => {
+	if (!iso) return '';
+	return new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+};
+
+/**
+ * Format an ISO datetime string to HH:MM in 24-hour format (for time input values).
+ */
+export const formatTime24h = (iso: string | null | undefined): string => {
+	if (!iso) return '';
+	return new Date(iso).toLocaleTimeString(undefined, {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false
+	});
+};


### PR DESCRIPTION
## Summary
This PR adds support for tracking the specific time when food was consumed by introducing an `eaten_at` timestamp field to food entries. Users can now optionally specify what time they ate a meal, enabling more granular tracking of their eating patterns throughout the day.

## Key Changes
- **Database Schema**: Added `eaten_at` timestamp column to the `food_entries` table with timezone support
- **API & Validation**: Updated entry validation schema and MCP server handlers to accept and process the `eaten_at` field
- **UI Components**: 
  - Added time input fields to both "Add Food" and "Edit Entry" modals
  - Updated entry display components to show the eaten time when available
  - Added time formatting utilities for consistent display across the application
- **Utilities**: Created `timeToIsoString()` helper function to convert HH:MM time strings to ISO 8601 datetime format
- **Internationalization**: Added translation keys for time input labels in English and German

## Implementation Details
- The `eaten_at` field is optional and nullable, allowing entries without a specific time
- Time input is converted to ISO 8601 format using the entry date and the provided time
- The field is included in entry listings and can be displayed in the UI
- Database migration creates the new column without affecting existing data

https://claude.ai/code/session_0165G1ZzWzrAr9hNK3iMQUTm