### PR TITLE
perf: add index on oauth_tokens.refresh_token_hash

### DIFF
--- a/drizzle/0025_tiny_miracleman.sql
+++ b/drizzle/0025_tiny_miracleman.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "idx_oauth_tokens_refresh_token_hash" ON "oauth_tokens" USING btree ("refresh_token_hash");

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "e07d1e35-85ce-4d66-abd3-42af73bd0351",
-  "prevId": "ad6ba0db-ae25-43d8-ad61-3867dc51cdfa",
+  "id": "c6a2a7c1-bf71-40d3-b7b6-0ddddb53dbfd",
+  "prevId": "e07d1e35-85ce-4d66-abd3-42af73bd0351",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1452,6 +1452,21 @@
           "columns": [
             {
               "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_refresh_token_hash": {
+          "name": "idx_oauth_tokens_refresh_token_hash",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
               "isExpression": false,
               "asc": true,
               "nulls": "last"

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1773360000000,
       "tag": "0024_seed_mobile_oauth_clients",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1773186230947,
+      "tag": "0025_tiny_miracleman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -517,7 +517,8 @@ export const oauthTokens = pgTable(
 		index('idx_oauth_tokens_client_id').on(table.clientId),
 		index('idx_oauth_tokens_user_id').on(table.userId),
 		index('idx_oauth_tokens_expires_at').on(table.expiresAt),
-		index('idx_oauth_tokens_access_token_hash').on(table.accessTokenHash)
+		index('idx_oauth_tokens_access_token_hash').on(table.accessTokenHash),
+		index('idx_oauth_tokens_refresh_token_hash').on(table.refreshTokenHash)
 	]
 );
 


### PR DESCRIPTION
## Summary
- Adds btree index `idx_oauth_tokens_refresh_token_hash` on `oauth_tokens.refresh_token_hash`
- Token refresh was doing a full table scan — now uses index lookup
- Also fixes a Drizzle snapshot collision between migrations 0023 and 0024 that prevented generating new migrations

## Test plan
- [ ] Verify migration `0025_tiny_miracleman.sql` applies cleanly on dev server start
- [ ] Verify token refresh still works correctly
- [ ] Verify `bun run check` passes with 0 errors

Closes #77