### PR TITLE
fix: return 400 instead of 500 on malformed JSON body

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -54,7 +54,7 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        run: ./gradlew androidApp:assembleRelease
+        run: ./gradlew androidApp:assembleRelease -PSENTRY_DSN=${{ secrets.SENTRY_DSN }}
 
       - name: Upload release APK
         uses: actions/upload-artifact@v4

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -9,6 +9,7 @@ import com.bissbilanz.android.ui.viewmodels.InsightsViewModel
 import com.bissbilanz.auth.SecureStorage
 import com.bissbilanz.cache.DatabaseDriverFactory
 import com.bissbilanz.di.sharedModule
+import io.sentry.android.core.SentryAndroid
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.viewModelOf
@@ -18,6 +19,18 @@ import org.koin.dsl.module
 class BissbilanzApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        if (BuildConfig.SENTRY_DSN.isNotBlank()) {
+            SentryAndroid.init(this) { options ->
+                options.dsn = BuildConfig.SENTRY_DSN
+                options.isAnrEnabled = true
+                options.isAttachScreenshot = true
+                options.isAttachViewHierarchy = true
+                options.tracesSampleRate = 0.2
+                options.environment = if (BuildConfig.DEBUG) "development" else "production"
+                options.release = "com.bissbilanz.android@${BuildConfig.VERSION_NAME}+${BuildConfig.VERSION_CODE}"
+            }
+        }
 
         val androidModule =
             module {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodDetailScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.bissbilanz.android.ui.components.FoodEditSheet
 import com.bissbilanz.android.ui.components.LoadingScreen
@@ -22,6 +23,7 @@ import com.bissbilanz.model.EntryCreate
 import com.bissbilanz.model.Food
 import com.bissbilanz.repository.EntryRepository
 import com.bissbilanz.repository.FoodRepository
+import com.bissbilanz.repository.PreferencesRepository
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
@@ -36,6 +38,9 @@ fun FoodDetailScreen(
 ) {
     val foodRepo: FoodRepository = koinInject()
     val entryRepo: EntryRepository = koinInject()
+    val prefsRepo: PreferencesRepository = koinInject()
+    val prefs by prefsRepo.preferences.collectAsStateWithLifecycle()
+    val visibleNutrients = prefs?.visibleNutrients?.toSet()
     var food by remember { mutableStateOf<Food?>(null) }
     var isLoading by remember { mutableStateOf(true) }
     var showLogDialog by remember { mutableStateOf(false) }
@@ -46,6 +51,7 @@ fun FoodDetailScreen(
 
     LaunchedEffect(foodId) {
         isLoading = true
+        prefsRepo.loadPreferences()
         try {
             food = foodRepo.getFood(foodId)
         } catch (_: Exception) {
@@ -200,15 +206,22 @@ fun FoodDetailScreen(
                     }
 
                     // Fat Breakdown
+                    val vn = visibleNutrients
                     val fatNutrients =
                         listOfNotNull(
-                            f.saturatedFat?.let { "Saturated Fat" to Pair(it, "g") },
-                            f.monounsaturatedFat?.let { "Monounsat. Fat" to Pair(it, "g") },
-                            f.polyunsaturatedFat?.let { "Polyunsat. Fat" to Pair(it, "g") },
-                            f.transFat?.let { "Trans Fat" to Pair(it, "g") },
-                            f.cholesterol?.let { "Cholesterol" to Pair(it, "mg") },
-                            f.omega3?.let { "Omega-3" to Pair(it, "mg") },
-                            f.omega6?.let { "Omega-6" to Pair(it, "mg") },
+                            f.saturatedFat?.takeIf { vn == null || "saturatedFat" in vn }?.let { "Saturated Fat" to Pair(it, "g") },
+                            f.monounsaturatedFat?.takeIf { vn == null || "monounsaturatedFat" in vn }?.let {
+                                "Monounsat. Fat" to
+                                    Pair(it, "g")
+                            },
+                            f.polyunsaturatedFat?.takeIf { vn == null || "polyunsaturatedFat" in vn }?.let {
+                                "Polyunsat. Fat" to
+                                    Pair(it, "g")
+                            },
+                            f.transFat?.takeIf { vn == null || "transFat" in vn }?.let { "Trans Fat" to Pair(it, "g") },
+                            f.cholesterol?.takeIf { vn == null || "cholesterol" in vn }?.let { "Cholesterol" to Pair(it, "mg") },
+                            f.omega3?.takeIf { vn == null || "omega3" in vn }?.let { "Omega-3" to Pair(it, "mg") },
+                            f.omega6?.takeIf { vn == null || "omega6" in vn }?.let { "Omega-6" to Pair(it, "mg") },
                         )
                     if (fatNutrients.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(12.dp))
@@ -218,10 +231,10 @@ fun FoodDetailScreen(
                     // Sugar & Carbs
                     val sugarNutrients =
                         listOfNotNull(
-                            f.sugar?.let { "Sugar" to Pair(it, "g") },
-                            f.addedSugars?.let { "Added Sugars" to Pair(it, "g") },
-                            f.sugarAlcohols?.let { "Sugar Alcohols" to Pair(it, "g") },
-                            f.starch?.let { "Starch" to Pair(it, "g") },
+                            f.sugar?.takeIf { vn == null || "sugar" in vn }?.let { "Sugar" to Pair(it, "g") },
+                            f.addedSugars?.takeIf { vn == null || "addedSugars" in vn }?.let { "Added Sugars" to Pair(it, "g") },
+                            f.sugarAlcohols?.takeIf { vn == null || "sugarAlcohols" in vn }?.let { "Sugar Alcohols" to Pair(it, "g") },
+                            f.starch?.takeIf { vn == null || "starch" in vn }?.let { "Starch" to Pair(it, "g") },
                         )
                     if (sugarNutrients.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(12.dp))
@@ -231,21 +244,21 @@ fun FoodDetailScreen(
                     // Minerals
                     val mineralNutrients =
                         listOfNotNull(
-                            f.sodium?.let { "Sodium" to Pair(it, "mg") },
-                            f.potassium?.let { "Potassium" to Pair(it, "mg") },
-                            f.calcium?.let { "Calcium" to Pair(it, "mg") },
-                            f.iron?.let { "Iron" to Pair(it, "mg") },
-                            f.magnesium?.let { "Magnesium" to Pair(it, "mg") },
-                            f.phosphorus?.let { "Phosphorus" to Pair(it, "mg") },
-                            f.zinc?.let { "Zinc" to Pair(it, "mg") },
-                            f.copper?.let { "Copper" to Pair(it, "mg") },
-                            f.manganese?.let { "Manganese" to Pair(it, "mg") },
-                            f.selenium?.let { "Selenium" to Pair(it, "mcg") },
-                            f.iodine?.let { "Iodine" to Pair(it, "mcg") },
-                            f.fluoride?.let { "Fluoride" to Pair(it, "mg") },
-                            f.chromium?.let { "Chromium" to Pair(it, "mcg") },
-                            f.molybdenum?.let { "Molybdenum" to Pair(it, "mcg") },
-                            f.chloride?.let { "Chloride" to Pair(it, "mg") },
+                            f.sodium?.takeIf { vn == null || "sodium" in vn }?.let { "Sodium" to Pair(it, "mg") },
+                            f.potassium?.takeIf { vn == null || "potassium" in vn }?.let { "Potassium" to Pair(it, "mg") },
+                            f.calcium?.takeIf { vn == null || "calcium" in vn }?.let { "Calcium" to Pair(it, "mg") },
+                            f.iron?.takeIf { vn == null || "iron" in vn }?.let { "Iron" to Pair(it, "mg") },
+                            f.magnesium?.takeIf { vn == null || "magnesium" in vn }?.let { "Magnesium" to Pair(it, "mg") },
+                            f.phosphorus?.takeIf { vn == null || "phosphorus" in vn }?.let { "Phosphorus" to Pair(it, "mg") },
+                            f.zinc?.takeIf { vn == null || "zinc" in vn }?.let { "Zinc" to Pair(it, "mg") },
+                            f.copper?.takeIf { vn == null || "copper" in vn }?.let { "Copper" to Pair(it, "mg") },
+                            f.manganese?.takeIf { vn == null || "manganese" in vn }?.let { "Manganese" to Pair(it, "mg") },
+                            f.selenium?.takeIf { vn == null || "selenium" in vn }?.let { "Selenium" to Pair(it, "mcg") },
+                            f.iodine?.takeIf { vn == null || "iodine" in vn }?.let { "Iodine" to Pair(it, "mcg") },
+                            f.fluoride?.takeIf { vn == null || "fluoride" in vn }?.let { "Fluoride" to Pair(it, "mg") },
+                            f.chromium?.takeIf { vn == null || "chromium" in vn }?.let { "Chromium" to Pair(it, "mcg") },
+                            f.molybdenum?.takeIf { vn == null || "molybdenum" in vn }?.let { "Molybdenum" to Pair(it, "mcg") },
+                            f.chloride?.takeIf { vn == null || "chloride" in vn }?.let { "Chloride" to Pair(it, "mg") },
                         )
                     if (mineralNutrients.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(12.dp))
@@ -255,19 +268,19 @@ fun FoodDetailScreen(
                     // Vitamins
                     val vitaminNutrients =
                         listOfNotNull(
-                            f.vitaminA?.let { "Vitamin A" to Pair(it, "mcg") },
-                            f.vitaminC?.let { "Vitamin C" to Pair(it, "mg") },
-                            f.vitaminD?.let { "Vitamin D" to Pair(it, "mcg") },
-                            f.vitaminE?.let { "Vitamin E" to Pair(it, "mg") },
-                            f.vitaminK?.let { "Vitamin K" to Pair(it, "mcg") },
-                            f.vitaminB1?.let { "Vitamin B1" to Pair(it, "mg") },
-                            f.vitaminB2?.let { "Vitamin B2" to Pair(it, "mg") },
-                            f.vitaminB3?.let { "Vitamin B3" to Pair(it, "mg") },
-                            f.vitaminB5?.let { "Vitamin B5" to Pair(it, "mg") },
-                            f.vitaminB6?.let { "Vitamin B6" to Pair(it, "mg") },
-                            f.vitaminB7?.let { "Vitamin B7" to Pair(it, "mcg") },
-                            f.vitaminB9?.let { "Vitamin B9" to Pair(it, "mcg") },
-                            f.vitaminB12?.let { "Vitamin B12" to Pair(it, "mcg") },
+                            f.vitaminA?.takeIf { vn == null || "vitaminA" in vn }?.let { "Vitamin A" to Pair(it, "mcg") },
+                            f.vitaminC?.takeIf { vn == null || "vitaminC" in vn }?.let { "Vitamin C" to Pair(it, "mg") },
+                            f.vitaminD?.takeIf { vn == null || "vitaminD" in vn }?.let { "Vitamin D" to Pair(it, "mcg") },
+                            f.vitaminE?.takeIf { vn == null || "vitaminE" in vn }?.let { "Vitamin E" to Pair(it, "mg") },
+                            f.vitaminK?.takeIf { vn == null || "vitaminK" in vn }?.let { "Vitamin K" to Pair(it, "mcg") },
+                            f.vitaminB1?.takeIf { vn == null || "vitaminB1" in vn }?.let { "Vitamin B1" to Pair(it, "mg") },
+                            f.vitaminB2?.takeIf { vn == null || "vitaminB2" in vn }?.let { "Vitamin B2" to Pair(it, "mg") },
+                            f.vitaminB3?.takeIf { vn == null || "vitaminB3" in vn }?.let { "Vitamin B3" to Pair(it, "mg") },
+                            f.vitaminB5?.takeIf { vn == null || "vitaminB5" in vn }?.let { "Vitamin B5" to Pair(it, "mg") },
+                            f.vitaminB6?.takeIf { vn == null || "vitaminB6" in vn }?.let { "Vitamin B6" to Pair(it, "mg") },
+                            f.vitaminB7?.takeIf { vn == null || "vitaminB7" in vn }?.let { "Vitamin B7" to Pair(it, "mcg") },
+                            f.vitaminB9?.takeIf { vn == null || "vitaminB9" in vn }?.let { "Vitamin B9" to Pair(it, "mcg") },
+                            f.vitaminB12?.takeIf { vn == null || "vitaminB12" in vn }?.let { "Vitamin B12" to Pair(it, "mcg") },
                         )
                     if (vitaminNutrients.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(12.dp))
@@ -277,10 +290,10 @@ fun FoodDetailScreen(
                     // Other
                     val otherNutrients =
                         listOfNotNull(
-                            f.caffeine?.let { "Caffeine" to Pair(it, "mg") },
-                            f.alcohol?.let { "Alcohol" to Pair(it, "g") },
-                            f.water?.let { "Water" to Pair(it, "ml") },
-                            f.salt?.let { "Salt" to Pair(it, "g") },
+                            f.caffeine?.takeIf { vn == null || "caffeine" in vn }?.let { "Caffeine" to Pair(it, "mg") },
+                            f.alcohol?.takeIf { vn == null || "alcohol" in vn }?.let { "Alcohol" to Pair(it, "g") },
+                            f.water?.takeIf { vn == null || "water" in vn }?.let { "Water" to Pair(it, "ml") },
+                            f.salt?.takeIf { vn == null || "salt" in vn }?.let { "Salt" to Pair(it, "g") },
                         )
                     if (otherNutrients.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(12.dp))

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -24,7 +25,9 @@ import com.bissbilanz.auth.AuthManager
 import com.bissbilanz.model.Goals
 import com.bissbilanz.model.MealType
 import com.bissbilanz.model.MealTypeCreate
+import com.bissbilanz.model.PreferencesUpdate
 import com.bissbilanz.repository.GoalsRepository
+import com.bissbilanz.repository.PreferencesRepository
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
@@ -32,8 +35,10 @@ import org.koin.compose.koinInject
 fun SettingsScreen(navController: NavController) {
     val authManager: AuthManager = koinInject()
     val goalsRepo: GoalsRepository = koinInject()
+    val prefsRepo: PreferencesRepository = koinInject()
     val api: BissbilanzApi = koinInject()
     val goals by goalsRepo.goals.collectAsStateWithLifecycle()
+    val prefs by prefsRepo.preferences.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     var showGoalsDialog by remember { mutableStateOf(false) }
@@ -41,9 +46,18 @@ fun SettingsScreen(navController: NavController) {
     var showCreateFoodSheet by remember { mutableStateOf(false) }
     var showCreateRecipeSheet by remember { mutableStateOf(false) }
     var customMealTypes by remember { mutableStateOf<List<MealType>>(emptyList()) }
+    var editedNutrients by remember { mutableStateOf<Set<String>?>(null) }
+    var nutrientsDirty by remember { mutableStateOf(false) }
+
+    LaunchedEffect(prefs) {
+        if (editedNutrients == null && prefs != null) {
+            editedNutrients = prefs!!.visibleNutrients.toSet()
+        }
+    }
 
     LaunchedEffect(Unit) {
         goalsRepo.loadGoals()
+        prefsRepo.loadPreferences()
         try {
             val response = api.getMealTypes()
             customMealTypes = response.mealTypes
@@ -257,6 +271,218 @@ fun SettingsScreen(navController: NavController) {
 
             Spacer(modifier = Modifier.height(12.dp))
 
+            // Dashboard Widgets
+            prefs?.let { p ->
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            "Dashboard Widgets",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        WidgetToggle("Chart", p.showChartWidget) { value ->
+                            scope.launch {
+                                try {
+                                    prefsRepo.updatePreferences(PreferencesUpdate(showChartWidget = value))
+                                } catch (_: Exception) {
+                                    snackbarHostState.showSnackbar("Failed to update preference")
+                                }
+                            }
+                        }
+                        WidgetToggle("Favorites", p.showFavoritesWidget) { value ->
+                            scope.launch {
+                                try {
+                                    prefsRepo.updatePreferences(PreferencesUpdate(showFavoritesWidget = value))
+                                } catch (_: Exception) {
+                                    snackbarHostState.showSnackbar("Failed to update preference")
+                                }
+                            }
+                        }
+                        WidgetToggle("Supplements", p.showSupplementsWidget) { value ->
+                            scope.launch {
+                                try {
+                                    prefsRepo.updatePreferences(PreferencesUpdate(showSupplementsWidget = value))
+                                } catch (_: Exception) {
+                                    snackbarHostState.showSnackbar("Failed to update preference")
+                                }
+                            }
+                        }
+                        WidgetToggle("Weight", p.showWeightWidget) { value ->
+                            scope.launch {
+                                try {
+                                    prefsRepo.updatePreferences(PreferencesUpdate(showWeightWidget = value))
+                                } catch (_: Exception) {
+                                    snackbarHostState.showSnackbar("Failed to update preference")
+                                }
+                            }
+                        }
+                        WidgetToggle("Meal Breakdown", p.showMealBreakdownWidget) { value ->
+                            scope.launch {
+                                try {
+                                    prefsRepo.updatePreferences(PreferencesUpdate(showMealBreakdownWidget = value))
+                                } catch (_: Exception) {
+                                    snackbarHostState.showSnackbar("Failed to update preference")
+                                }
+                            }
+                        }
+                        WidgetToggle("Top Foods", p.showTopFoodsWidget) { value ->
+                            scope.launch {
+                                try {
+                                    prefsRepo.updatePreferences(PreferencesUpdate(showTopFoodsWidget = value))
+                                } catch (_: Exception) {
+                                    snackbarHostState.showSnackbar("Failed to update preference")
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Favorite Logging
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            "Favorite Logging",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = p.favoriteMealAssignmentMode == "time_based",
+                                onClick = {
+                                    scope.launch {
+                                        try {
+                                            prefsRepo.updatePreferences(
+                                                PreferencesUpdate(favoriteMealAssignmentMode = "time_based"),
+                                            )
+                                            snackbarHostState.showSnackbar("Meal assignment updated")
+                                        } catch (_: Exception) {
+                                            snackbarHostState.showSnackbar("Failed to update preference")
+                                        }
+                                    }
+                                },
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Auto-assign by time")
+                        }
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = p.favoriteMealAssignmentMode == "ask_meal",
+                                onClick = {
+                                    scope.launch {
+                                        try {
+                                            prefsRepo.updatePreferences(
+                                                PreferencesUpdate(favoriteMealAssignmentMode = "ask_meal"),
+                                            )
+                                            snackbarHostState.showSnackbar("Meal assignment updated")
+                                        } catch (_: Exception) {
+                                            snackbarHostState.showSnackbar("Failed to update preference")
+                                        }
+                                    }
+                                },
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Always ask")
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Visible Nutrients
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            "Visible Nutrients",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            "Choose which nutrients to display on food detail pages",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            OutlinedButton(
+                                onClick = {
+                                    editedNutrients = ALL_NUTRIENT_KEYS.toSet()
+                                    nutrientsDirty = true
+                                },
+                                modifier = Modifier.weight(1f),
+                            ) { Text("Select All") }
+                            OutlinedButton(
+                                onClick = {
+                                    editedNutrients = emptySet()
+                                    nutrientsDirty = true
+                                },
+                                modifier = Modifier.weight(1f),
+                            ) { Text("Deselect All") }
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                        editedNutrients?.let { selected ->
+                            NUTRIENT_CATEGORIES.forEach { (category, nutrients) ->
+                                Text(
+                                    category,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    fontWeight = FontWeight.SemiBold,
+                                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
+                                )
+                                nutrients.forEach { (key, label) ->
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Checkbox(
+                                            checked = key in selected,
+                                            onCheckedChange = { checked ->
+                                                editedNutrients = if (checked) selected + key else selected - key
+                                                nutrientsDirty = true
+                                            },
+                                        )
+                                        Text(label, style = MaterialTheme.typography.bodyMedium)
+                                    }
+                                }
+                            }
+                        }
+                        if (nutrientsDirty) {
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Button(
+                                onClick = {
+                                    scope.launch {
+                                        try {
+                                            prefsRepo.updatePreferences(
+                                                PreferencesUpdate(visibleNutrients = editedNutrients?.toList() ?: emptyList()),
+                                            )
+                                            nutrientsDirty = false
+                                            snackbarHostState.showSnackbar("Visible nutrients updated")
+                                        } catch (_: Exception) {
+                                            snackbarHostState.showSnackbar("Failed to update nutrients")
+                                        }
+                                    }
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                            ) { Text("Save") }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
             // Account
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp)) {
@@ -366,3 +592,128 @@ fun GoalTextField(
         colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = color, focusedLabelColor = color),
     )
 }
+
+@Composable
+fun WidgetToggle(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+val ALL_NUTRIENT_KEYS =
+    listOf(
+        "saturatedFat",
+        "monounsaturatedFat",
+        "polyunsaturatedFat",
+        "transFat",
+        "cholesterol",
+        "omega3",
+        "omega6",
+        "sugar",
+        "addedSugars",
+        "sugarAlcohols",
+        "starch",
+        "sodium",
+        "potassium",
+        "calcium",
+        "iron",
+        "magnesium",
+        "phosphorus",
+        "zinc",
+        "copper",
+        "manganese",
+        "selenium",
+        "iodine",
+        "fluoride",
+        "chromium",
+        "molybdenum",
+        "chloride",
+        "vitaminA",
+        "vitaminC",
+        "vitaminD",
+        "vitaminE",
+        "vitaminK",
+        "vitaminB1",
+        "vitaminB2",
+        "vitaminB3",
+        "vitaminB5",
+        "vitaminB6",
+        "vitaminB7",
+        "vitaminB9",
+        "vitaminB12",
+        "caffeine",
+        "alcohol",
+        "water",
+        "salt",
+    )
+
+val NUTRIENT_CATEGORIES =
+    listOf(
+        "Fat Breakdown" to
+            listOf(
+                "saturatedFat" to "Saturated Fat",
+                "monounsaturatedFat" to "Monounsaturated Fat",
+                "polyunsaturatedFat" to "Polyunsaturated Fat",
+                "transFat" to "Trans Fat",
+                "cholesterol" to "Cholesterol",
+                "omega3" to "Omega-3",
+                "omega6" to "Omega-6",
+            ),
+        "Sugar & Carbs" to
+            listOf(
+                "sugar" to "Sugar",
+                "addedSugars" to "Added Sugars",
+                "sugarAlcohols" to "Sugar Alcohols",
+                "starch" to "Starch",
+            ),
+        "Minerals" to
+            listOf(
+                "sodium" to "Sodium",
+                "potassium" to "Potassium",
+                "calcium" to "Calcium",
+                "iron" to "Iron",
+                "magnesium" to "Magnesium",
+                "phosphorus" to "Phosphorus",
+                "zinc" to "Zinc",
+                "copper" to "Copper",
+                "manganese" to "Manganese",
+                "selenium" to "Selenium",
+                "iodine" to "Iodine",
+                "fluoride" to "Fluoride",
+                "chromium" to "Chromium",
+                "molybdenum" to "Molybdenum",
+                "chloride" to "Chloride",
+            ),
+        "Vitamins" to
+            listOf(
+                "vitaminA" to "Vitamin A",
+                "vitaminC" to "Vitamin C",
+                "vitaminD" to "Vitamin D",
+                "vitaminE" to "Vitamin E",
+                "vitaminK" to "Vitamin K",
+                "vitaminB1" to "Vitamin B1",
+                "vitaminB2" to "Vitamin B2",
+                "vitaminB3" to "Vitamin B3",
+                "vitaminB5" to "Vitamin B5",
+                "vitaminB6" to "Vitamin B6",
+                "vitaminB7" to "Vitamin B7",
+                "vitaminB9" to "Vitamin B9",
+                "vitaminB12" to "Vitamin B12",
+            ),
+        "Other" to
+            listOf(
+                "caffeine" to "Caffeine",
+                "alcohol" to "Alcohol",
+                "water" to "Water",
+                "salt" to "Salt",
+            ),
+    )

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ security-crypto = "1.1.0-alpha06"
 activity-compose = "1.9.3"
 lifecycle = "2.8.7"
 material3 = "1.3.1"
+sentry-android = "7.19.1"
 
 [libraries]
 # Compose
@@ -70,6 +71,9 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 
 # Health Connect
 health-connect = { group = "androidx.health.connect", name = "connect-client", version.ref = "health-connect" }
+
+# Sentry
+sentry-android = { group = "io.sentry", name = "sentry-android", version.ref = "sentry-android" }
 
 # Testing
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
@@ -20,4 +20,5 @@ val sharedModule =
         single { WeightRepository(get()) }
         single { SupplementRepository(get()) }
         single { StatsRepository(get()) }
+        single { PreferencesRepository(get()) }
     }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
@@ -1,0 +1,25 @@
+package com.bissbilanz.repository
+
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.model.Preferences
+import com.bissbilanz.model.PreferencesUpdate
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class PreferencesRepository(
+    private val api: BissbilanzApi,
+) {
+    private val _preferences = MutableStateFlow<Preferences?>(null)
+    val preferences: StateFlow<Preferences?> = _preferences.asStateFlow()
+
+    suspend fun loadPreferences() {
+        _preferences.value = api.getPreferences()
+    }
+
+    suspend fun updatePreferences(update: PreferencesUpdate): Preferences {
+        val updated = api.updatePreferences(update)
+        _preferences.value = updated
+        return updated
+    }
+}

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -98,6 +98,14 @@ export function handleApiError(error: unknown): Response {
  * @param locals - SvelteKit locals object
  * @returns User ID
  */
+export async function parseJsonBody(request: Request): Promise<unknown> {
+	try {
+		return await request.json();
+	} catch {
+		throw new ApiError(400, 'Invalid JSON body');
+	}
+}
+
 export function requireAuth(locals: App.Locals): string {
 	if (!locals.user) {
 		throw new ApiError(401, 'Unauthorized');

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -92,12 +92,6 @@ export function handleApiError(error: unknown): Response {
 	return json({ error: 'Internal server error' }, { status: 500 });
 }
 
-/**
- * Checks if user is authenticated and returns user ID
- * Throws ApiError if not authenticated
- * @param locals - SvelteKit locals object
- * @returns User ID
- */
 export async function parseJsonBody(request: Request): Promise<unknown> {
 	try {
 		return await request.json();
@@ -106,6 +100,12 @@ export async function parseJsonBody(request: Request): Promise<unknown> {
 	}
 }
 
+/**
+ * Checks if user is authenticated and returns user ID
+ * Throws ApiError if not authenticated
+ * @param locals - SvelteKit locals object
+ * @returns User ID
+ */
 export function requireAuth(locals: App.Locals): string {
 	if (!locals.user) {
 		throw new ApiError(401, 'Unauthorized');

--- a/src/routes/api/entries/+server.ts
+++ b/src/routes/api/entries/+server.ts
@@ -2,7 +2,13 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createEntry, listEntriesByDate } from '$lib/server/entries';
 import { paginationSchema } from '$lib/server/validation';
-import { handleApiError, requireAuth, unwrapResult, validationError } from '$lib/server/errors';
+import {
+	handleApiError,
+	requireAuth,
+	unwrapResult,
+	validationError,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
 	try {
@@ -32,7 +38,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 
 		const entry = unwrapResult(await createEntry(userId, body));
 		return json({ entry }, { status: 201 });

--- a/src/routes/api/entries/[id]/+server.ts
+++ b/src/routes/api/entries/[id]/+server.ts
@@ -1,12 +1,18 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { deleteEntry, updateEntry } from '$lib/server/entries';
-import { handleApiError, notFound, requireAuth, unwrapResult } from '$lib/server/errors';
+import {
+	handleApiError,
+	notFound,
+	requireAuth,
+	unwrapResult,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const PATCH: RequestHandler = async ({ locals, request, params }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const entry = unwrapResult(await updateEntry(userId, params.id, body));
 		if (!entry) {
 			return notFound('Entry');

--- a/src/routes/api/foods/+server.ts
+++ b/src/routes/api/foods/+server.ts
@@ -2,7 +2,13 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createFood, findFoodByBarcode, listFoods } from '$lib/server/foods';
 import { paginationSchema } from '$lib/server/validation';
-import { handleApiError, requireAuth, unwrapResult, validationError } from '$lib/server/errors';
+import {
+	handleApiError,
+	requireAuth,
+	unwrapResult,
+	validationError,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
 	try {
@@ -39,7 +45,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const food = unwrapResult(await createFood(userId, body));
 		return json({ food }, { status: 201 });
 	} catch (error) {

--- a/src/routes/api/foods/[id]/+server.ts
+++ b/src/routes/api/foods/[id]/+server.ts
@@ -1,7 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { deleteFood, getFood, updateFood } from '$lib/server/foods';
-import { handleApiError, notFound, requireAuth, unwrapResult } from '$lib/server/errors';
+import {
+	handleApiError,
+	notFound,
+	requireAuth,
+	unwrapResult,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals, params }) => {
 	try {
@@ -19,7 +25,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 export const PATCH: RequestHandler = async ({ locals, request, params }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const food = unwrapResult(await updateFood(userId, params.id, body));
 		if (!food) {
 			return notFound('Food');

--- a/src/routes/api/goals/+server.ts
+++ b/src/routes/api/goals/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getGoals, upsertGoals } from '$lib/server/goals';
-import { handleApiError, requireAuth, unwrapResult } from '$lib/server/errors';
+import { handleApiError, requireAuth, unwrapResult, parseJsonBody } from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals }) => {
 	try {
@@ -16,7 +16,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const goals = unwrapResult(await upsertGoals(userId, body));
 		return json({ goals });
 	} catch (error) {

--- a/src/routes/api/meal-types/+server.ts
+++ b/src/routes/api/meal-types/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createMealType, listMealTypes } from '$lib/server/meal-types';
-import { handleApiError, requireAuth, unwrapResult } from '$lib/server/errors';
+import { handleApiError, requireAuth, unwrapResult, parseJsonBody } from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals }) => {
 	try {
@@ -16,7 +16,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const mealType = unwrapResult(await createMealType(userId, body));
 		return json({ mealType }, { status: 201 });
 	} catch (error) {

--- a/src/routes/api/meal-types/[id]/+server.ts
+++ b/src/routes/api/meal-types/[id]/+server.ts
@@ -1,12 +1,18 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { deleteMealType, updateMealType } from '$lib/server/meal-types';
-import { handleApiError, notFound, requireAuth, unwrapResult } from '$lib/server/errors';
+import {
+	handleApiError,
+	notFound,
+	requireAuth,
+	unwrapResult,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const mealType = unwrapResult(await updateMealType(userId, params.id, body));
 		if (!mealType) {
 			return notFound('Meal type');

--- a/src/routes/api/preferences/+server.ts
+++ b/src/routes/api/preferences/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getPreferences, updatePreferences, DEFAULT_PREFERENCES } from '$lib/server/preferences';
-import { handleApiError, requireAuth, unwrapResult } from '$lib/server/errors';
+import { handleApiError, requireAuth, unwrapResult, parseJsonBody } from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals }) => {
 	try {
@@ -16,7 +16,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 export const PATCH: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 
 		const preferences = unwrapResult(await updatePreferences(userId, body));
 		return json({ preferences });

--- a/src/routes/api/recipes/+server.ts
+++ b/src/routes/api/recipes/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createRecipe, listRecipes } from '$lib/server/recipes';
-import { handleApiError, requireAuth, unwrapResult } from '$lib/server/errors';
+import { handleApiError, requireAuth, unwrapResult, parseJsonBody } from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals }) => {
 	try {
@@ -16,7 +16,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 
 		const recipe = unwrapResult(await createRecipe(userId, body));
 		return json({ recipe }, { status: 201 });

--- a/src/routes/api/recipes/[id]/+server.ts
+++ b/src/routes/api/recipes/[id]/+server.ts
@@ -1,7 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { deleteRecipe, getRecipe, updateRecipe } from '$lib/server/recipes';
-import { handleApiError, notFound, requireAuth, unwrapResult } from '$lib/server/errors';
+import {
+	handleApiError,
+	notFound,
+	requireAuth,
+	unwrapResult,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals, params }) => {
 	try {
@@ -19,7 +25,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const recipe = unwrapResult(await updateRecipe(userId, params.id, body));
 		if (!recipe) {
 			return notFound('Recipe');

--- a/src/routes/api/supplements/+server.ts
+++ b/src/routes/api/supplements/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { listSupplements, createSupplement } from '$lib/server/supplements';
-import { handleApiError, requireAuth, unwrapResult } from '$lib/server/errors';
+import { handleApiError, requireAuth, unwrapResult, parseJsonBody } from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
 	try {
@@ -17,7 +17,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const supplement = unwrapResult(await createSupplement(userId, body));
 		return json({ supplement }, { status: 201 });
 	} catch (error) {

--- a/src/routes/api/supplements/[id]/+server.ts
+++ b/src/routes/api/supplements/[id]/+server.ts
@@ -1,7 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getSupplementById, updateSupplement, deleteSupplement } from '$lib/server/supplements';
-import { handleApiError, notFound, requireAuth, unwrapResult } from '$lib/server/errors';
+import {
+	handleApiError,
+	notFound,
+	requireAuth,
+	unwrapResult,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals, params }) => {
 	try {
@@ -19,7 +25,7 @@ export const GET: RequestHandler = async ({ locals, params }) => {
 export const PUT: RequestHandler = async ({ locals, params, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const supplement = unwrapResult(await updateSupplement(userId, params.id, body));
 		if (!supplement) {
 			return notFound('Supplement');

--- a/src/routes/api/supplements/[id]/log/+server.ts
+++ b/src/routes/api/supplements/[id]/log/+server.ts
@@ -3,12 +3,12 @@ import type { RequestHandler } from './$types';
 import { logSupplement } from '$lib/server/supplements';
 import { supplementLogSchema } from '$lib/server/validation';
 import { today } from '$lib/utils/dates';
-import { handleApiError, requireAuth, validationError } from '$lib/server/errors';
+import { handleApiError, requireAuth, validationError, parseJsonBody } from '$lib/server/errors';
 
 export const POST: RequestHandler = async ({ locals, params, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json().catch(() => ({}));
+		const body = await parseJsonBody(request);
 
 		const parsed = supplementLogSchema.safeParse(body);
 		if (!parsed.success) {

--- a/src/routes/api/supplements/[id]/log/+server.ts
+++ b/src/routes/api/supplements/[id]/log/+server.ts
@@ -8,7 +8,7 @@ import { handleApiError, requireAuth, validationError, parseJsonBody } from '$li
 export const POST: RequestHandler = async ({ locals, params, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await parseJsonBody(request);
+		const body = await parseJsonBody(request).catch(() => ({}));
 
 		const parsed = supplementLogSchema.safeParse(body);
 		if (!parsed.success) {

--- a/src/routes/api/weight/+server.ts
+++ b/src/routes/api/weight/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getWeightEntries, getWeightWithTrend, createWeightEntry } from '$lib/server/weight';
-import { handleApiError, requireAuth, unwrapResult } from '$lib/server/errors';
+import { handleApiError, requireAuth, unwrapResult, parseJsonBody } from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
 	try {
@@ -24,7 +24,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const entry = unwrapResult(await createWeightEntry(userId, body));
 		return json({ entry }, { status: 201 });
 	} catch (error) {

--- a/src/routes/api/weight/[id]/+server.ts
+++ b/src/routes/api/weight/[id]/+server.ts
@@ -1,12 +1,18 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { updateWeightEntry, deleteWeightEntry } from '$lib/server/weight';
-import { handleApiError, notFound, requireAuth, unwrapResult } from '$lib/server/errors';
+import {
+	handleApiError,
+	notFound,
+	requireAuth,
+	unwrapResult,
+	parseJsonBody
+} from '$lib/server/errors';
 
 export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 	try {
 		const userId = requireAuth(locals);
-		const body = await request.json();
+		const body = await parseJsonBody(request);
 		const entry = unwrapResult(await updateWeightEntry(userId, params.id, body));
 		if (!entry) {
 			return notFound('Weight entry');


### PR DESCRIPTION
## Summary
- Adds `parseJsonBody` helper to `src/lib/server/errors.ts` that wraps `request.json()` and throws `ApiError(400)` on parse failure
- Replaces bare `await request.json()` in all 15 API mutation routes with `parseJsonBody(request)`
- Previously, malformed JSON caused an unhandled exception resulting in a 500 Internal Server Error

## Test plan
- [ ] Send malformed JSON to any mutation endpoint and verify 400 response with `"Invalid JSON body"` message
- [ ] Send valid JSON and verify normal behavior is unchanged
- [ ] Verify `bun run check` passes with 0 errors

Closes #74