### PR TITLE
Fix boolean isFavorite queries using .filter() instead of .where()

### DIFF
--- a/src/lib/services/favorites-service.svelte.ts
+++ b/src/lib/services/favorites-service.svelte.ts
@@ -4,8 +4,8 @@ import { api } from '$lib/api/client';
 
 function favorites() {
 	return liveQuery(async () => {
-		const foods = await db.foods.where('isFavorite').equals(true).toArray();
-		const recipes = await db.recipes.where('isFavorite').equals(true).toArray();
+		const foods = await db.foods.filter((f) => f.isFavorite).toArray();
+		const recipes = await db.recipes.filter((r) => r.isFavorite).toArray();
 		return { foods, recipes };
 	});
 }

--- a/src/lib/services/favorites-service.svelte.ts
+++ b/src/lib/services/favorites-service.svelte.ts
@@ -4,8 +4,8 @@ import { api } from '$lib/api/client';
 
 function favorites() {
 	return liveQuery(async () => {
-		const foods = await db.foods.where('isFavorite').equals(1).toArray();
-		const recipes = await db.recipes.where('isFavorite').equals(1).toArray();
+		const foods = await db.foods.where('isFavorite').equals(true).toArray();
+		const recipes = await db.recipes.where('isFavorite').equals(true).toArray();
 		return { foods, recipes };
 	});
 }

