### PR TITLE
Make AddFoodModal open in full screen on mobile

### DIFF
--- a/src/lib/components/entries/AddFoodModal.svelte
+++ b/src/lib/components/entries/AddFoodModal.svelte
@@ -267,7 +267,7 @@
 	};
 </script>
 
-<ResponsiveModal bind:open title={m.add_food_title()}>
+<ResponsiveModal bind:open title={m.add_food_title()} openFull>
 	<div class="min-w-0 space-y-4">
 		{#if selectedFood}
 			<div class="space-y-4">


### PR DESCRIPTION
## Summary
Updated the AddFoodModal component to open in full screen mode on mobile devices by adding the `openFull` prop to the ResponsiveModal component.

## Changes
- Added `openFull` prop to `<ResponsiveModal>` in AddFoodModal.svelte to enable full-screen modal behavior on smaller screens

## Details
This change improves the mobile user experience by allowing the food addition modal to utilize the full available screen space on mobile devices, making it easier to interact with the form and reducing the need for scrolling within a constrained modal window.

https://claude.ai/code/session_01UKwnYbmm511aqfoaLedbs1