### PR TITLE
fix: add duplex: 'half' to fetch calls with Request body

### DIFF
--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -28,7 +28,7 @@ async function apiFetchRequest(request: Request): Promise<Response> {
 		});
 	}
 
-	return fetch(request);
+	return fetch(request, { duplex: 'half' } as RequestInit);
 }
 
 async function apiFetchString(url: string, options: RequestInit = {}): Promise<Response> {

--- a/tests/utils/api-fetch.test.ts
+++ b/tests/utils/api-fetch.test.ts
@@ -255,7 +255,7 @@ describe('apiFetch', () => {
 			const response = await apiFetch(request);
 
 			expect(response.status).toBe(200);
-			expect(fetchSpy).toHaveBeenCalledWith(request);
+			expect(fetchSpy).toHaveBeenCalledWith(request, { duplex: 'half' });
 		});
 
 		test('queues Request when offline', async () => {
@@ -300,7 +300,7 @@ describe('apiFetch', () => {
 			const request = new Request('http://localhost/api/foods');
 			await apiFetch(request);
 
-			expect(fetchSpy).toHaveBeenCalledWith(request);
+			expect(fetchSpy).toHaveBeenCalledWith(request, { duplex: 'half' });
 			expect(enqueue).not.toHaveBeenCalled();
 		});
 	});


### PR DESCRIPTION
Chrome enforces the Fetch spec requirement that requests with streaming
bodies must specify duplex: "half". When openapi-fetch passes a Request
object to our custom fetch wrapper, the body is treated as a
ReadableStream, causing TypeError on Chrome Mobile.

https://claude.ai/code/session_01WFgAkPGCQaEGF1yjb7HYFL