### PR TITLE
fix: exclude MCP routes from API rate limiting

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -151,7 +151,7 @@ const sessionHandle: Handle = async ({ event, resolve }) => {
 	}
 
 	// Rate limit authenticated API write requests
-	if (event.locals.user && pathname.startsWith('/api/')) {
+	if (event.locals.user && pathname.startsWith('/api/') && !isMcpRoute(pathname)) {
 		const method = event.request.method;
 		const userId = event.locals.user.id;
 		try {


### PR DESCRIPTION
## Summary
- MCP endpoints (`/api/mcp/*`, `/api/oauth/*`, `/.well-known/*`) are now excluded from the session-based API rate limiter
- These endpoints have their own auth flow via Bearer tokens and should not share rate limit buckets with regular API routes
- `rateLimitApi` and `rateLimitUpload` were already correctly wired to all other write endpoints

## Test plan
- [ ] Verify MCP tool calls are not rate-limited by the API limiter
- [ ] Verify regular API write requests are still rate-limited
- [ ] Verify `bun run check` passes with 0 errors

Closes #76