--- a/src/lib/services/food-service.svelte.ts
+++ b/src/lib/services/food-service.svelte.ts
@@ -23,7 +23,7 @@ function search(query: string) {
 }
 
 function favorites() {
-	return liveQuery(() => db.foods.where('isFavorite').equals(1).toArray());
+	return liveQuery(() => db.foods.where('isFavorite').equals(true).toArray());
 }
 
 async function refresh() {

--- a/src/lib/services/food-service.svelte.ts
+++ b/src/lib/services/food-service.svelte.ts
@@ -23,7 +23,7 @@ function search(query: string) {
 }
 
 function favorites() {
-	return liveQuery(() => db.foods.where('isFavorite').equals(true).toArray());
+	return liveQuery(() => db.foods.filter((f) => f.isFavorite).toArray());
 }
 
 async function refresh() {

--- a/tests/services/favorites-service.test.ts
+++ b/tests/services/favorites-service.test.ts
@@ -16,9 +16,11 @@ type TestDB = Dexie & {
 
 function createTestDb(): TestDB {
 	const db = new Dexie('test-favorites-' + Math.random()) as TestDB;
+	// Mirror the production Dexie schema (including the isFavorite index)
+	// to reproduce the real environment where booleans in indexes cause issues
 	db.version(1).stores({
-		foods: 'id, name',
-		recipes: 'id, name'
+		foods: 'id, name, barcode, isFavorite, updatedAt',
+		recipes: 'id, name, isFavorite, updatedAt'
 	});
 	return db;
 }
@@ -153,6 +155,33 @@ describe('favorites Dexie queries use .filter() for boolean isFavorite', () => {
 		await db.foods.toCollection().modify({ isFavorite: false });
 
 		const results = await db.foods.filter((f) => f.isFavorite).toArray();
+		expect(results).toHaveLength(0);
+	});
+
+	test('filter correctly finds multiple favorites among many items', async () => {
+		await db.foods.bulkAdd([
+			makeFood({ id: 'f1', name: 'Apple', isFavorite: true }),
+			makeFood({ id: 'f2', name: 'Banana', isFavorite: false }),
+			makeFood({ id: 'f3', name: 'Chicken', isFavorite: true }),
+			makeFood({ id: 'f4', name: 'Donut', isFavorite: false }),
+			makeFood({ id: 'f5', name: 'Eggs', isFavorite: false })
+		]);
+
+		const results = await db.foods.filter((f) => f.isFavorite).toArray();
+		expect(results).toHaveLength(2);
+		expect(results.map((r) => r.name).sort()).toEqual(['Apple', 'Chicken']);
+	});
+
+	test('.where().equals(1) fails to find boolean true (regression guard)', async () => {
+		await db.foods.add(makeFood({ id: 'f1', isFavorite: true }));
+
+		// This is the OLD broken approach — booleans are not valid IndexedDB keys,
+		// so .where('isFavorite').equals(1) must not be used
+		const results = await db.foods
+			.where('isFavorite')
+			.equals(1)
+			.toArray()
+			.catch(() => []);
 		expect(results).toHaveLength(0);
 	});
 });

--- a/tests/services/favorites-service.test.ts
+++ b/tests/services/favorites-service.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import Dexie from 'dexie';
+import type { DexieFood, DexieRecipe } from '../../src/lib/db/types';
+
+/**
+ * Regression test: Dexie queries for isFavorite must use .filter()
+ * instead of .where().equals() because booleans are not valid IndexedDB
+ * index key types. Using .where('isFavorite').equals(1) or .equals(true)
+ * produces unreliable results.
+ */
+
+type TestDB = Dexie & {
+	foods: Dexie.Table<DexieFood, string>;
+	recipes: Dexie.Table<DexieRecipe, string>;
+};
+
+function createTestDb(): TestDB {
+	const db = new Dexie('test-favorites-' + Math.random()) as TestDB;
+	db.version(1).stores({
+		foods: 'id, name',
+		recipes: 'id, name'
+	});
+	return db;
+}
+
+const makeFood = (overrides: Partial<DexieFood> = {}): DexieFood => ({
+	id: 'food-1',
+	userId: 'user-1',
+	name: 'Test Food',
+	brand: null,
+	servingSize: 100,
+	servingUnit: 'g',
+	calories: 200,
+	protein: 10,
+	carbs: 20,
+	fat: 5,
+	fiber: 3,
+	saturatedFat: null,
+	monounsaturatedFat: null,
+	polyunsaturatedFat: null,
+	transFat: null,
+	cholesterol: null,
+	omega3: null,
+	omega6: null,
+	sugar: null,
+	addedSugars: null,
+	sugarAlcohols: null,
+	starch: null,
+	sodium: null,
+	potassium: null,
+	calcium: null,
+	iron: null,
+	magnesium: null,
+	phosphorus: null,
+	zinc: null,
+	copper: null,
+	manganese: null,
+	selenium: null,
+	iodine: null,
+	fluoride: null,
+	chromium: null,
+	molybdenum: null,
+	chloride: null,
+	vitaminA: null,
+	vitaminC: null,
+	vitaminD: null,
+	vitaminE: null,
+	vitaminK: null,
+	vitaminB1: null,
+	vitaminB2: null,
+	vitaminB3: null,
+	vitaminB5: null,
+	vitaminB6: null,
+	vitaminB7: null,
+	vitaminB9: null,
+	vitaminB12: null,
+	caffeine: null,
+	alcohol: null,
+	water: null,
+	salt: null,
+	barcode: null,
+	isFavorite: false,
+	nutriScore: null,
+	novaGroup: null,
+	additives: null,
+	ingredientsText: null,
+	imageUrl: null,
+	createdAt: null,
+	updatedAt: null,
+	...overrides
+});
+
+const makeRecipe = (overrides: Partial<DexieRecipe> = {}): DexieRecipe => ({
+	id: 'recipe-1',
+	userId: 'user-1',
+	name: 'Test Recipe',
+	totalServings: 1,
+	isFavorite: false,
+	imageUrl: null,
+	calories: null,
+	protein: null,
+	carbs: null,
+	fat: null,
+	fiber: null,
+	createdAt: null,
+	updatedAt: null,
+	...overrides
+});
+
+describe('favorites Dexie queries use .filter() for boolean isFavorite', () => {
+	let db: TestDB;
+
+	beforeEach(() => {
+		db = createTestDb();
+	});
+
+	afterEach(async () => {
+		await db.delete();
+	});
+
+	test('filter finds favorite foods stored with boolean true', async () => {
+		await db.foods.bulkAdd([
+			makeFood({ id: 'f1', name: 'Fav Food', isFavorite: true }),
+			makeFood({ id: 'f2', name: 'Normal Food', isFavorite: false })
+		]);
+
+		const results = await db.foods.filter((f) => f.isFavorite).toArray();
+		expect(results).toHaveLength(1);
+		expect(results[0].name).toBe('Fav Food');
+	});
+
+	test('filter finds favorite recipes stored with boolean true', async () => {
+		await db.recipes.bulkAdd([
+			makeRecipe({ id: 'r1', name: 'Fav Recipe', isFavorite: true }),
+			makeRecipe({ id: 'r2', name: 'Normal Recipe', isFavorite: false })
+		]);
+
+		const results = await db.recipes.filter((r) => r.isFavorite).toArray();
+		expect(results).toHaveLength(1);
+		expect(results[0].name).toBe('Fav Recipe');
+	});
+
+	test('filter finds favorites after update from false to true', async () => {
+		await db.foods.add(makeFood({ id: 'f1', isFavorite: false }));
+		await db.foods.update('f1', { isFavorite: true });
+
+		const results = await db.foods.filter((f) => f.isFavorite).toArray();
+		expect(results).toHaveLength(1);
+	});
+
+	test('filter returns empty when all favorites are cleared', async () => {
+		await db.foods.add(makeFood({ id: 'f1', isFavorite: true }));
+		await db.foods.toCollection().modify({ isFavorite: false });
+
+		const results = await db.foods.filter((f) => f.isFavorite).toArray();
+		expect(results).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary
Fixed unreliable Dexie queries for filtering favorite foods and recipes by replacing `.where('isFavorite').equals(1)` with `.filter((item) => item.isFavorite)`. This addresses a fundamental IndexedDB limitation where boolean values cannot be used as index key types, causing queries to produce unreliable results.

## Key Changes
- **favorites-service.svelte.ts**: Updated both foods and recipes queries to use `.filter()` instead of `.where().equals(1)`
- **food-service.svelte.ts**: Updated the favorites query to use `.filter()` instead of `.where().equals(1)`
- **Added comprehensive regression tests** in `favorites-service.test.ts` that:
  - Verify `.filter()` correctly finds favorite items stored with boolean `true`
  - Test both foods and recipes tables
  - Cover edge cases: updates from false to true, clearing all favorites, multiple favorites among many items
  - Include a regression guard test demonstrating that `.where().equals(1)` fails to find boolean values

## Implementation Details
The fix leverages Dexie's `.filter()` method which performs client-side filtering and works reliably with boolean values, unlike `.where()` which attempts to use IndexedDB indexes that don't support boolean key types. This is a safer approach that ensures consistent query results across all scenarios.

https://claude.ai/code/session_016ko9QRvYbDpRwh8uMa2K61