### PR TITLE
Increase left padding in WeightChart component

### DIFF
--- a/src/lib/components/weight/WeightChart.svelte
+++ b/src/lib/components/weight/WeightChart.svelte
@@ -288,7 +288,7 @@
 							x="dateLabel"
 							{series}
 							{yDomain}
-							padding={{ left: 16, bottom: 4 }}
+							padding={{ left: 36, bottom: 4 }}
 							tooltip={true}
 							axis={true}
 							grid={true}


### PR DESCRIPTION
## Summary
Adjusted the left padding of the chart in the WeightChart component to improve layout spacing.

## Changes
- Increased the left padding value from 16 to 36 pixels in the WeightChart component's chart configuration

## Details
This padding adjustment provides more space on the left side of the chart, likely to accommodate axis labels or improve overall visual balance of the weight chart visualization.

https://claude.ai/code/session_01KiBa1K4cx8aRvpsMqtw9gM