### PR TITLE
fix: wrap recipe and oauth operations in transactions

### DIFF
--- a/src/lib/server/oauth.ts
+++ b/src/lib/server/oauth.ts
@@ -385,12 +385,16 @@ export async function listAuthorizedClients(
 
 export async function revokeAuthorization(userId: string, clientId: string): Promise<void> {
 	const db = getDB();
-	await db
-		.delete(oauthAuthorizations)
-		.where(and(eq(oauthAuthorizations.userId, userId), eq(oauthAuthorizations.clientId, clientId)));
-	await db
-		.delete(oauthTokens)
-		.where(and(eq(oauthTokens.clientId, clientId), eq(oauthTokens.userId, userId)));
+	await db.transaction(async (tx) => {
+		await tx
+			.delete(oauthAuthorizations)
+			.where(
+				and(eq(oauthAuthorizations.userId, userId), eq(oauthAuthorizations.clientId, clientId))
+			);
+		await tx
+			.delete(oauthTokens)
+			.where(and(eq(oauthTokens.clientId, clientId), eq(oauthTokens.userId, userId)));
+	});
 }
 
 export async function revokeClientTokens(clientId: string): Promise<void> {

--- a/src/lib/server/recipes.ts
+++ b/src/lib/server/recipes.ts
@@ -54,24 +54,27 @@ export const createRecipe = async (
 
 	try {
 		const db = getDB();
-		const [recipe] = await db
-			.insert(recipes)
-			.values(toRecipeInsert(userId, result.data))
-			.returning();
+		const recipe = await db.transaction(async (tx) => {
+			const [created] = await tx
+				.insert(recipes)
+				.values(toRecipeInsert(userId, result.data))
+				.returning();
 
-		if (!recipe) {
-			return { success: false, error: new Error('Failed to create recipe') };
-		}
+			if (!created) {
+				throw new Error('Failed to create recipe');
+			}
 
-		const ingredientRows = result.data.ingredients.map((ingredient, index) => ({
-			recipeId: recipe.id,
-			foodId: ingredient.foodId,
-			quantity: ingredient.quantity,
-			servingUnit: ingredient.servingUnit,
-			sortOrder: index
-		}));
+			const ingredientRows = result.data.ingredients.map((ingredient, index) => ({
+				recipeId: created.id,
+				foodId: ingredient.foodId,
+				quantity: ingredient.quantity,
+				servingUnit: ingredient.servingUnit,
+				sortOrder: index
+			}));
 
-		await db.insert(recipeIngredients).values(ingredientRows);
+			await tx.insert(recipeIngredients).values(ingredientRows);
+			return created;
+		});
 		return { success: true, data: recipe };
 	} catch (error) {
 		return { success: false, error: error as Error };
@@ -110,23 +113,27 @@ export const updateRecipe = async (
 		const db = getDB();
 		const { ingredients, ...recipeData } = result.data;
 
-		const [recipe] = await db
-			.update(recipes)
-			.set({ ...recipeData, updatedAt: new Date() })
-			.where(and(eq(recipes.id, id), eq(recipes.userId, userId)))
-			.returning();
+		const recipe = await db.transaction(async (tx) => {
+			const [updated] = await tx
+				.update(recipes)
+				.set({ ...recipeData, updatedAt: new Date() })
+				.where(and(eq(recipes.id, id), eq(recipes.userId, userId)))
+				.returning();
 
-		if (ingredients && recipe) {
-			await db.delete(recipeIngredients).where(eq(recipeIngredients.recipeId, id));
-			const rows = ingredients.map((ingredient, index) => ({
-				recipeId: id,
-				foodId: ingredient.foodId,
-				quantity: ingredient.quantity,
-				servingUnit: ingredient.servingUnit,
-				sortOrder: index
-			}));
-			await db.insert(recipeIngredients).values(rows);
-		}
+			if (ingredients && updated) {
+				await tx.delete(recipeIngredients).where(eq(recipeIngredients.recipeId, id));
+				const rows = ingredients.map((ingredient, index) => ({
+					recipeId: id,
+					foodId: ingredient.foodId,
+					quantity: ingredient.quantity,
+					servingUnit: ingredient.servingUnit,
+					sortOrder: index
+				}));
+				await tx.insert(recipeIngredients).values(rows);
+			}
+
+			return updated;
+		});
 
 		return { success: true, data: recipe };
 	} catch (error) {


### PR DESCRIPTION
## Summary
- `createRecipe` now uses `db.transaction()` — prevents orphaned recipe rows if ingredient insert fails
- `updateRecipe` now uses `db.transaction()` — prevents recipes losing all ingredients on partial failure
- `revokeAuthorization` now uses `db.transaction()` — ensures authorization and token deletion are atomic

## Test plan
- [ ] Create a recipe with valid ingredients — verify it works as before
- [ ] Update a recipe's ingredients — verify old ingredients are replaced atomically
- [ ] Revoke an OAuth authorization — verify both authorization and tokens are deleted
- [ ] Verify `bun run check` passes with 0 errors

Closes #75