### PR TITLE
UI updates, SSR improvements, and Android widget + polish

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,26 @@
+## Design Context
+
+### Users
+
+Small user base (creator + friends/family). Used daily on mobile (PWA) and occasionally on desktop. Context: quick food logging throughout the day, reviewing progress in the evening. Users are already familiar with calorie/macro tracking concepts.
+
+### Brand Personality
+
+Premium, polished, reliable. Three words: **refined, purposeful, trustworthy**. The interface should feel like a well-crafted personal tool — not clinical, not playful. Quiet confidence.
+
+### Aesthetic Direction
+
+- Clean and functional with premium touches — not sterile
+- Existing conventions: shadcn-svelte components, Tailwind CSS 4, oklch color system
+- Macro color coding: Calories=Blue, Protein=Red, Carbs=Orange, Fat=Yellow, Fiber=Green
+- Light and dark mode support
+- Mobile-first PWA — touch-optimized, safe area handling
+- Anti-references: generic fitness app aesthetics, gamification, aggressive gradients
+
+### Design Principles
+
+1. **Data clarity over decoration** — every visual element should communicate, not just fill space
+2. **Fast to scan, fast to act** — the most common action (logging food) should feel instant
+3. **Consistent visual language** — macro colors, card patterns, and spacing should be predictable across all pages
+4. **Quiet hierarchy** — important information stands out through contrast and position, not size or color intensity
+5. **Touch-first confidence** — interactive elements should feel substantial and responsive on mobile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,3 +192,30 @@ feat: add food database CRUD endpoints
 fix: correct macro calculation for recipes
 refactor: extract macro calculation to utility function
 ```
+
+## Design Context
+
+### Users
+
+Small user base (creator + friends/family). Used daily on mobile (PWA) and occasionally on desktop. Context: quick food logging throughout the day, reviewing progress in the evening. Users are already familiar with calorie/macro tracking concepts.
+
+### Brand Personality
+
+Premium, polished, reliable. Three words: **refined, purposeful, trustworthy**. The interface should feel like a well-crafted personal tool — not clinical, not playful. Quiet confidence.
+
+### Aesthetic Direction
+
+- Clean and functional with premium touches — not sterile
+- Existing conventions: shadcn-svelte components, Tailwind CSS 4, oklch color system
+- Macro color coding: Calories=Blue, Protein=Red, Carbs=Orange, Fat=Yellow, Fiber=Green
+- Light and dark mode support
+- Mobile-first PWA — touch-optimized, safe area handling
+- Anti-references: generic fitness app aesthetics, gamification, aggressive gradients
+
+### Design Principles
+
+1. **Data clarity over decoration** — every visual element should communicate, not just fill space
+2. **Fast to scan, fast to act** — the most common action (logging food) should feel instant
+3. **Consistent visual language** — macro colors, card patterns, and spacing should be predictable across all pages
+4. **Quiet hierarchy** — important information stands out through contrast and position, not size or color intensity
+5. **Touch-first confidence** — interactive elements should feel substantial and responsive on mobile

--- a/drizzle/0030_blushing_titania.sql
+++ b/drizzle/0030_blushing_titania.sql
@@ -1,0 +1,2 @@
+DROP INDEX "idx_foods_image_url";--> statement-breakpoint
+DROP INDEX "idx_recipes_image_url";

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,2725 @@
+{
+  "id": "654fe1c1-6b55-4486-8a86-d5868bede0ae",
+  "prevId": "ec5c0568-8acb-4b4a-bedb-d19e90329968",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.custom_meal_types": {
+      "name": "custom_meal_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_meal_types_user_id": {
+          "name": "idx_custom_meal_types_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_meal_types_user_id_users_id_fk": {
+          "name": "custom_meal_types_user_id_users_id_fk",
+          "tableFrom": "custom_meal_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.day_properties": {
+      "name": "day_properties",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_fasting_day": {
+          "name": "is_fasting_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "day_properties_user_id_users_id_fk": {
+          "name": "day_properties_user_id_users_id_fk",
+          "tableFrom": "day_properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "day_properties_user_id_date_pk": {
+          "name": "day_properties_user_id_date_pk",
+          "columns": [
+            "user_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorite_meal_timeframes": {
+      "name": "favorite_meal_timeframes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_meal_type_id": {
+          "name": "custom_meal_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_favorite_meal_timeframes_user_id": {
+          "name": "idx_favorite_meal_timeframes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_favorite_meal_timeframes_custom_meal_type_id": {
+          "name": "idx_favorite_meal_timeframes_custom_meal_type_id",
+          "columns": [
+            {
+              "expression": "custom_meal_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorite_meal_timeframes_user_id_users_id_fk": {
+          "name": "favorite_meal_timeframes_user_id_users_id_fk",
+          "tableFrom": "favorite_meal_timeframes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorite_meal_timeframes_custom_meal_type_id_custom_meal_types_id_fk": {
+          "name": "favorite_meal_timeframes_custom_meal_type_id_custom_meal_types_id_fk",
+          "tableFrom": "favorite_meal_timeframes",
+          "tableTo": "custom_meal_types",
+          "columnsFrom": [
+            "custom_meal_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorite_meal_timeframes_minute_bounds": {
+          "name": "favorite_meal_timeframes_minute_bounds",
+          "value": "\"favorite_meal_timeframes\".\"start_minute\" >= 0 AND \"favorite_meal_timeframes\".\"start_minute\" <= 1439 AND \"favorite_meal_timeframes\".\"end_minute\" >= 1 AND \"favorite_meal_timeframes\".\"end_minute\" <= 1439"
+        },
+        "favorite_meal_timeframes_valid_range": {
+          "name": "favorite_meal_timeframes_valid_range",
+          "value": "\"favorite_meal_timeframes\".\"start_minute\" < \"favorite_meal_timeframes\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.food_entries": {
+      "name": "food_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_name": {
+          "name": "quick_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_calories": {
+          "name": "quick_calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_protein": {
+          "name": "quick_protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_carbs": {
+          "name": "quick_carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_fat": {
+          "name": "quick_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_fiber": {
+          "name": "quick_fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eaten_at": {
+          "name": "eaten_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_food_entries_user_date": {
+          "name": "idx_food_entries_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_food_id": {
+          "name": "idx_food_entries_food_id",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_recipe_id": {
+          "name": "idx_food_entries_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_created_at": {
+          "name": "idx_food_entries_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "food_entries_user_id_users_id_fk": {
+          "name": "food_entries_user_id_users_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "food_entries_food_id_foods_id_fk": {
+          "name": "food_entries_food_id_foods_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "food_entries_recipe_id_recipes_id_fk": {
+          "name": "food_entries_recipe_id_recipes_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "food_entries_servings_positive": {
+          "name": "food_entries_servings_positive",
+          "value": "\"food_entries\".\"servings\" > 0"
+        },
+        "food_entries_has_source": {
+          "name": "food_entries_has_source",
+          "value": "\"food_entries\".\"food_id\" IS NOT NULL OR \"food_entries\".\"recipe_id\" IS NOT NULL OR \"food_entries\".\"quick_calories\" IS NOT NULL"
+        },
+        "food_entries_meal_type_length": {
+          "name": "food_entries_meal_type_length",
+          "value": "length(\"food_entries\".\"meal_type\") > 0 AND length(\"food_entries\".\"meal_type\") <= 50"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.foods": {
+      "name": "foods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "serving_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saturated_fat": {
+          "name": "saturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monounsaturated_fat": {
+          "name": "monounsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polyunsaturated_fat": {
+          "name": "polyunsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trans_fat": {
+          "name": "trans_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cholesterol": {
+          "name": "cholesterol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega3": {
+          "name": "omega3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega6": {
+          "name": "omega6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_sugars": {
+          "name": "added_sugars",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar_alcohols": {
+          "name": "sugar_alcohols",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starch": {
+          "name": "starch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sodium": {
+          "name": "sodium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "potassium": {
+          "name": "potassium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calcium": {
+          "name": "calcium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iron": {
+          "name": "iron",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magnesium": {
+          "name": "magnesium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phosphorus": {
+          "name": "phosphorus",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zinc": {
+          "name": "zinc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copper": {
+          "name": "copper",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manganese": {
+          "name": "manganese",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selenium": {
+          "name": "selenium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iodine": {
+          "name": "iodine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fluoride": {
+          "name": "fluoride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chromium": {
+          "name": "chromium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "molybdenum": {
+          "name": "molybdenum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chloride": {
+          "name": "chloride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_a": {
+          "name": "vitamin_a",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_c": {
+          "name": "vitamin_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_d": {
+          "name": "vitamin_d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_e": {
+          "name": "vitamin_e",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_k": {
+          "name": "vitamin_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b1": {
+          "name": "vitamin_b1",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b2": {
+          "name": "vitamin_b2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b3": {
+          "name": "vitamin_b3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b5": {
+          "name": "vitamin_b5",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b6": {
+          "name": "vitamin_b6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b7": {
+          "name": "vitamin_b7",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b9": {
+          "name": "vitamin_b9",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b12": {
+          "name": "vitamin_b12",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caffeine": {
+          "name": "caffeine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alcohol": {
+          "name": "alcohol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "water": {
+          "name": "water",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nutri_score": {
+          "name": "nutri_score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nova_group": {
+          "name": "nova_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additives": {
+          "name": "additives",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingredients_text": {
+          "name": "ingredients_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_foods_user_id": {
+          "name": "idx_foods_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_barcode": {
+          "name": "idx_foods_barcode",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "barcode IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_user_name": {
+          "name": "idx_foods_user_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foods_user_id_users_id_fk": {
+          "name": "foods_user_id_users_id_fk",
+          "tableFrom": "foods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "foods_serving_positive": {
+          "name": "foods_serving_positive",
+          "value": "\"foods\".\"serving_size\" > 0"
+        },
+        "foods_nutrition_nonnegative": {
+          "name": "foods_nutrition_nonnegative",
+          "value": "\"foods\".\"calories\" >= 0 AND \"foods\".\"protein\" >= 0 AND \"foods\".\"carbs\" >= 0 AND \"foods\".\"fat\" >= 0 AND \"foods\".\"fiber\" >= 0"
+        },
+        "foods_fat_breakdown_nonneg": {
+          "name": "foods_fat_breakdown_nonneg",
+          "value": "(\"foods\".\"saturated_fat\" IS NULL OR \"foods\".\"saturated_fat\" >= 0) AND (\"foods\".\"monounsaturated_fat\" IS NULL OR \"foods\".\"monounsaturated_fat\" >= 0) AND (\"foods\".\"polyunsaturated_fat\" IS NULL OR \"foods\".\"polyunsaturated_fat\" >= 0) AND (\"foods\".\"trans_fat\" IS NULL OR \"foods\".\"trans_fat\" >= 0) AND (\"foods\".\"cholesterol\" IS NULL OR \"foods\".\"cholesterol\" >= 0) AND (\"foods\".\"omega3\" IS NULL OR \"foods\".\"omega3\" >= 0) AND (\"foods\".\"omega6\" IS NULL OR \"foods\".\"omega6\" >= 0)"
+        },
+        "foods_sugar_carb_nonneg": {
+          "name": "foods_sugar_carb_nonneg",
+          "value": "(\"foods\".\"sugar\" IS NULL OR \"foods\".\"sugar\" >= 0) AND (\"foods\".\"added_sugars\" IS NULL OR \"foods\".\"added_sugars\" >= 0) AND (\"foods\".\"sugar_alcohols\" IS NULL OR \"foods\".\"sugar_alcohols\" >= 0) AND (\"foods\".\"starch\" IS NULL OR \"foods\".\"starch\" >= 0)"
+        },
+        "foods_minerals_nonneg": {
+          "name": "foods_minerals_nonneg",
+          "value": "(\"foods\".\"sodium\" IS NULL OR \"foods\".\"sodium\" >= 0) AND (\"foods\".\"potassium\" IS NULL OR \"foods\".\"potassium\" >= 0) AND (\"foods\".\"calcium\" IS NULL OR \"foods\".\"calcium\" >= 0) AND (\"foods\".\"iron\" IS NULL OR \"foods\".\"iron\" >= 0) AND (\"foods\".\"magnesium\" IS NULL OR \"foods\".\"magnesium\" >= 0) AND (\"foods\".\"phosphorus\" IS NULL OR \"foods\".\"phosphorus\" >= 0) AND (\"foods\".\"zinc\" IS NULL OR \"foods\".\"zinc\" >= 0) AND (\"foods\".\"copper\" IS NULL OR \"foods\".\"copper\" >= 0) AND (\"foods\".\"manganese\" IS NULL OR \"foods\".\"manganese\" >= 0) AND (\"foods\".\"selenium\" IS NULL OR \"foods\".\"selenium\" >= 0) AND (\"foods\".\"iodine\" IS NULL OR \"foods\".\"iodine\" >= 0) AND (\"foods\".\"fluoride\" IS NULL OR \"foods\".\"fluoride\" >= 0) AND (\"foods\".\"chromium\" IS NULL OR \"foods\".\"chromium\" >= 0) AND (\"foods\".\"molybdenum\" IS NULL OR \"foods\".\"molybdenum\" >= 0) AND (\"foods\".\"chloride\" IS NULL OR \"foods\".\"chloride\" >= 0)"
+        },
+        "foods_vitamins_nonneg": {
+          "name": "foods_vitamins_nonneg",
+          "value": "(\"foods\".\"vitamin_a\" IS NULL OR \"foods\".\"vitamin_a\" >= 0) AND (\"foods\".\"vitamin_c\" IS NULL OR \"foods\".\"vitamin_c\" >= 0) AND (\"foods\".\"vitamin_d\" IS NULL OR \"foods\".\"vitamin_d\" >= 0) AND (\"foods\".\"vitamin_e\" IS NULL OR \"foods\".\"vitamin_e\" >= 0) AND (\"foods\".\"vitamin_k\" IS NULL OR \"foods\".\"vitamin_k\" >= 0) AND (\"foods\".\"vitamin_b1\" IS NULL OR \"foods\".\"vitamin_b1\" >= 0) AND (\"foods\".\"vitamin_b2\" IS NULL OR \"foods\".\"vitamin_b2\" >= 0) AND (\"foods\".\"vitamin_b3\" IS NULL OR \"foods\".\"vitamin_b3\" >= 0) AND (\"foods\".\"vitamin_b5\" IS NULL OR \"foods\".\"vitamin_b5\" >= 0) AND (\"foods\".\"vitamin_b6\" IS NULL OR \"foods\".\"vitamin_b6\" >= 0) AND (\"foods\".\"vitamin_b7\" IS NULL OR \"foods\".\"vitamin_b7\" >= 0) AND (\"foods\".\"vitamin_b9\" IS NULL OR \"foods\".\"vitamin_b9\" >= 0) AND (\"foods\".\"vitamin_b12\" IS NULL OR \"foods\".\"vitamin_b12\" >= 0)"
+        },
+        "foods_other_nutrients_nonneg": {
+          "name": "foods_other_nutrients_nonneg",
+          "value": "(\"foods\".\"caffeine\" IS NULL OR \"foods\".\"caffeine\" >= 0) AND (\"foods\".\"alcohol\" IS NULL OR \"foods\".\"alcohol\" >= 0) AND (\"foods\".\"water\" IS NULL OR \"foods\".\"water\" >= 0) AND (\"foods\".\"salt\" IS NULL OR \"foods\".\"salt\" >= 0)"
+        },
+        "foods_nutri_score_valid": {
+          "name": "foods_nutri_score_valid",
+          "value": "\"foods\".\"nutri_score\" IS NULL OR \"foods\".\"nutri_score\" IN ('a', 'b', 'c', 'd', 'e')"
+        },
+        "foods_nova_group_valid": {
+          "name": "foods_nova_group_valid",
+          "value": "\"foods\".\"nova_group\" IS NULL OR (\"foods\".\"nova_group\" >= 1 AND \"foods\".\"nova_group\" <= 4)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_codes_client_id": {
+          "name": "idx_oauth_codes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_codes_expires_at": {
+          "name": "idx_oauth_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_codes_method_check": {
+          "name": "oauth_codes_method_check",
+          "value": "code_challenge_method = 'S256'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorizations": {
+      "name": "oauth_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_authorizations_user_id": {
+          "name": "idx_oauth_authorizations_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_authorizations_client_id": {
+          "name": "idx_oauth_authorizations_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_authorizations_user_client": {
+          "name": "idx_oauth_authorizations_user_client",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorizations_user_id_users_id_fk": {
+          "name": "oauth_authorizations_user_id_users_id_fk",
+          "tableFrom": "oauth_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorizations_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorizations_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorizations",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_redirect_uris": {
+          "name": "allowed_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_user_id": {
+          "name": "idx_oauth_clients_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['mcp:access']::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_tokens_client_id": {
+          "name": "idx_oauth_tokens_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_user_id": {
+          "name": "idx_oauth_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_expires_at": {
+          "name": "idx_oauth_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_access_token_hash": {
+          "name": "idx_oauth_tokens_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_refresh_token_hash": {
+          "name": "idx_oauth_tokens_refresh_token_hash",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_tokens_user_id_users_id_fk": {
+          "name": "oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_ingredients": {
+      "name": "recipe_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "serving_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recipe_ingredients_recipe_id": {
+          "name": "idx_recipe_ingredients_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_ingredients_food_id": {
+          "name": "idx_recipe_ingredients_food_id",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_ingredients_recipe_id_recipes_id_fk": {
+          "name": "recipe_ingredients_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_ingredients_food_id_foods_id_fk": {
+          "name": "recipe_ingredients_food_id_foods_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recipe_ingredients_quantity_positive": {
+          "name": "recipe_ingredients_quantity_positive",
+          "value": "\"recipe_ingredients\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_servings": {
+          "name": "total_servings",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_recipes_user_id": {
+          "name": "idx_recipes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_created_at": {
+          "name": "idx_recipes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_user_id_users_id_fk": {
+          "name": "recipes_user_id_users_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recipes_servings_positive": {
+          "name": "recipes_servings_positive",
+          "value": "\"recipes\".\"total_servings\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplement_ingredients": {
+      "name": "supplement_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "supplement_id": {
+          "name": "supplement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage_unit": {
+          "name": "dosage_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_supplement_ingredients_supplement_id": {
+          "name": "idx_supplement_ingredients_supplement_id",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplement_ingredients_supplement_id_supplements_id_fk": {
+          "name": "supplement_ingredients_supplement_id_supplements_id_fk",
+          "tableFrom": "supplement_ingredients",
+          "tableTo": "supplements",
+          "columnsFrom": [
+            "supplement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplement_ingredients_dosage_positive": {
+          "name": "supplement_ingredients_dosage_positive",
+          "value": "\"supplement_ingredients\".\"dosage\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplement_logs": {
+      "name": "supplement_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "supplement_id": {
+          "name": "supplement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supplement_logs_unique": {
+          "name": "idx_supplement_logs_unique",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplement_logs_user_date": {
+          "name": "idx_supplement_logs_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplement_logs_supplement_id": {
+          "name": "idx_supplement_logs_supplement_id",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplement_logs_supplement_id_supplements_id_fk": {
+          "name": "supplement_logs_supplement_id_supplements_id_fk",
+          "tableFrom": "supplement_logs",
+          "tableTo": "supplements",
+          "columnsFrom": [
+            "supplement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "supplement_logs_user_id_users_id_fk": {
+          "name": "supplement_logs_user_id_users_id_fk",
+          "tableFrom": "supplement_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplements": {
+      "name": "supplements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage_unit": {
+          "name": "dosage_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_days": {
+          "name": "schedule_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_start_date": {
+          "name": "schedule_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supplements_user_id": {
+          "name": "idx_supplements_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplements_user_active": {
+          "name": "idx_supplements_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplements_user_id_users_id_fk": {
+          "name": "supplements_user_id_users_id_fk",
+          "tableFrom": "supplements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplements_dosage_positive": {
+          "name": "supplements_dosage_positive",
+          "value": "\"supplements\".\"dosage\" > 0"
+        },
+        "supplements_schedule_days_required": {
+          "name": "supplements_schedule_days_required",
+          "value": "\"supplements\".\"schedule_type\" NOT IN ('weekly', 'specific_days') OR (\"supplements\".\"schedule_days\" IS NOT NULL AND array_length(\"supplements\".\"schedule_days\", 1) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_goals": {
+      "name": "user_goals",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calorie_goal": {
+          "name": "calorie_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_goal": {
+          "name": "protein_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carb_goal": {
+          "name": "carb_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fat_goal": {
+          "name": "fat_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiber_goal": {
+          "name": "fiber_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sodium_goal": {
+          "name": "sodium_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar_goal": {
+          "name": "sugar_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_goals_user_id_users_id_fk": {
+          "name": "user_goals_user_id_users_id_fk",
+          "tableFrom": "user_goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_goals_positive": {
+          "name": "user_goals_positive",
+          "value": "\"user_goals\".\"calorie_goal\" > 0 AND \"user_goals\".\"protein_goal\" >= 0 AND \"user_goals\".\"carb_goal\" >= 0 AND \"user_goals\".\"fat_goal\" >= 0 AND \"user_goals\".\"fiber_goal\" >= 0"
+        },
+        "user_goals_optional_nonnegative": {
+          "name": "user_goals_optional_nonnegative",
+          "value": "(\"user_goals\".\"sodium_goal\" IS NULL OR \"user_goals\".\"sodium_goal\" >= 0) AND (\"user_goals\".\"sugar_goal\" IS NULL OR \"user_goals\".\"sugar_goal\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_chart_widget": {
+          "name": "show_chart_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_favorites_widget": {
+          "name": "show_favorites_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_supplements_widget": {
+          "name": "show_supplements_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_weight_widget": {
+          "name": "show_weight_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_meal_breakdown_widget": {
+          "name": "show_meal_breakdown_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_top_foods_widget": {
+          "name": "show_top_foods_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "widget_order": {
+          "name": "widget_order",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['chart', 'favorites', 'supplements', 'weight', 'daylog']::text[]"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dashboard'"
+        },
+        "favorite_tap_action": {
+          "name": "favorite_tap_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instant'"
+        },
+        "favorite_meal_assignment_mode": {
+          "name": "favorite_meal_assignment_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_based'"
+        },
+        "visible_nutrients": {
+          "name": "visible_nutrients",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['sodium', 'sugar', 'saturatedFat', 'cholesterol']::text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "infomaniak_sub": {
+          "name": "infomaniak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_infomaniak_sub_unique": {
+          "name": "users_infomaniak_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "infomaniak_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_entries": {
+      "name": "weight_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_weight_entries_user_date": {
+          "name": "idx_weight_entries_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weight_entries_user_logged": {
+          "name": "idx_weight_entries_user_logged",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_user_id_users_id_fk": {
+          "name": "weight_entries_user_id_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "weight_entries_user_date_unique": {
+          "name": "weight_entries_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "entry_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "weight_entries_valid": {
+          "name": "weight_entries_valid",
+          "value": "\"weight_entries\".\"weight_kg\" > 0 AND \"weight_entries\".\"weight_kg\" <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "daily",
+        "every_other_day",
+        "weekly",
+        "specific_days"
+      ]
+    },
+    "public.serving_unit": {
+      "name": "serving_unit",
+      "schema": "public",
+      "values": [
+        "g",
+        "kg",
+        "ml",
+        "l",
+        "oz",
+        "lb",
+        "fl_oz",
+        "cup",
+        "tbsp",
+        "tsp"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1773697565416,
       "tag": "0029_aromatic_bloodstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1774100784043,
+      "tag": "0030_blushing_titania",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -502,6 +502,8 @@
 	"recipes_delete": "Rezept löschen",
 
 	"nav_maintenance": "Erhaltung",
+	"nav_group_manage": "Verwalten",
+	"nav_group_analyze": "Analysieren",
 
 	"maintenance_title": "Erhaltungskalorienrechner",
 	"maintenance_description": "Schätze deine Erhaltungskalorien anhand von Gewichtsverlauf und Kalorienaufnahme über einen Zeitraum.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -502,6 +502,8 @@
 	"recipes_delete": "Delete recipe",
 
 	"nav_maintenance": "Maintenance",
+	"nav_group_manage": "Manage",
+	"nav_group_analyze": "Analyze",
 
 	"maintenance_title": "Maintenance Calculator",
 	"maintenance_description": "Estimate your maintenance calories based on weight change and calorie intake over a period.",

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(project(":shared"))
+            implementation(libs.kotlinx.serialization.json)
         }
     }
 }

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -60,7 +60,9 @@ android {
         }
         release {
             signingConfig = signingConfigs.getByName("release")
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
 

--- a/mobile/androidApp/proguard-rules.pro
+++ b/mobile/androidApp/proguard-rules.pro
@@ -1,0 +1,42 @@
+-keepattributes *Annotation*, InnerClasses
+-keepattributes Signature, Exception
+
+# kotlinx.serialization
+-keepclassmembers class kotlinx.serialization.json.** { *** *; }
+-keepclasseswithmembers class * {
+    @kotlinx.serialization.Serializable <fields>;
+}
+-keep class kotlinx.serialization.** { *; }
+-keepclassmembers @kotlinx.serialization.Serializable class ** {
+    *** Companion;
+    *** serializer(...);
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keepclassmembers class ** {
+    @kotlinx.serialization.SerialName *;
+    @kotlinx.serialization.Transient *;
+}
+
+# Ktor
+-keep class io.ktor.** { *; }
+-keepclassmembers class io.ktor.** { volatile <fields>; }
+-dontwarn io.ktor.**
+
+# Koin
+-keep class org.koin.** { *; }
+-keepclassmembers class * {
+    @org.koin.core.annotation.* *;
+}
+-dontwarn org.koin.**
+
+# Generated API model classes
+-keep class com.bissbilanz.api.generated.model.** { *; }
+
+# Glance widgets
+-keep class androidx.glance.** { *; }
+-dontwarn androidx.glance.**
+
+# SQLDelight
+-keep class com.squareup.sqldelight.** { *; }
+-keep class app.cash.sqldelight.** { *; }
+-dontwarn app.cash.sqldelight.**

--- a/mobile/androidApp/proguard-rules.pro
+++ b/mobile/androidApp/proguard-rules.pro
@@ -32,6 +32,10 @@
 # Generated API model classes
 -keep class com.bissbilanz.api.generated.model.** { *; }
 
+# App model and sync classes (serialized to/from JSON and SQLite)
+-keep class com.bissbilanz.model.** { *; }
+-keep class com.bissbilanz.sync.SyncOperation** { *; }
+
 # Glance widgets
 -keep class androidx.glance.** { *; }
 -dontwarn androidx.glance.**

--- a/mobile/androidApp/src/androidMain/AndroidManifest.xml
+++ b/mobile/androidApp/src/androidMain/AndroidManifest.xml
@@ -86,6 +86,17 @@
             android:exported="false"
             android:theme="@style/Theme.Bissbilanz.Dialog" />
 
+        <receiver
+            android:name=".widget.FavoritesWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/favorites_widget_info" />
+        </receiver>
+
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
     </application>
 </manifest>

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -14,12 +14,12 @@ import com.bissbilanz.android.ui.viewmodels.WeightViewModel
 import com.bissbilanz.android.widget.FavoritesWidget
 import com.bissbilanz.android.widget.MacroWidget
 import com.bissbilanz.android.widget.QuickWeightWidget
-import com.bissbilanz.repository.FoodRepository
 import com.bissbilanz.auth.SecureStorage
 import com.bissbilanz.cache.DatabaseDriverFactory
 import com.bissbilanz.di.sharedModule
 import com.bissbilanz.health.HealthConnectService
 import com.bissbilanz.repository.*
+import com.bissbilanz.repository.FoodRepository
 import com.bissbilanz.sync.ConnectivityProvider
 import com.bissbilanz.sync.SyncManager
 import io.sentry.android.core.SentryAndroid

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -9,6 +9,7 @@ import com.bissbilanz.android.ui.viewmodels.DayLogViewModel
 import com.bissbilanz.android.ui.viewmodels.FavoritesViewModel
 import com.bissbilanz.android.ui.viewmodels.FoodSearchViewModel
 import com.bissbilanz.android.ui.viewmodels.InsightsViewModel
+import com.bissbilanz.android.ui.viewmodels.SettingsViewModel
 import com.bissbilanz.android.ui.viewmodels.WeightViewModel
 import com.bissbilanz.android.widget.MacroWidget
 import com.bissbilanz.android.widget.QuickWeightWidget
@@ -57,6 +58,7 @@ class BissbilanzApplication : Application() {
                 viewModelOf(::FoodSearchViewModel)
                 viewModelOf(::FavoritesViewModel)
                 viewModelOf(::WeightViewModel)
+                viewModelOf(::SettingsViewModel)
             }
 
         startKoin {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -1,6 +1,8 @@
 package com.bissbilanz.android
 
 import android.app.Application
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.android.sync.RefreshManager
@@ -11,7 +13,7 @@ import com.bissbilanz.android.ui.viewmodels.FoodSearchViewModel
 import com.bissbilanz.android.ui.viewmodels.InsightsViewModel
 import com.bissbilanz.android.ui.viewmodels.SettingsViewModel
 import com.bissbilanz.android.ui.viewmodels.WeightViewModel
-import com.bissbilanz.android.widget.FavoritesWidget
+import com.bissbilanz.android.widget.FavoritesWidgetWorker
 import com.bissbilanz.android.widget.MacroWidget
 import com.bissbilanz.android.widget.QuickWeightWidget
 import com.bissbilanz.auth.SecureStorage
@@ -76,7 +78,12 @@ class BissbilanzApplication : Application() {
             MacroWidget.updateAllWidgets(this@BissbilanzApplication)
         }
         koin.get<FoodRepository>().onFoodChanged = {
-            FavoritesWidget.updateAllWidgets(this@BissbilanzApplication)
+            WorkManager
+                .getInstance(this@BissbilanzApplication)
+                .enqueue(
+                    OneTimeWorkRequestBuilder<FavoritesWidgetWorker>()
+                        .build(),
+                )
         }
         koin.get<WeightRepository>().onWeightChanged = {
             QuickWeightWidget.updateAllWidgets(this@BissbilanzApplication)
@@ -87,7 +94,12 @@ class BissbilanzApplication : Application() {
             refreshManager.refreshAll()
             MacroWidget.updateAllWidgets(this@BissbilanzApplication)
             QuickWeightWidget.updateAllWidgets(this@BissbilanzApplication)
-            FavoritesWidget.updateAllWidgets(this@BissbilanzApplication)
+            WorkManager
+                .getInstance(this@BissbilanzApplication)
+                .enqueue(
+                    OneTimeWorkRequestBuilder<FavoritesWidgetWorker>()
+                        .build(),
+                )
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -11,8 +11,10 @@ import com.bissbilanz.android.ui.viewmodels.FoodSearchViewModel
 import com.bissbilanz.android.ui.viewmodels.InsightsViewModel
 import com.bissbilanz.android.ui.viewmodels.SettingsViewModel
 import com.bissbilanz.android.ui.viewmodels.WeightViewModel
+import com.bissbilanz.android.widget.FavoritesWidget
 import com.bissbilanz.android.widget.MacroWidget
 import com.bissbilanz.android.widget.QuickWeightWidget
+import com.bissbilanz.repository.FoodRepository
 import com.bissbilanz.auth.SecureStorage
 import com.bissbilanz.cache.DatabaseDriverFactory
 import com.bissbilanz.di.sharedModule
@@ -73,6 +75,9 @@ class BissbilanzApplication : Application() {
         koin.get<EntryRepository>().onEntryChanged = {
             MacroWidget.updateAllWidgets(this@BissbilanzApplication)
         }
+        koin.get<FoodRepository>().onFoodChanged = {
+            FavoritesWidget.updateAllWidgets(this@BissbilanzApplication)
+        }
         koin.get<WeightRepository>().onWeightChanged = {
             QuickWeightWidget.updateAllWidgets(this@BissbilanzApplication)
         }
@@ -82,6 +87,7 @@ class BissbilanzApplication : Application() {
             refreshManager.refreshAll()
             MacroWidget.updateAllWidgets(this@BissbilanzApplication)
             QuickWeightWidget.updateAllWidgets(this@BissbilanzApplication)
+            FavoritesWidget.updateAllWidgets(this@BissbilanzApplication)
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/MainActivity.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/MainActivity.kt
@@ -56,6 +56,7 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         const val EXTRA_NAVIGATE_TO = "navigate_to"
+        const val EXTRA_FOOD_ID = "food_id"
         private val _navigationEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
         val navigationEvent = _navigationEvent.asSharedFlow()
     }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/MainActivity.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/MainActivity.kt
@@ -8,7 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.bissbilanz.android.ui.BissbilanzApp
 import com.bissbilanz.auth.AuthManager
-import kotlinx.coroutines.CoroutineScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -48,7 +48,7 @@ class MainActivity : ComponentActivity() {
                 return
             }
             val code = uri.getQueryParameter("code") ?: return
-            CoroutineScope(Dispatchers.IO).launch {
+            lifecycleScope.launch(Dispatchers.IO) {
                 authManager.handleCallback(code)
             }
         }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/MainActivity.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/MainActivity.kt
@@ -6,9 +6,9 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.lifecycle.lifecycleScope
 import com.bissbilanz.android.ui.BissbilanzApp
 import com.bissbilanz.auth.AuthManager
-import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/CalendarHeatmap.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/CalendarHeatmap.kt
@@ -7,12 +7,28 @@ import androidx.compose.animation.core.EaseOutCubic
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -24,10 +40,12 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.bissbilanz.android.R
 import com.bissbilanz.android.ui.theme.CaloriesBlue
 import com.bissbilanz.android.ui.theme.FiberGreen
 import com.bissbilanz.android.ui.theme.ProteinRed
@@ -108,6 +126,26 @@ fun CalendarHeatmap(
             selectedDay = null
         }
 
+        val headerPaint =
+            remember(onSurface) {
+                Paint().apply {
+                    color = onSurface.copy(alpha = 0.5f).toArgb()
+                    textSize = with(density) { 11.sp.toPx() }
+                    textAlign = Paint.Align.CENTER
+                    typeface = Typeface.DEFAULT
+                }
+            }
+        val dayTextPaint =
+            remember {
+                Paint().apply {
+                    textSize = with(density) { 12.sp.toPx() }
+                    textAlign = Paint.Align.CENTER
+                    typeface = Typeface.DEFAULT
+                }
+            }
+
+        val noDataText = stringResource(R.string.chart_no_data)
+
         Box(modifier = Modifier.fillMaxWidth().onSizeChanged { containerSize = it }) {
             Canvas(
                 modifier =
@@ -129,8 +167,8 @@ fun CalendarHeatmap(
                                         } else {
                                             selectedDay = date
                                             tooltipOffset = tapOffset
+                                            onDayClick(date)
                                         }
-                                        onDayClick(date)
                                     }
                                 }
                             }
@@ -138,14 +176,6 @@ fun CalendarHeatmap(
             ) {
                 val cellW = size.width / 7f
                 val cellH = (size.height - headerHeight) / totalRows.toFloat()
-
-                val headerPaint =
-                    Paint().apply {
-                        color = onSurface.copy(alpha = 0.5f).toArgb()
-                        textSize = with(density) { 11.sp.toPx() }
-                        textAlign = Paint.Align.CENTER
-                        typeface = Typeface.DEFAULT
-                    }
 
                 dayHeaders.forEachIndexed { i, label ->
                     drawContext.canvas.nativeCanvas.drawText(
@@ -155,13 +185,6 @@ fun CalendarHeatmap(
                         headerPaint,
                     )
                 }
-
-                val textPaint =
-                    Paint().apply {
-                        textSize = with(density) { 12.sp.toPx() }
-                        textAlign = Paint.Align.CENTER
-                        typeface = Typeface.DEFAULT
-                    }
 
                 for (day in 1..daysInMonth) {
                     val idx = offset + day - 1
@@ -205,13 +228,13 @@ fun CalendarHeatmap(
                         } else {
                             onSurface.copy(alpha = 0.4f)
                         }
-                    textPaint.color = textColor.toArgb()
+                    dayTextPaint.color = textColor.toArgb()
 
                     drawContext.canvas.nativeCanvas.drawText(
                         "$day",
                         x + w / 2,
-                        y + h / 2 + textPaint.textSize / 3,
-                        textPaint,
+                        y + h / 2 + dayTextPaint.textSize / 3,
+                        dayTextPaint,
                     )
                 }
             }
@@ -232,7 +255,7 @@ fun CalendarHeatmap(
                         )
                         if (calDay != null && calDay.hasEntries) {
                             Text(
-                                "${calDay.calories.roundToInt()} kcal",
+                                stringResource(R.string.chart_kcal_format, calDay.calories.roundToInt()),
                                 style = MaterialTheme.typography.labelMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.inverseOnSurface,
@@ -240,14 +263,14 @@ fun CalendarHeatmap(
                             if (calorieGoal > 0) {
                                 val pct = (calDay.calories / calorieGoal * 100).roundToInt()
                                 Text(
-                                    "$pct% of goal",
+                                    stringResource(R.string.chart_percent_of_goal, pct),
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
                                 )
                             }
                         } else {
                             Text(
-                                "No data",
+                                noDataText,
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.5f),
                             )

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/CalendarHeatmap.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/CalendarHeatmap.kt
@@ -22,8 +22,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bissbilanz.android.ui.theme.CaloriesBlue
@@ -35,6 +37,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlin.math.abs
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 @Composable
 fun CalendarHeatmap(
@@ -97,104 +100,160 @@ fun CalendarHeatmap(
         val cellPadding = with(density) { 2.dp.toPx() }
         val canvasHeight = with(density) { (headerHeight + (totalRows * (36.dp.toPx() + cellPadding))).toDp() }
 
-        Canvas(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(canvasHeight)
-                    .pointerInput(month, year) {
-                        detectTapGestures { tapOffset ->
-                            val cellW = size.width / 7f
-                            val cellH = (size.height - headerHeight) / totalRows.toFloat()
-                            val col = (tapOffset.x / cellW).toInt()
-                            val row = ((tapOffset.y - headerHeight) / cellH).toInt()
-                            if (row >= 0 && col in 0..6) {
-                                val dayNum = row * 7 + col - offset + 1
-                                if (dayNum in 1..daysInMonth) {
-                                    val date = LocalDate(year, month, dayNum).toString()
-                                    onDayClick(date)
+        var containerSize by remember { mutableStateOf(IntSize.Zero) }
+        var selectedDay by remember { mutableStateOf<String?>(null) }
+        var tooltipOffset by remember { mutableStateOf(Offset.Zero) }
+
+        LaunchedEffect(month, year) {
+            selectedDay = null
+        }
+
+        Box(modifier = Modifier.fillMaxWidth().onSizeChanged { containerSize = it }) {
+            Canvas(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(canvasHeight)
+                        .pointerInput(month, year) {
+                            detectTapGestures { tapOffset ->
+                                val cellW = size.width / 7f
+                                val cellH = (size.height - headerHeight) / totalRows.toFloat()
+                                val col = (tapOffset.x / cellW).toInt()
+                                val row = ((tapOffset.y - headerHeight) / cellH).toInt()
+                                if (row >= 0 && col in 0..6) {
+                                    val dayNum = row * 7 + col - offset + 1
+                                    if (dayNum in 1..daysInMonth) {
+                                        val date = LocalDate(year, month, dayNum).toString()
+                                        if (selectedDay == date) {
+                                            selectedDay = null
+                                        } else {
+                                            selectedDay = date
+                                            tooltipOffset = tapOffset
+                                        }
+                                        onDayClick(date)
+                                    }
                                 }
                             }
-                        }
-                    },
-        ) {
-            val cellW = size.width / 7f
-            val cellH = (size.height - headerHeight) / totalRows.toFloat()
+                        },
+            ) {
+                val cellW = size.width / 7f
+                val cellH = (size.height - headerHeight) / totalRows.toFloat()
 
-            val headerPaint =
-                Paint().apply {
-                    color = onSurface.copy(alpha = 0.5f).toArgb()
-                    textSize = with(density) { 11.sp.toPx() }
-                    textAlign = Paint.Align.CENTER
-                    typeface = Typeface.DEFAULT
+                val headerPaint =
+                    Paint().apply {
+                        color = onSurface.copy(alpha = 0.5f).toArgb()
+                        textSize = with(density) { 11.sp.toPx() }
+                        textAlign = Paint.Align.CENTER
+                        typeface = Typeface.DEFAULT
+                    }
+
+                dayHeaders.forEachIndexed { i, label ->
+                    drawContext.canvas.nativeCanvas.drawText(
+                        label,
+                        cellW * i + cellW / 2,
+                        headerHeight - 4f,
+                        headerPaint,
+                    )
                 }
 
-            dayHeaders.forEachIndexed { i, label ->
-                drawContext.canvas.nativeCanvas.drawText(
-                    label,
-                    cellW * i + cellW / 2,
-                    headerHeight - 4f,
-                    headerPaint,
-                )
+                val textPaint =
+                    Paint().apply {
+                        textSize = with(density) { 12.sp.toPx() }
+                        textAlign = Paint.Align.CENTER
+                        typeface = Typeface.DEFAULT
+                    }
+
+                for (day in 1..daysInMonth) {
+                    val idx = offset + day - 1
+                    val row = idx / 7
+                    val col = idx % 7
+                    val x = col * cellW + cellPadding
+                    val y = headerHeight + row * cellH + cellPadding
+                    val w = cellW - cellPadding * 2
+                    val h = cellH - cellPadding * 2
+
+                    val dateStr = LocalDate(year, month, day).toString()
+                    val calDay = dayMap[dateStr]
+
+                    val bgColor =
+                        if (calDay != null && calDay.hasEntries && calorieGoal > 0) {
+                            val ratio = calDay.calories / calorieGoal
+                            val dist = abs(1.0 - ratio)
+                            if (dist <= 0.10) {
+                                FiberGreen.copy(alpha = 0.9f * revealFraction.value)
+                            } else if (ratio > 1.0) {
+                                val intensity = min(dist / 0.5, 1.0).toFloat()
+                                ProteinRed.copy(alpha = (0.2f + 0.6f * intensity) * revealFraction.value)
+                            } else {
+                                val intensity = min(dist / 0.5, 1.0).toFloat()
+                                CaloriesBlue.copy(alpha = (0.2f + 0.6f * intensity) * revealFraction.value)
+                            }
+                        } else {
+                            surfaceVariant.copy(alpha = 0.3f * revealFraction.value)
+                        }
+
+                    drawRoundRect(
+                        color = bgColor,
+                        topLeft = Offset(x, y),
+                        size = Size(w, h),
+                        cornerRadius = CornerRadius(4f, 4f),
+                    )
+
+                    val textColor =
+                        if (calDay != null && calDay.hasEntries && calorieGoal > 0) {
+                            onSurface
+                        } else {
+                            onSurface.copy(alpha = 0.4f)
+                        }
+                    textPaint.color = textColor.toArgb()
+
+                    drawContext.canvas.nativeCanvas.drawText(
+                        "$day",
+                        x + w / 2,
+                        y + h / 2 + textPaint.textSize / 3,
+                        textPaint,
+                    )
+                }
             }
 
-            val textPaint =
-                Paint().apply {
-                    textSize = with(density) { 12.sp.toPx() }
-                    textAlign = Paint.Align.CENTER
-                    typeface = Typeface.DEFAULT
-                }
-
-            for (day in 1..daysInMonth) {
-                val idx = offset + day - 1
-                val row = idx / 7
-                val col = idx % 7
-                val x = col * cellW + cellPadding
-                val y = headerHeight + row * cellH + cellPadding
-                val w = cellW - cellPadding * 2
-                val h = cellH - cellPadding * 2
-
-                val dateStr = LocalDate(year, month, day).toString()
-                val calDay = dayMap[dateStr]
-
-                val bgColor =
-                    if (calDay != null && calDay.hasEntries && calorieGoal > 0) {
-                        val ratio = calDay.calories / calorieGoal
-                        val dist = abs(1.0 - ratio)
-                        if (dist <= 0.10) {
-                            FiberGreen.copy(alpha = 0.9f * revealFraction.value)
-                        } else if (ratio > 1.0) {
-                            val intensity = min(dist / 0.5, 1.0).toFloat()
-                            ProteinRed.copy(alpha = (0.2f + 0.6f * intensity) * revealFraction.value)
+            val selDay = selectedDay
+            val calDay = selDay?.let { dayMap[it] }
+            ChartTooltip(
+                visible = selDay != null,
+                touchOffset = tooltipOffset,
+                containerSize = containerSize,
+            ) {
+                if (selDay != null) {
+                    Column {
+                        Text(
+                            selDay,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
+                        )
+                        if (calDay != null && calDay.hasEntries) {
+                            Text(
+                                "${calDay.calories.roundToInt()} kcal",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.inverseOnSurface,
+                            )
+                            if (calorieGoal > 0) {
+                                val pct = (calDay.calories / calorieGoal * 100).roundToInt()
+                                Text(
+                                    "$pct% of goal",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
+                                )
+                            }
                         } else {
-                            val intensity = min(dist / 0.5, 1.0).toFloat()
-                            CaloriesBlue.copy(alpha = (0.2f + 0.6f * intensity) * revealFraction.value)
+                            Text(
+                                "No data",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.5f),
+                            )
                         }
-                    } else {
-                        surfaceVariant.copy(alpha = 0.3f * revealFraction.value)
                     }
-
-                drawRoundRect(
-                    color = bgColor,
-                    topLeft = Offset(x, y),
-                    size = Size(w, h),
-                    cornerRadius = CornerRadius(4f, 4f),
-                )
-
-                val textColor =
-                    if (calDay != null && calDay.hasEntries && calorieGoal > 0) {
-                        onSurface
-                    } else {
-                        onSurface.copy(alpha = 0.4f)
-                    }
-                textPaint.color = textColor.toArgb()
-
-                drawContext.canvas.nativeCanvas.drawText(
-                    "$day",
-                    x + w / 2,
-                    y + h / 2 + textPaint.textSize / 3,
-                    textPaint,
-                )
+                }
             }
         }
 

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/ChartTooltip.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/ChartTooltip.kt
@@ -1,0 +1,66 @@
+package com.bissbilanz.android.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BoxScope.ChartTooltip(
+    visible: Boolean,
+    touchOffset: Offset,
+    containerSize: IntSize,
+    content: @Composable () -> Unit,
+) {
+    val density = LocalDensity.current
+    val tooltipWidth = with(density) { 140.dp.toPx() }
+    val tooltipHeight = with(density) { 60.dp.toPx() }
+    val margin = with(density) { 12.dp.toPx() }
+
+    val x =
+        if (touchOffset.x + margin + tooltipWidth > containerSize.width) {
+            (touchOffset.x - margin - tooltipWidth).toInt()
+        } else {
+            (touchOffset.x + margin).toInt()
+        }
+    val y =
+        if (touchOffset.y - tooltipHeight - margin < 0) {
+            (touchOffset.y + margin).toInt()
+        } else {
+            (touchOffset.y - tooltipHeight - margin).toInt()
+        }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(animationSpec = tween(100)),
+        exit = fadeOut(animationSpec = tween(100)),
+        modifier =
+            Modifier
+                .offset { IntOffset(x, y) },
+    ) {
+        Surface(
+            shape = RoundedCornerShape(8.dp),
+            color = MaterialTheme.colorScheme.inverseSurface,
+            tonalElevation = 4.dp,
+            shadowElevation = 4.dp,
+        ) {
+            Box(modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
+                content()
+            }
+        }
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/ChartTooltip.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/ChartTooltip.kt
@@ -12,8 +12,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -27,21 +32,20 @@ fun BoxScope.ChartTooltip(
     content: @Composable () -> Unit,
 ) {
     val density = LocalDensity.current
-    val tooltipWidth = with(density) { 140.dp.toPx() }
-    val tooltipHeight = with(density) { 60.dp.toPx() }
     val margin = with(density) { 12.dp.toPx() }
+    var tooltipSize by remember { mutableStateOf(IntSize.Zero) }
 
     val x =
-        if (touchOffset.x + margin + tooltipWidth > containerSize.width) {
-            (touchOffset.x - margin - tooltipWidth).toInt()
+        if (touchOffset.x + margin + tooltipSize.width > containerSize.width) {
+            (touchOffset.x - margin - tooltipSize.width).toInt()
         } else {
             (touchOffset.x + margin).toInt()
         }
     val y =
-        if (touchOffset.y - tooltipHeight - margin < 0) {
+        if (touchOffset.y - tooltipSize.height - margin < 0) {
             (touchOffset.y + margin).toInt()
         } else {
-            (touchOffset.y - tooltipHeight - margin).toInt()
+            (touchOffset.y - tooltipSize.height - margin).toInt()
         }
 
     AnimatedVisibility(
@@ -57,6 +61,7 @@ fun BoxScope.ChartTooltip(
             color = MaterialTheme.colorScheme.inverseSurface,
             tonalElevation = 4.dp,
             shadowElevation = 4.dp,
+            modifier = Modifier.onSizeChanged { tooltipSize = it },
         ) {
             Box(modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
                 content()

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MacroRadarChart.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MacroRadarChart.kt
@@ -6,11 +6,19 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseOutCubic
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -19,14 +27,20 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bissbilanz.android.ui.theme.*
 import kotlin.math.PI
+import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.min
 import kotlin.math.sin
+import kotlin.math.sqrt
 
 data class RadarAxis(
     val label: String,
@@ -48,120 +62,211 @@ fun MacroRadarChart(
     }
 
     val density = LocalDensity.current
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var selectedIndex by remember { mutableStateOf<Int?>(null) }
+    var selectedOffset by remember { mutableStateOf(Offset.Zero) }
 
-    Canvas(
+    Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(240.dp),
+                .height(240.dp)
+                .onSizeChanged { containerSize = it },
     ) {
-        val cx = size.width / 2
-        val cy = size.height / 2
-        val radius = min(size.width, size.height) / 2 * 0.7f
-        val n = axes.size
-        val angleStep = 2 * PI / n
-        val startAngle = -PI / 2
+        Canvas(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .pointerInput(axes) {
+                        detectTapGestures { tapOffset ->
+                            val cx = size.width / 2f
+                            val cy = size.height / 2f
+                            val radius = min(size.width, size.height) / 2f * 0.7f
+                            val n = axes.size
+                            val angleStep = 2 * PI / n
+                            val startAngle = -PI / 2
 
-        for (ring in 1..4) {
-            val r = radius * ring / 4f
-            val ringPath = Path()
+                            val dx = tapOffset.x - cx
+                            val dy = tapOffset.y - cy
+                            val dist = sqrt(dx * dx + dy * dy)
+
+                            if (dist > radius * 1.8f) {
+                                selectedIndex = null
+                                return@detectTapGestures
+                            }
+
+                            var tapAngle = atan2(dy.toDouble(), dx.toDouble())
+                            if (tapAngle < startAngle) tapAngle += 2 * PI
+
+                            var closest = 0
+                            var minAngleDist = Double.MAX_VALUE
+                            for (i in 0 until n) {
+                                var axisAngle = startAngle + i * angleStep
+                                if (axisAngle < startAngle) axisAngle += 2 * PI
+                                val angleDiff = kotlin.math.abs(tapAngle - axisAngle)
+                                val d = angleDiff.coerceAtMost(2 * PI - angleDiff)
+                                if (d < minAngleDist) {
+                                    minAngleDist = d
+                                    closest = i
+                                }
+                            }
+
+                            if (selectedIndex == closest) {
+                                selectedIndex = null
+                            } else {
+                                selectedIndex = closest
+                                val angle = startAngle + closest * angleStep
+                                val v = axes[closest].value.coerceAtMost(1.5f)
+                                val r = radius * v
+                                selectedOffset =
+                                    Offset(
+                                        cx + (r * cos(angle)).toFloat(),
+                                        cy + (r * sin(angle)).toFloat(),
+                                    )
+                            }
+                        }
+                    },
+        ) {
+            val cx = size.width / 2
+            val cy = size.height / 2
+            val radius = min(size.width, size.height) / 2 * 0.7f
+            val n = axes.size
+            val angleStep = 2 * PI / n
+            val startAngle = -PI / 2
+
+            for (ring in 1..4) {
+                val r = radius * ring / 4f
+                val ringPath = Path()
+                for (i in 0 until n) {
+                    val angle = startAngle + i * angleStep
+                    val x = cx + r * cos(angle).toFloat()
+                    val y = cy + r * sin(angle).toFloat()
+                    if (i == 0) ringPath.moveTo(x, y) else ringPath.lineTo(x, y)
+                }
+                ringPath.close()
+                drawPath(
+                    ringPath,
+                    color = Color.Gray.copy(alpha = 0.15f),
+                    style = Stroke(width = 1f),
+                )
+            }
+
             for (i in 0 until n) {
                 val angle = startAngle + i * angleStep
+                val x = cx + radius * cos(angle).toFloat()
+                val y = cy + radius * sin(angle).toFloat()
+                drawLine(
+                    color = Color.Gray.copy(alpha = 0.2f),
+                    start = Offset(cx, cy),
+                    end = Offset(x, y),
+                    strokeWidth = 1f,
+                )
+            }
+
+            val goalPath = Path()
+            for (i in 0 until n) {
+                val angle = startAngle + i * angleStep
+                val x = cx + radius * cos(angle).toFloat()
+                val y = cy + radius * sin(angle).toFloat()
+                if (i == 0) goalPath.moveTo(x, y) else goalPath.lineTo(x, y)
+            }
+            goalPath.close()
+            drawPath(
+                goalPath,
+                color = Color.Gray.copy(alpha = 0.5f),
+                style =
+                    Stroke(
+                        width = 2f,
+                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)),
+                    ),
+            )
+
+            val valuePath = Path()
+            for (i in 0 until n) {
+                val angle = startAngle + i * angleStep
+                val v = (axes[i].value.coerceAtMost(1.5f)) * revealFraction.value
+                val r = radius * v
                 val x = cx + r * cos(angle).toFloat()
                 val y = cy + r * sin(angle).toFloat()
-                if (i == 0) ringPath.moveTo(x, y) else ringPath.lineTo(x, y)
+                if (i == 0) valuePath.moveTo(x, y) else valuePath.lineTo(x, y)
             }
-            ringPath.close()
+            valuePath.close()
             drawPath(
-                ringPath,
-                color = Color.Gray.copy(alpha = 0.15f),
-                style = Stroke(width = 1f),
+                valuePath,
+                color = CaloriesBlue.copy(alpha = 0.2f * revealFraction.value),
             )
-        }
-
-        for (i in 0 until n) {
-            val angle = startAngle + i * angleStep
-            val x = cx + radius * cos(angle).toFloat()
-            val y = cy + radius * sin(angle).toFloat()
-            drawLine(
-                color = Color.Gray.copy(alpha = 0.2f),
-                start = Offset(cx, cy),
-                end = Offset(x, y),
-                strokeWidth = 1f,
+            drawPath(
+                valuePath,
+                color = CaloriesBlue.copy(alpha = 0.7f * revealFraction.value),
+                style = Stroke(width = 2.5f),
             )
-        }
 
-        val goalPath = Path()
-        for (i in 0 until n) {
-            val angle = startAngle + i * angleStep
-            val x = cx + radius * cos(angle).toFloat()
-            val y = cy + radius * sin(angle).toFloat()
-            if (i == 0) goalPath.moveTo(x, y) else goalPath.lineTo(x, y)
-        }
-        goalPath.close()
-        drawPath(
-            goalPath,
-            color = Color.Gray.copy(alpha = 0.5f),
-            style =
-                Stroke(
-                    width = 2f,
-                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)),
-                ),
-        )
-
-        val valuePath = Path()
-        for (i in 0 until n) {
-            val angle = startAngle + i * angleStep
-            val v = (axes[i].value.coerceAtMost(1.5f)) * revealFraction.value
-            val r = radius * v
-            val x = cx + r * cos(angle).toFloat()
-            val y = cy + r * sin(angle).toFloat()
-            if (i == 0) valuePath.moveTo(x, y) else valuePath.lineTo(x, y)
-        }
-        valuePath.close()
-        drawPath(
-            valuePath,
-            color = CaloriesBlue.copy(alpha = 0.2f * revealFraction.value),
-        )
-        drawPath(
-            valuePath,
-            color = CaloriesBlue.copy(alpha = 0.7f * revealFraction.value),
-            style = Stroke(width = 2.5f),
-        )
-
-        for (i in 0 until n) {
-            val angle = startAngle + i * angleStep
-            val v = (axes[i].value.coerceAtMost(1.5f)) * revealFraction.value
-            val r = radius * v
-            val x = cx + r * cos(angle).toFloat()
-            val y = cy + r * sin(angle).toFloat()
-            drawCircle(
-                color = axes[i].color,
-                radius = 4f,
-                center = Offset(x, y),
-            )
-        }
-
-        val textPaint =
-            Paint().apply {
-                textSize = with(density) { 11.sp.toPx() }
-                textAlign = Paint.Align.CENTER
-                typeface = Typeface.DEFAULT_BOLD
-                isAntiAlias = true
+            for (i in 0 until n) {
+                val angle = startAngle + i * angleStep
+                val v = (axes[i].value.coerceAtMost(1.5f)) * revealFraction.value
+                val r = radius * v
+                val x = cx + r * cos(angle).toFloat()
+                val y = cy + r * sin(angle).toFloat()
+                val isSelected = selectedIndex == i
+                drawCircle(
+                    color = axes[i].color,
+                    radius = if (isSelected) 7f else 4f,
+                    center = Offset(x, y),
+                )
+                if (isSelected) {
+                    drawCircle(
+                        color = Color.White,
+                        radius = 3f,
+                        center = Offset(x, y),
+                    )
+                }
             }
 
-        for (i in 0 until n) {
-            val angle = startAngle + i * angleStep
-            val labelR = radius + with(density) { 16.dp.toPx() }
-            val x = cx + labelR * cos(angle).toFloat()
-            val y = cy + labelR * sin(angle).toFloat()
-            val pctStr = "${(axes[i].value * 100).toInt()}%"
-            textPaint.color = axes[i].color.toArgb()
-            drawContext.canvas.nativeCanvas.drawText(axes[i].label, x, y, textPaint)
-            textPaint.color = axes[i].color.copy(alpha = 0.7f).toArgb()
-            textPaint.textSize = with(density) { 9.sp.toPx() }
-            drawContext.canvas.nativeCanvas.drawText(pctStr, x, y + textPaint.textSize + 2f, textPaint)
-            textPaint.textSize = with(density) { 11.sp.toPx() }
+            val textPaint =
+                Paint().apply {
+                    textSize = with(density) { 11.sp.toPx() }
+                    textAlign = Paint.Align.CENTER
+                    typeface = Typeface.DEFAULT_BOLD
+                    isAntiAlias = true
+                }
+
+            for (i in 0 until n) {
+                val angle = startAngle + i * angleStep
+                val labelR = radius + with(density) { 16.dp.toPx() }
+                val x = cx + labelR * cos(angle).toFloat()
+                val y = cy + labelR * sin(angle).toFloat()
+                val pctStr = "${(axes[i].value * 100).toInt()}%"
+                textPaint.color = axes[i].color.toArgb()
+                drawContext.canvas.nativeCanvas.drawText(axes[i].label, x, y, textPaint)
+                textPaint.color = axes[i].color.copy(alpha = 0.7f).toArgb()
+                textPaint.textSize = with(density) { 9.sp.toPx() }
+                drawContext.canvas.nativeCanvas.drawText(pctStr, x, y + textPaint.textSize + 2f, textPaint)
+                textPaint.textSize = with(density) { 11.sp.toPx() }
+            }
+        }
+
+        val selIdx = selectedIndex
+        ChartTooltip(
+            visible = selIdx != null,
+            touchOffset = selectedOffset,
+            containerSize = containerSize,
+        ) {
+            if (selIdx != null && selIdx in axes.indices) {
+                val axis = axes[selIdx]
+                Column {
+                    Text(
+                        axis.label,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                    )
+                    Text(
+                        "${(axis.value * 100).toInt()}% of goal",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
+                    )
+                }
+            }
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MacroRadarChart.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MacroRadarChart.kt
@@ -30,11 +30,11 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.res.stringResource
 import com.bissbilanz.android.R
 import com.bissbilanz.android.ui.theme.*
 import kotlin.math.PI

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MacroRadarChart.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MacroRadarChart.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import com.bissbilanz.android.R
 import com.bissbilanz.android.ui.theme.*
 import kotlin.math.PI
 import kotlin.math.atan2
@@ -65,6 +67,16 @@ fun MacroRadarChart(
     var containerSize by remember { mutableStateOf(IntSize.Zero) }
     var selectedIndex by remember { mutableStateOf<Int?>(null) }
     var selectedOffset by remember { mutableStateOf(Offset.Zero) }
+
+    val textPaint =
+        remember(density) {
+            Paint().apply {
+                textSize = with(density) { 11.sp.toPx() }
+                textAlign = Paint.Align.CENTER
+                typeface = Typeface.DEFAULT_BOLD
+                isAntiAlias = true
+            }
+        }
 
     Box(
         modifier =
@@ -222,14 +234,6 @@ fun MacroRadarChart(
                 }
             }
 
-            val textPaint =
-                Paint().apply {
-                    textSize = with(density) { 11.sp.toPx() }
-                    textAlign = Paint.Align.CENTER
-                    typeface = Typeface.DEFAULT_BOLD
-                    isAntiAlias = true
-                }
-
             for (i in 0 until n) {
                 val angle = startAngle + i * angleStep
                 val labelR = radius + with(density) { 16.dp.toPx() }
@@ -261,7 +265,7 @@ fun MacroRadarChart(
                         color = MaterialTheme.colorScheme.inverseOnSurface,
                     )
                     Text(
-                        "${(axis.value * 100).toInt()}% of goal",
+                        stringResource(R.string.chart_percent_of_goal, (axis.value * 100).toInt()),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
                     )

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MealCard.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/MealCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.bissbilanz.android.ui.theme.*
 import com.bissbilanz.model.Entry
@@ -68,7 +69,10 @@ fun MealCard(
                 Spacer(modifier = Modifier.height(4.dp))
             }
 
-            entries.forEach { entry ->
+            entries.forEachIndexed { index, entry ->
+                if (index > 0) {
+                    HorizontalDivider(color = DividerDefaults.color.copy(alpha = 0.5f))
+                }
                 val name = entry.resolvedName()
                 val cal = entry.resolvedCalories()
                 val servingsText =
@@ -78,13 +82,15 @@ fun MealCard(
                         ""
                     }
                 Row(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Text(
                         "$servingsText$name",
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         "${cal.roundToInt()}",

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SimpleLineChart.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SimpleLineChart.kt
@@ -1,0 +1,133 @@
+package com.bissbilanz.android.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseOutCubic
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
+import kotlin.math.roundToInt
+
+@Composable
+fun SimpleLineChart(
+    data: List<Float>,
+    color: Color,
+    modifier: Modifier = Modifier,
+    unit: String = "",
+) {
+    if (data.isEmpty()) return
+    val maxVal = data.max().coerceAtLeast(1f)
+    val minVal = data.min()
+
+    val revealFraction = remember { Animatable(0f) }
+    LaunchedEffect(data) {
+        revealFraction.snapTo(0f)
+        revealFraction.animateTo(1f, animationSpec = tween(500, easing = EaseOutCubic))
+    }
+
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var selectedIndex by remember { mutableStateOf<Int?>(null) }
+    var touchOffset by remember { mutableStateOf<Offset?>(null) }
+
+    Box(modifier = modifier.onSizeChanged { containerSize = it }) {
+        Canvas(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .pointerInput(data) {
+                        detectDragGestures(
+                            onDragStart = { offset ->
+                                val stepX = size.width.toFloat() / (data.size - 1).coerceAtLeast(1)
+                                val idx = (offset.x / stepX).toInt().coerceIn(0, data.lastIndex)
+                                selectedIndex = idx
+                                touchOffset = offset
+                            },
+                            onDrag = { change, _ ->
+                                change.consume()
+                                val stepX = size.width.toFloat() / (data.size - 1).coerceAtLeast(1)
+                                val idx = (change.position.x / stepX).toInt().coerceIn(0, data.lastIndex)
+                                selectedIndex = idx
+                                touchOffset = change.position
+                            },
+                            onDragEnd = {
+                                selectedIndex = null
+                                touchOffset = null
+                            },
+                            onDragCancel = {
+                                selectedIndex = null
+                                touchOffset = null
+                            },
+                        )
+                    },
+        ) {
+            clipRect(right = size.width * revealFraction.value) {
+                val stepX = size.width / (data.size - 1).coerceAtLeast(1)
+                val range = (maxVal - minVal).coerceAtLeast(1f)
+                val padding = 8f
+
+                val path = Path()
+                data.forEachIndexed { i, value ->
+                    val x = i * stepX
+                    val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
+                    if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                }
+
+                drawPath(path, color = color, style = Stroke(width = 3f, cap = StrokeCap.Round))
+
+                data.forEachIndexed { i, value ->
+                    val x = i * stepX
+                    val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
+                    val isSelected = selectedIndex == i
+                    drawCircle(color = color, radius = if (isSelected) 6f else 3f, center = Offset(x, y))
+                    if (isSelected) {
+                        drawCircle(color = Color.White, radius = 3f, center = Offset(x, y))
+                        drawLine(
+                            color = Color.Gray.copy(alpha = 0.4f),
+                            start = Offset(x, 0f),
+                            end = Offset(x, size.height),
+                            strokeWidth = 1f,
+                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 3f)),
+                        )
+                    }
+                }
+            }
+        }
+
+        val selIdx = selectedIndex
+        val tOff = touchOffset
+        ChartTooltip(
+            visible = selIdx != null && tOff != null,
+            touchOffset = tOff ?: Offset.Zero,
+            containerSize = containerSize,
+        ) {
+            if (selIdx != null && selIdx in data.indices) {
+                Text(
+                    "${data[selIdx].roundToInt()}${if (unit.isNotEmpty()) " $unit" else ""}",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                )
+            }
+        }
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SimplePieChart.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SimplePieChart.kt
@@ -1,0 +1,166 @@
+package com.bissbilanz.android.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseOutCubic
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
+import com.bissbilanz.android.R
+import com.bissbilanz.model.MealBreakdownEntry
+import kotlin.math.roundToInt
+
+val MealColors =
+    listOf(
+        Color(0xFF3B82F6),
+        Color(0xFFEF4444),
+        Color(0xFFF97316),
+        Color(0xFFEAB308),
+        Color(0xFF22C55E),
+        Color(0xFF8B5CF6),
+        Color(0xFFEC4899),
+        Color(0xFF14B8A6),
+    )
+
+@Composable
+fun SimplePieChart(
+    entries: List<MealBreakdownEntry>,
+    modifier: Modifier = Modifier,
+) {
+    val total = entries.sumOf { it.calories }.toFloat()
+    if (total <= 0f) return
+    val surfaceColor = MaterialTheme.colorScheme.surfaceContainerLow
+
+    val sweepFraction = remember { Animatable(0f) }
+    LaunchedEffect(entries) {
+        sweepFraction.snapTo(0f)
+        sweepFraction.animateTo(1f, animationSpec = tween(600, easing = EaseOutCubic))
+    }
+
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var selectedIndex by remember { mutableStateOf<Int?>(null) }
+    var tapOffset by remember { mutableStateOf(Offset.Zero) }
+
+    val kcalPctFormat = stringResource(R.string.chart_kcal_pct_format)
+
+    Box(modifier = modifier.onSizeChanged { containerSize = it }) {
+        Canvas(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .pointerInput(entries) {
+                        detectTapGestures { offset ->
+                            val cx = size.width / 2f
+                            val cy = size.height / 2f
+                            val diameter = minOf(size.width, size.height) * 0.8f
+                            val radius = diameter / 2f
+                            val innerRadius = radius * 0.5f
+
+                            val dx = offset.x - cx
+                            val dy = offset.y - cy
+                            val dist = kotlin.math.sqrt(dx * dx + dy * dy)
+
+                            if (dist < innerRadius || dist > radius) {
+                                selectedIndex = null
+                                return@detectTapGestures
+                            }
+
+                            var angle = Math.toDegrees(kotlin.math.atan2(dy.toDouble(), dx.toDouble())).toFloat()
+                            angle = (angle + 90f + 360f) % 360f
+
+                            var cumulative = 0f
+                            var found = -1
+                            for (i in entries.indices) {
+                                val sweep = (entries[i].calories.toFloat() / total) * 360f
+                                if (angle >= cumulative && angle < cumulative + sweep) {
+                                    found = i
+                                    break
+                                }
+                                cumulative += sweep
+                            }
+
+                            if (found >= 0) {
+                                if (selectedIndex == found) {
+                                    selectedIndex = null
+                                } else {
+                                    selectedIndex = found
+                                    tapOffset = offset
+                                }
+                            } else {
+                                selectedIndex = null
+                            }
+                        }
+                    },
+        ) {
+            val diameter = minOf(size.width, size.height) * 0.8f
+            val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
+            var startAngle = -90f
+
+            entries.forEachIndexed { index, entry ->
+                val sweep = (entry.calories.toFloat() / total) * 360f * sweepFraction.value
+                val isSelected = selectedIndex == index
+                val arcColor = MealColors[index % MealColors.size]
+                drawArc(
+                    color = if (isSelected) arcColor else arcColor.copy(alpha = if (selectedIndex != null) 0.5f else 1f),
+                    startAngle = startAngle,
+                    sweepAngle = sweep,
+                    useCenter = true,
+                    topLeft = topLeft,
+                    size = Size(diameter, diameter),
+                )
+                startAngle += sweep
+            }
+
+            val innerDiameter = diameter * 0.5f
+            val innerTopLeft = Offset((size.width - innerDiameter) / 2f, (size.height - innerDiameter) / 2f)
+            drawOval(
+                color = surfaceColor,
+                topLeft = innerTopLeft,
+                size = Size(innerDiameter, innerDiameter),
+            )
+        }
+
+        val selIdx = selectedIndex
+        ChartTooltip(
+            visible = selIdx != null,
+            touchOffset = tapOffset,
+            containerSize = containerSize,
+        ) {
+            if (selIdx != null && selIdx in entries.indices) {
+                val entry = entries[selIdx]
+                val pct = (entry.calories / total * 100).roundToInt()
+                Column {
+                    Text(
+                        entry.mealType.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                    )
+                    Text(
+                        kcalPctFormat.format(entry.calories.roundToInt(), pct),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SupplementsWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SupplementsWidget.kt
@@ -7,9 +7,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.bissbilanz.android.R
 import com.bissbilanz.repository.SupplementRepository
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -38,19 +40,19 @@ fun SupplementsWidget(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         Icons.Default.Medication,
-                        contentDescription = "Supplements",
+                        contentDescription = stringResource(R.string.chart_supplements),
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(20.dp),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        "Supplements",
+                        stringResource(R.string.chart_supplements),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
                 Text(
-                    "${takenIds.size} of ${supplements.size} taken",
+                    stringResource(R.string.chart_supplements_taken, takenIds.size, supplements.size),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -71,14 +73,17 @@ fun SupplementsWidget(
                             takenIds =
                                 if (checked) takenIds + supplement.id else takenIds - supplement.id
                             scope.launch {
-                                if (checked) {
-                                    supplementRepo.logSupplement(supplement.id, date)
-                                } else {
-                                    supplementRepo.unlogSupplement(supplement.id, date)
+                                try {
+                                    if (checked) {
+                                        supplementRepo.logSupplement(supplement.id, date)
+                                    } else {
+                                        supplementRepo.unlogSupplement(supplement.id, date)
+                                    }
+                                } catch (e: Exception) {
+                                    if (e is kotlinx.coroutines.CancellationException) throw e
+                                    takenIds =
+                                        if (checked) takenIds - supplement.id else takenIds + supplement.id
                                 }
-                                takenIds =
-                                    supplementRepo.getChecklist(date)
-                                        .map { it.supplementId }.toSet()
                             }
                         },
                     )
@@ -93,7 +98,7 @@ fun SupplementsWidget(
                 onClick = onViewAll,
                 modifier = Modifier.align(Alignment.End),
             ) {
-                Text("View All")
+                Text(stringResource(R.string.chart_view_all))
             }
         }
     }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SupplementsWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/SupplementsWidget.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bissbilanz.model.SupplementLog
 import com.bissbilanz.repository.SupplementRepository
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -22,14 +21,12 @@ fun SupplementsWidget(
 ) {
     val supplementRepo: SupplementRepository = koinInject()
     val supplements by supplementRepo.supplements().collectAsStateWithLifecycle(emptyList())
-    var checklist by remember { mutableStateOf<List<SupplementLog>>(emptyList()) }
+    var takenIds by remember { mutableStateOf(setOf<String>()) }
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(date) {
-        checklist = supplementRepo.getChecklist(date)
+        takenIds = supplementRepo.getChecklist(date).map { it.supplementId }.toSet()
     }
-
-    val takenCount = supplements.count { supp -> checklist.any { it.supplementId == supp.id } }
 
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -53,14 +50,14 @@ fun SupplementsWidget(
                     )
                 }
                 Text(
-                    "$takenCount of ${supplements.size} taken",
+                    "${takenIds.size} of ${supplements.size} taken",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))
             supplements.forEach { supplement ->
-                val isTaken = checklist.any { it.supplementId == supplement.id }
+                val isTaken = takenIds.contains(supplement.id)
                 Row(
                     modifier =
                         Modifier
@@ -71,13 +68,17 @@ fun SupplementsWidget(
                     Checkbox(
                         checked = isTaken,
                         onCheckedChange = { checked ->
+                            takenIds =
+                                if (checked) takenIds + supplement.id else takenIds - supplement.id
                             scope.launch {
                                 if (checked) {
                                     supplementRepo.logSupplement(supplement.id, date)
                                 } else {
                                     supplementRepo.unlogSupplement(supplement.id, date)
                                 }
-                                checklist = supplementRepo.getChecklist(date)
+                                takenIds =
+                                    supplementRepo.getChecklist(date)
+                                        .map { it.supplementId }.toSet()
                             }
                         },
                     )

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/WeightTrendChart.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/WeightTrendChart.kt
@@ -6,9 +6,17 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseOutCubic
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -18,7 +26,11 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bissbilanz.android.ui.theme.ProjectionPurple
@@ -28,6 +40,7 @@ import com.bissbilanz.model.WeightTrendEntry
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
+import kotlin.math.abs
 import kotlin.math.ceil
 
 internal data class ProjectionPoint(
@@ -51,6 +64,13 @@ internal fun linearRegression(points: List<Pair<Float, Float>>): Pair<Float, Flo
         0f to (sumY / n)
     }
 }
+
+private data class SelectedWeightPoint(
+    val date: String,
+    val weight: Float,
+    val movingAvg: Float?,
+    val canvasOffset: Offset,
+)
 
 @Composable
 fun WeightTrendChart(
@@ -80,7 +100,7 @@ fun WeightTrendChart(
         revealFraction.animateTo(1f, animationSpec = tween(600, easing = EaseOutCubic))
     }
 
-    val textColor = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
+    val textColor = MaterialTheme.colorScheme.onSurfaceVariant
     val textColorArgb =
         android.graphics.Color.argb(
             (textColor.alpha * 255).toInt(),
@@ -89,126 +109,236 @@ fun WeightTrendChart(
             (textColor.blue * 255).toInt(),
         )
 
-    Canvas(modifier = modifier) {
-        val leftPadding = 44.dp.toPx()
-        val bottomPadding = 20.dp.toPx()
-        val topPadding = 8.dp.toPx()
-        val rightPadding = 8.dp.toPx()
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var touchOffset by remember { mutableStateOf<Offset?>(null) }
+    var selectedPoint by remember { mutableStateOf<SelectedWeightPoint?>(null) }
 
-        val chartWidth = size.width - leftPadding - rightPadding
-        val chartHeight = size.height - topPadding - bottomPadding
+    val leftPaddingDp = 44.dp
+    val bottomPaddingDp = 20.dp
+    val topPaddingDp = 8.dp
+    val rightPaddingDp = 8.dp
 
-        val state = chartState
-        val yMin = state.yMin
-        val yMax = state.yMax
-        val yRange = (yMax - yMin).coerceAtLeast(1f)
-        val maxDayIndex = state.maxDayIndex.coerceAtLeast(1f)
+    Box(
+        modifier = modifier.onSizeChanged { containerSize = it },
+    ) {
+        Canvas(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .pointerInput(chartState) {
+                        val leftPadding = leftPaddingDp.toPx()
+                        val rightPadding = rightPaddingDp.toPx()
+                        val topPadding = topPaddingDp.toPx()
+                        val bottomPadding = bottomPaddingDp.toPx()
+                        val chartWidth = size.width - leftPadding - rightPadding
+                        val chartHeight = size.height - topPadding - bottomPadding
+                        val maxDayIndex = chartState.maxDayIndex.coerceAtLeast(1f)
+                        val yMin = chartState.yMin
+                        val yRange = (chartState.yMax - yMin).coerceAtLeast(1f)
 
-        fun xPos(dayIndex: Float): Float = leftPadding + (dayIndex / maxDayIndex) * chartWidth
+                        fun findNearest(x: Float): SelectedWeightPoint? {
+                            val dayIndex = ((x - leftPadding) / chartWidth) * maxDayIndex
+                            val nearest =
+                                chartState.actualPoints.minByOrNull { abs(it.dayIndex - dayIndex) }
+                                    ?: return null
+                            val ptX = leftPadding + (nearest.dayIndex / maxDayIndex) * chartWidth
+                            val ptY = topPadding + (1f - (nearest.weight - yMin) / yRange) * chartHeight
+                            val idx = chartState.actualPoints.indexOf(nearest)
+                            val entry = trendData.getOrNull(idx)
+                            val dateLabel = entry?.entryDate?.take(10) ?: ""
+                            val avgPt = chartState.movingAvgPoints.find { it.dayIndex == nearest.dayIndex }
+                            return SelectedWeightPoint(dateLabel, nearest.weight, avgPt?.weight, Offset(ptX, ptY))
+                        }
 
-        fun yPos(value: Float): Float = topPadding + (1f - (value - yMin) / yRange) * chartHeight
-
-        // Y-axis labels
-        val yTicks = 5
-        val textPaint =
-            Paint().apply {
-                color = textColorArgb
-                textSize = labelSizePx
-                isAntiAlias = true
-                textAlign = Paint.Align.RIGHT
-                typeface = Typeface.DEFAULT
-            }
-        for (i in 0..yTicks) {
-            val value = yMin + (yMax - yMin) * i / yTicks
-            val y = yPos(value)
-            drawContext.canvas.nativeCanvas.drawText(
-                "%.1f".format(value),
-                leftPadding - 6.dp.toPx(),
-                y + labelSizePx / 3,
-                textPaint,
-            )
-            // Grid line
-            drawLine(
-                color = Color.Gray.copy(alpha = 0.15f),
-                start = Offset(leftPadding, y),
-                end = Offset(size.width - rightPadding, y),
-                strokeWidth = 1f,
-            )
-        }
-
-        // X-axis labels
-        val xLabelPaint =
-            Paint().apply {
-                color = textColorArgb
-                textSize = labelSizePx * 0.9f
-                isAntiAlias = true
-                textAlign = Paint.Align.CENTER
-                typeface = Typeface.DEFAULT
-            }
-        val xLabelStep = ceil(state.dateLabels.size.toFloat() / 7f).toInt().coerceAtLeast(1)
-        for (i in state.dateLabels.indices step xLabelStep) {
-            val (dayIndex, label) = state.dateLabels[i]
-            val x = xPos(dayIndex)
-            drawContext.canvas.nativeCanvas.drawText(
-                label,
-                x,
-                size.height - 2.dp.toPx(),
-                xLabelPaint,
-            )
-        }
-
-        // Clip data lines to reveal fraction
-        clipRect(
-            left = leftPadding,
-            top = 0f,
-            right = leftPadding + chartWidth * revealFraction.value,
-            bottom = size.height,
+                        detectDragGestures(
+                            onDragStart = { offset ->
+                                val pt = findNearest(offset.x)
+                                touchOffset = pt?.canvasOffset ?: offset
+                                selectedPoint = pt
+                            },
+                            onDrag = { change, _ ->
+                                change.consume()
+                                val pt = findNearest(change.position.x)
+                                touchOffset = pt?.canvasOffset ?: change.position
+                                selectedPoint = pt
+                            },
+                            onDragEnd = {
+                                touchOffset = null
+                                selectedPoint = null
+                            },
+                            onDragCancel = {
+                                touchOffset = null
+                                selectedPoint = null
+                            },
+                        )
+                    },
         ) {
-            // Draw actual weight line (blue)
-            if (state.actualPoints.size >= 2) {
-                val path = Path()
-                state.actualPoints.forEachIndexed { i, pt ->
-                    val x = xPos(pt.dayIndex)
-                    val y = yPos(pt.weight)
-                    if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
-                }
-                drawPath(path, color = WeightBlue, style = Stroke(width = 3f, cap = StrokeCap.Round))
-                state.actualPoints.forEach { pt ->
-                    drawCircle(color = WeightBlue, radius = 3f, center = Offset(xPos(pt.dayIndex), yPos(pt.weight)))
-                }
-            }
+            val leftPadding = leftPaddingDp.toPx()
+            val bottomPadding = bottomPaddingDp.toPx()
+            val topPadding = topPaddingDp.toPx()
+            val rightPadding = rightPaddingDp.toPx()
 
-            // Draw moving average line (green)
-            val avgPoints = state.movingAvgPoints
-            if (avgPoints.size >= 2) {
-                val path = Path()
-                avgPoints.forEachIndexed { i, pt ->
-                    val x = xPos(pt.dayIndex)
-                    val y = yPos(pt.weight)
-                    if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
-                }
-                drawPath(path, color = TrendGreen, style = Stroke(width = 2.5f, cap = StrokeCap.Round))
-            }
+            val chartWidth = size.width - leftPadding - rightPadding
+            val chartHeight = size.height - topPadding - bottomPadding
 
-            // Draw projection line (purple dashed)
-            val projPoints = state.projectionPoints
-            if (projPoints.size >= 2) {
-                val path = Path()
-                projPoints.forEachIndexed { i, pt ->
-                    val x = xPos(pt.dayIndex)
-                    val y = yPos(pt.weight)
-                    if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+            val state = chartState
+            val yMin = state.yMin
+            val yMax = state.yMax
+            val yRange = (yMax - yMin).coerceAtLeast(1f)
+            val maxDayIndex = state.maxDayIndex.coerceAtLeast(1f)
+
+            fun xPos(dayIndex: Float): Float = leftPadding + (dayIndex / maxDayIndex) * chartWidth
+
+            fun yPos(value: Float): Float = topPadding + (1f - (value - yMin) / yRange) * chartHeight
+
+            val yTicks = 5
+            val textPaint =
+                Paint().apply {
+                    color = textColorArgb
+                    textSize = labelSizePx
+                    isAntiAlias = true
+                    textAlign = Paint.Align.RIGHT
+                    typeface = Typeface.DEFAULT
                 }
-                drawPath(
-                    path,
-                    color = ProjectionPurple,
-                    style =
-                        Stroke(
-                            width = 2.5f,
-                            cap = StrokeCap.Round,
-                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(12f, 8f)),
-                        ),
+            for (i in 0..yTicks) {
+                val value = yMin + (yMax - yMin) * i / yTicks
+                val y = yPos(value)
+                drawContext.canvas.nativeCanvas.drawText(
+                    "%.1f".format(value),
+                    leftPadding - 6.dp.toPx(),
+                    y + labelSizePx / 3,
+                    textPaint,
                 )
+                drawLine(
+                    color = Color.Gray.copy(alpha = 0.15f),
+                    start = Offset(leftPadding, y),
+                    end = Offset(size.width - rightPadding, y),
+                    strokeWidth = 1f,
+                )
+            }
+
+            val xLabelPaint =
+                Paint().apply {
+                    color = textColorArgb
+                    textSize = labelSizePx * 0.9f
+                    isAntiAlias = true
+                    textAlign = Paint.Align.CENTER
+                    typeface = Typeface.DEFAULT
+                }
+            val xLabelStep = ceil(state.dateLabels.size.toFloat() / 7f).toInt().coerceAtLeast(1)
+            for (i in state.dateLabels.indices step xLabelStep) {
+                val (dayIndex, label) = state.dateLabels[i]
+                val x = xPos(dayIndex)
+                drawContext.canvas.nativeCanvas.drawText(
+                    label,
+                    x,
+                    size.height - 2.dp.toPx(),
+                    xLabelPaint,
+                )
+            }
+
+            clipRect(
+                left = leftPadding,
+                top = 0f,
+                right = leftPadding + chartWidth * revealFraction.value,
+                bottom = size.height,
+            ) {
+                if (state.actualPoints.size >= 2) {
+                    val path = Path()
+                    state.actualPoints.forEachIndexed { i, pt ->
+                        val x = xPos(pt.dayIndex)
+                        val y = yPos(pt.weight)
+                        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                    }
+                    drawPath(path, color = WeightBlue, style = Stroke(width = 3f, cap = StrokeCap.Round))
+                    state.actualPoints.forEach { pt ->
+                        drawCircle(color = WeightBlue, radius = 3f, center = Offset(xPos(pt.dayIndex), yPos(pt.weight)))
+                    }
+                }
+
+                val avgPoints = state.movingAvgPoints
+                if (avgPoints.size >= 2) {
+                    val path = Path()
+                    avgPoints.forEachIndexed { i, pt ->
+                        val x = xPos(pt.dayIndex)
+                        val y = yPos(pt.weight)
+                        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                    }
+                    drawPath(path, color = TrendGreen, style = Stroke(width = 2.5f, cap = StrokeCap.Round))
+                }
+
+                val projPoints = state.projectionPoints
+                if (projPoints.size >= 2) {
+                    val path = Path()
+                    projPoints.forEachIndexed { i, pt ->
+                        val x = xPos(pt.dayIndex)
+                        val y = yPos(pt.weight)
+                        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                    }
+                    drawPath(
+                        path,
+                        color = ProjectionPurple,
+                        style =
+                            Stroke(
+                                width = 2.5f,
+                                cap = StrokeCap.Round,
+                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(12f, 8f)),
+                            ),
+                    )
+                }
+
+                // Crosshair and highlight for selected point
+                val sel = selectedPoint
+                if (sel != null) {
+                    drawLine(
+                        color = Color.Gray.copy(alpha = 0.5f),
+                        start = Offset(sel.canvasOffset.x, topPadding),
+                        end = Offset(sel.canvasOffset.x, topPadding + chartHeight),
+                        strokeWidth = 1f,
+                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 4f)),
+                    )
+                    drawCircle(
+                        color = WeightBlue,
+                        radius = 6f,
+                        center = sel.canvasOffset,
+                    )
+                    drawCircle(
+                        color = Color.White,
+                        radius = 3f,
+                        center = sel.canvasOffset,
+                    )
+                }
+            }
+        }
+
+        val sel = selectedPoint
+        val tOff = touchOffset
+        ChartTooltip(
+            visible = sel != null && tOff != null,
+            touchOffset = tOff ?: Offset.Zero,
+            containerSize = containerSize,
+        ) {
+            if (sel != null) {
+                Column {
+                    Text(
+                        sel.date,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
+                    )
+                    Text(
+                        "%.1f kg".format(sel.weight),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                    )
+                    if (sel.movingAvg != null) {
+                        Text(
+                            "Avg: %.1f kg".format(sel.movingAvg),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
+                        )
+                    }
+                }
             }
         }
     }
@@ -238,15 +368,12 @@ private fun computeChartState(
         }
 
     val movingAvgPoints =
-        trendData.mapNotNull { entry ->
-            entry.movingAvg?.let {
-                val date = LocalDate.parse(entry.entryDate.take(10))
-                val dayIndex = (date.toEpochDays() - firstDate.toEpochDays()).toFloat()
-                ProjectionPoint(dayIndex, it.toFloat())
-            }
+        trendData.map { entry ->
+            val date = LocalDate.parse(entry.entryDate.take(10))
+            val dayIndex = (date.toEpochDays() - firstDate.toEpochDays()).toFloat()
+            ProjectionPoint(dayIndex, entry.movingAvg.toFloat())
         }
 
-    // Linear regression for projection
     val projectionPoints = mutableListOf<ProjectionPoint>()
     if (projectionDays > 0 && trendData.size >= 3) {
         val regressionPoints = actualPoints.map { it.dayIndex to it.weight }
@@ -263,7 +390,6 @@ private fun computeChartState(
     val lastDayIndex = actualPoints.lastOrNull()?.dayIndex ?: 0f
     val maxDayIndex = lastDayIndex + projectionDays.coerceAtLeast(0)
 
-    // Date labels paired with their dayIndex for correct positioning
     val dateLabels = mutableListOf<Pair<Float, String>>()
     for (entry in trendData) {
         val date = LocalDate.parse(entry.entryDate.take(10))
@@ -278,7 +404,6 @@ private fun computeChartState(
         }
     }
 
-    // Compute Y range with 15% padding
     val allValues = mutableListOf<Float>()
     actualPoints.forEach { allValues.add(it.weight) }
     movingAvgPoints.forEach { allValues.add(it.weight) }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/WeightTrendChart.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/WeightTrendChart.kt
@@ -29,10 +29,12 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.bissbilanz.android.R
 import com.bissbilanz.android.ui.theme.ProjectionPurple
 import com.bissbilanz.android.ui.theme.TrendGreen
 import com.bissbilanz.android.ui.theme.WeightBlue
@@ -118,6 +120,30 @@ fun WeightTrendChart(
     val topPaddingDp = 8.dp
     val rightPaddingDp = 8.dp
 
+    val textPaint =
+        remember(textColorArgb, labelSizePx) {
+            Paint().apply {
+                color = textColorArgb
+                textSize = labelSizePx
+                isAntiAlias = true
+                textAlign = Paint.Align.RIGHT
+                typeface = Typeface.DEFAULT
+            }
+        }
+    val xLabelPaint =
+        remember(textColorArgb, labelSizePx) {
+            Paint().apply {
+                color = textColorArgb
+                textSize = labelSizePx * 0.9f
+                isAntiAlias = true
+                textAlign = Paint.Align.CENTER
+                typeface = Typeface.DEFAULT
+            }
+        }
+
+    val weightFormat = stringResource(R.string.chart_weight_format)
+    val weightAvgFormat = stringResource(R.string.chart_weight_avg_format)
+
     Box(
         modifier = modifier.onSizeChanged { containerSize = it },
     ) {
@@ -192,19 +218,11 @@ fun WeightTrendChart(
             fun yPos(value: Float): Float = topPadding + (1f - (value - yMin) / yRange) * chartHeight
 
             val yTicks = 5
-            val textPaint =
-                Paint().apply {
-                    color = textColorArgb
-                    textSize = labelSizePx
-                    isAntiAlias = true
-                    textAlign = Paint.Align.RIGHT
-                    typeface = Typeface.DEFAULT
-                }
             for (i in 0..yTicks) {
                 val value = yMin + (yMax - yMin) * i / yTicks
                 val y = yPos(value)
                 drawContext.canvas.nativeCanvas.drawText(
-                    "%.1f".format(value),
+                    weightFormat.format(value),
                     leftPadding - 6.dp.toPx(),
                     y + labelSizePx / 3,
                     textPaint,
@@ -217,14 +235,6 @@ fun WeightTrendChart(
                 )
             }
 
-            val xLabelPaint =
-                Paint().apply {
-                    color = textColorArgb
-                    textSize = labelSizePx * 0.9f
-                    isAntiAlias = true
-                    textAlign = Paint.Align.CENTER
-                    typeface = Typeface.DEFAULT
-                }
             val xLabelStep = ceil(state.dateLabels.size.toFloat() / 7f).toInt().coerceAtLeast(1)
             for (i in state.dateLabels.indices step xLabelStep) {
                 val (dayIndex, label) = state.dateLabels[i]
@@ -326,14 +336,14 @@ fun WeightTrendChart(
                         color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
                     )
                     Text(
-                        "%.1f kg".format(sel.weight),
+                        weightFormat.format(sel.weight),
                         style = MaterialTheme.typography.labelMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.inverseOnSurface,
                     )
                     if (sel.movingAvg != null) {
                         Text(
-                            "Avg: %.1f kg".format(sel.movingAvg),
+                            weightAvgFormat.format(sel.movingAvg),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
                         )

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DashboardScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DashboardScreen.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import com.bissbilanz.ErrorReporter
-import com.bissbilanz.android.sync.RefreshManager
 import com.bissbilanz.android.ui.components.EntryEditSheet
 import com.bissbilanz.android.ui.components.MacroRing
 import com.bissbilanz.android.ui.components.MealCard
@@ -31,8 +29,6 @@ import com.bissbilanz.android.ui.components.SupplementsWidget
 import com.bissbilanz.android.ui.components.WeightWidget
 import com.bissbilanz.android.ui.theme.*
 import com.bissbilanz.android.ui.viewmodels.DashboardViewModel
-import com.bissbilanz.repository.EntryRepository
-import com.bissbilanz.repository.PreferencesRepository
 import com.bissbilanz.util.DefaultGoals
 import com.bissbilanz.util.mealTypes
 import com.bissbilanz.util.resolvedCalories
@@ -43,7 +39,6 @@ import com.bissbilanz.util.resolvedProtein
 import kotlinx.coroutines.launch
 import kotlinx.datetime.*
 import org.koin.androidx.compose.koinViewModel
-import org.koin.compose.koinInject
 
 @Composable
 fun DashboardScreen(navController: NavController) {
@@ -53,13 +48,17 @@ fun DashboardScreen(navController: NavController) {
     val selectedDate by viewModel.selectedDate.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
 
-    val entryRepo: EntryRepository = koinInject()
-    val prefsRepo: PreferencesRepository = koinInject()
-    val refreshManager: RefreshManager = koinInject()
-    val errorReporter: ErrorReporter = koinInject()
-    val prefs by prefsRepo.preferences().collectAsStateWithLifecycle(null)
-    val scope = rememberCoroutineScope()
+    val prefs by viewModel.prefs.collectAsStateWithLifecycle()
+    val snackbarMessage by viewModel.snackbarMessage.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(snackbarMessage) {
+        snackbarMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSnackbar()
+        }
+    }
     val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
     var showQuickAddSheet by remember { mutableStateOf(false) }
 
@@ -111,7 +110,7 @@ fun DashboardScreen(navController: NavController) {
         }
 
         PullToRefreshWrapper(
-            onRefresh = { refreshManager.refreshAll(selectedDate.toString()) },
+            onRefresh = { viewModel.refreshAll() },
             modifier = Modifier.fillMaxSize().padding(padding),
         ) {
             Column(
@@ -208,20 +207,7 @@ fun DashboardScreen(navController: NavController) {
                                         )
                                         Spacer(modifier = Modifier.height(16.dp))
                                         OutlinedButton(
-                                            onClick = {
-                                                scope.launch {
-                                                    try {
-                                                        val yesterday = selectedDate.minus(1, DateTimeUnit.DAY).toString()
-                                                        val count = entryRepo.copyEntries(yesterday, selectedDate.toString())
-                                                        snackbarHostState.showSnackbar("Copied $count entries from yesterday")
-                                                        viewModel.loadData()
-                                                    } catch (e: Exception) {
-                                                        if (e is kotlinx.coroutines.CancellationException) throw e
-                                                        errorReporter.captureException(e)
-                                                        snackbarHostState.showSnackbar("No entries to copy from yesterday")
-                                                    }
-                                                }
-                                            },
+                                            onClick = { viewModel.copyEntriesFromYesterday() },
                                         ) {
                                             Icon(Icons.Default.ContentCopy, "Copy", modifier = Modifier.size(18.dp))
                                             Spacer(modifier = Modifier.width(8.dp))

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DashboardScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DashboardScreen.kt
@@ -154,18 +154,66 @@ fun DashboardScreen(navController: NavController) {
 
                 Spacer(modifier = Modifier.height(16.dp))
 
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    MacroRing(
+                        "Calories",
+                        totalCalories,
+                        goals?.calorieGoal ?: DefaultGoals.CALORIES,
+                        CaloriesBlue,
+                        size = 88.dp,
+                        strokeWidth = 8.dp,
+                        showGoal = true,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                 ) {
-                    MacroRing("Cal", totalCalories, goals?.calorieGoal ?: DefaultGoals.CALORIES, CaloriesBlue, showGoal = true)
-                    MacroRing("Protein", totalProtein, goals?.proteinGoal ?: DefaultGoals.PROTEIN, ProteinRed, showGoal = true)
-                    MacroRing("Carbs", totalCarbs, goals?.carbGoal ?: DefaultGoals.CARBS, CarbsOrange, showGoal = true)
-                    MacroRing("Fat", totalFat, goals?.fatGoal ?: DefaultGoals.FAT, FatYellow, showGoal = true)
-                    MacroRing("Fiber", totalFiber, goals?.fiberGoal ?: DefaultGoals.FIBER, FiberGreen, showGoal = true)
+                    MacroRing(
+                        "Protein",
+                        totalProtein,
+                        goals?.proteinGoal ?: DefaultGoals.PROTEIN,
+                        ProteinRed,
+                        size = 56.dp,
+                        strokeWidth = 5.dp,
+                        showGoal = true,
+                    )
+                    MacroRing(
+                        "Carbs",
+                        totalCarbs,
+                        goals?.carbGoal ?: DefaultGoals.CARBS,
+                        CarbsOrange,
+                        size = 56.dp,
+                        strokeWidth = 5.dp,
+                        showGoal = true,
+                    )
+                    MacroRing(
+                        "Fat",
+                        totalFat,
+                        goals?.fatGoal ?: DefaultGoals.FAT,
+                        FatYellow,
+                        size = 56.dp,
+                        strokeWidth = 5.dp,
+                        showGoal = true,
+                    )
+                    MacroRing(
+                        "Fiber",
+                        totalFiber,
+                        goals?.fiberGoal ?: DefaultGoals.FIBER,
+                        FiberGreen,
+                        size = 56.dp,
+                        strokeWidth = 5.dp,
+                        showGoal = true,
+                    )
                 }
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(28.dp))
 
                 Crossfade(targetState = isLoading, label = "dashboard") { loading ->
                     if (loading) {
@@ -219,7 +267,7 @@ fun DashboardScreen(navController: NavController) {
 
                             // Supplements widget
                             if (prefs?.showSupplementsWidget == true) {
-                                Spacer(modifier = Modifier.height(8.dp))
+                                Spacer(modifier = Modifier.height(16.dp))
                                 SupplementsWidget(
                                     date = selectedDate.toString(),
                                     onViewAll = { navController.navigate("supplements") },
@@ -228,13 +276,15 @@ fun DashboardScreen(navController: NavController) {
 
                             // Weight widget
                             if (prefs?.showWeightWidget == true) {
-                                Spacer(modifier = Modifier.height(8.dp))
+                                Spacer(modifier = Modifier.height(16.dp))
                                 WeightWidget(
                                     date = selectedDate.toString(),
                                     onViewAll = { navController.navigate("weight") },
                                     onError = { msg -> scope.launch { snackbarHostState.showSnackbar(msg) } },
                                 )
                             }
+
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     }
                 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DashboardScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DashboardScreen.kt
@@ -33,6 +33,7 @@ import com.bissbilanz.android.ui.theme.*
 import com.bissbilanz.android.ui.viewmodels.DashboardViewModel
 import com.bissbilanz.repository.EntryRepository
 import com.bissbilanz.repository.PreferencesRepository
+import com.bissbilanz.util.DefaultGoals
 import com.bissbilanz.util.mealTypes
 import com.bissbilanz.util.resolvedCalories
 import com.bissbilanz.util.resolvedCarbs
@@ -158,11 +159,11 @@ fun DashboardScreen(navController: NavController) {
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                 ) {
-                    MacroRing("Cal", totalCalories, goals?.calorieGoal ?: 2000.0, CaloriesBlue, showGoal = true)
-                    MacroRing("Protein", totalProtein, goals?.proteinGoal ?: 150.0, ProteinRed, showGoal = true)
-                    MacroRing("Carbs", totalCarbs, goals?.carbGoal ?: 250.0, CarbsOrange, showGoal = true)
-                    MacroRing("Fat", totalFat, goals?.fatGoal ?: 65.0, FatYellow, showGoal = true)
-                    MacroRing("Fiber", totalFiber, goals?.fiberGoal ?: 30.0, FiberGreen, showGoal = true)
+                    MacroRing("Cal", totalCalories, goals?.calorieGoal ?: DefaultGoals.CALORIES, CaloriesBlue, showGoal = true)
+                    MacroRing("Protein", totalProtein, goals?.proteinGoal ?: DefaultGoals.PROTEIN, ProteinRed, showGoal = true)
+                    MacroRing("Carbs", totalCarbs, goals?.carbGoal ?: DefaultGoals.CARBS, CarbsOrange, showGoal = true)
+                    MacroRing("Fat", totalFat, goals?.fatGoal ?: DefaultGoals.FAT, FatYellow, showGoal = true)
+                    MacroRing("Fiber", totalFiber, goals?.fiberGoal ?: DefaultGoals.FIBER, FiberGreen, showGoal = true)
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DayLogScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DayLogScreen.kt
@@ -61,6 +61,7 @@ fun DayLogScreen(
     var entryToDelete by remember { mutableStateOf<Entry?>(null) }
     var editingEntryId by remember { mutableStateOf<String?>(null) }
     var showQuickAddSheet by remember { mutableStateOf(false) }
+    var showCopyDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(date) {
@@ -103,6 +104,39 @@ fun DayLogScreen(
         )
     }
 
+    if (showCopyDialog) {
+        val parsedDate = LocalDate.parse(date)
+        val yesterday = parsedDate.minus(1, DateTimeUnit.DAY).toString()
+        AlertDialog(
+            onDismissRequest = { showCopyDialog = false },
+            title = { Text("Copy from yesterday") },
+            text = { Text("This will copy all entries from $yesterday to $date. Existing entries will not be affected.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCopyDialog = false
+                        scope.launch {
+                            try {
+                                val count = entryRepo.copyEntries(yesterday, date)
+                                snackbarHostState.showSnackbar("Copied $count entries")
+                                viewModel.loadEntries(date, force = true)
+                            } catch (e: Exception) {
+                                if (e is kotlinx.coroutines.CancellationException) throw e
+                                errorReporter.captureException(e)
+                                snackbarHostState.showSnackbar("No entries to copy")
+                            }
+                        }
+                    },
+                ) {
+                    Text("Copy")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCopyDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -113,21 +147,7 @@ fun DayLogScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = {
-                        scope.launch {
-                            try {
-                                val parsedDate = LocalDate.parse(date)
-                                val yesterday = parsedDate.minus(1, DateTimeUnit.DAY).toString()
-                                val count = entryRepo.copyEntries(yesterday, date)
-                                snackbarHostState.showSnackbar("Copied $count entries")
-                                viewModel.loadEntries(date, force = true)
-                            } catch (e: Exception) {
-                                if (e is kotlinx.coroutines.CancellationException) throw e
-                                errorReporter.captureException(e)
-                                snackbarHostState.showSnackbar("No entries to copy")
-                            }
-                        }
-                    }) {
+                    IconButton(onClick = { showCopyDialog = true }) {
                         Icon(Icons.Default.ContentCopy, "Copy from yesterday")
                     }
                     IconButton(onClick = { showQuickAddSheet = true }) {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DayLogScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/DayLogScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -270,7 +271,7 @@ fun DayLogScreen(
                                 }
                             }
                             items(mealEntries, key = { it.id }) { entry ->
-                                Box(modifier = Modifier.animateItem()) {
+                                Box(modifier = Modifier.animateItem().padding(vertical = 2.dp)) {
                                     SwipeToDismissEntry(
                                         entry = entry,
                                         onDelete = { entryToDelete = entry },
@@ -349,7 +350,7 @@ fun EntryListItem(
         onClick = onClick,
     ) {
         ListItem(
-            headlineContent = { Text(name) },
+            headlineContent = { Text(name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
             supportingContent = {
                 Text("${entry.servings}x  ·  ${calories.roundToInt()} cal  ·  P ${protein.roundToInt()}g")
             },

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FavoritesScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FavoritesScreen.kt
@@ -125,13 +125,17 @@ fun FavoritesScreen(navController: NavController) {
                 Text("Favorites", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
                 Spacer(modifier = Modifier.height(8.dp))
 
-                TabRow(selectedTabIndex = selectedTab) {
-                    Tab(selected = selectedTab == 0, onClick = { viewModel.selectTab(0) }, text = { Text("Foods (${favorites.size})") })
-                    Tab(
-                        selected = selectedTab == 1,
-                        onClick = { viewModel.selectTab(1) },
-                        text = { Text("Recipes (${favoriteRecipes.size})") },
-                    )
+                val tabLabels = listOf("Foods (${favorites.size})", "Recipes (${favoriteRecipes.size})")
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    tabLabels.forEachIndexed { index, label ->
+                        SegmentedButton(
+                            selected = selectedTab == index,
+                            onClick = { viewModel.selectTab(index) },
+                            shape = SegmentedButtonDefaults.itemShape(index, tabLabels.size),
+                        ) {
+                            Text(label)
+                        }
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(12.dp))

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FavoritesScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FavoritesScreen.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -32,7 +30,6 @@ import com.bissbilanz.model.Recipe
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
-import kotlin.math.roundToInt
 
 @Composable
 fun FavoritesScreen(navController: NavController) {
@@ -147,18 +144,14 @@ fun FavoritesScreen(navController: NavController) {
                             EmptyState("No favorite foods yet.\nMark foods as favorite to see them here.")
                         } else {
                             LazyVerticalGrid(
-                                columns = GridCells.Fixed(2),
+                                columns = GridCells.Fixed(3),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
                                 items(favorites, key = { it.id }) { food ->
                                     FavoriteCard(
                                         name = food.name,
-                                        subtitle = "${food.calories.roundToInt()} cal",
-                                        secondaryText =
-                                            "P${food.protein.roundToInt()} C${food.carbs.roundToInt()} F${food.fat.roundToInt()}",
                                         imageUrl = food.imageUrl?.let { if (it.startsWith("/")) "$baseUrl$it" else it },
-                                        onClick = { navController.navigate("food/${food.id}") },
                                         onQuickLog = {
                                             handleQuickLog(
                                                 viewModel = viewModel,
@@ -177,17 +170,14 @@ fun FavoritesScreen(navController: NavController) {
                             EmptyState("No favorite recipes yet.\nMark recipes as favorite to see them here.")
                         } else {
                             LazyVerticalGrid(
-                                columns = GridCells.Fixed(2),
+                                columns = GridCells.Fixed(3),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
                                 items(favoriteRecipes, key = { it.id }) { recipe ->
                                     FavoriteCard(
                                         name = recipe.name,
-                                        subtitle = "${recipe.totalServings.toInt()} servings",
-                                        secondaryText = "${recipe.ingredients?.size ?: 0} ingredients",
                                         imageUrl = recipe.imageUrl?.let { if (it.startsWith("/")) "$baseUrl$it" else it },
-                                        onClick = { navController.navigate("recipe/${recipe.id}") },
                                         onQuickLog = {
                                             handleQuickLog(
                                                 viewModel = viewModel,
@@ -235,14 +225,11 @@ private fun handleQuickLog(
 @Composable
 fun FavoriteCard(
     name: String,
-    subtitle: String,
-    secondaryText: String,
     imageUrl: String? = null,
-    onClick: () -> Unit,
     onQuickLog: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(modifier = modifier.clickable(onClick = onClick)) {
+    Card(modifier = modifier.clickable(onClick = onQuickLog)) {
         Column {
             imageUrl?.let { url ->
                 AsyncImage(
@@ -251,41 +238,19 @@ fun FavoriteCard(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .height(80.dp)
+                            .height(56.dp)
                             .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
                     contentScale = ContentScale.Crop,
                 )
             }
-            Column(modifier = Modifier.padding(12.dp)) {
-                Text(
-                    name,
-                    style = MaterialTheme.typography.titleSmall,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    fontWeight = FontWeight.Medium,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = CaloriesBlue,
-                )
-                Text(
-                    secondaryText,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                FilledTonalButton(
-                    onClick = onQuickLog,
-                    modifier = Modifier.fillMaxWidth(),
-                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
-                ) {
-                    Icon(Icons.Default.Add, "Log", modifier = Modifier.size(16.dp))
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text("Quick log", style = MaterialTheme.typography.labelSmall)
-                }
-            }
+            Text(
+                name,
+                style = MaterialTheme.typography.labelMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(8.dp),
+            )
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodDetailScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -174,7 +175,26 @@ fun FoodDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(food?.name ?: "Food") },
+                title = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        if (food?.isFavorite == true) {
+                            Icon(
+                                Icons.Default.Star,
+                                contentDescription = "Favorite",
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        Text(
+                            food?.name ?: "Food",
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodDetailScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodDetailScreen.kt
@@ -130,15 +130,7 @@ fun FoodDetailScreen(
             onDismiss = { showEditSheet = false },
             onSaved = {
                 showEditSheet = false
-                scope.launch {
-                    try {
-                        food = foodRepo.getFood(foodId)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        errorReporter.captureException(e)
-                        snackbarHostState.showSnackbar("Failed to refresh food")
-                    }
-                }
+                food = foodRepo.getFoodCached(foodId) ?: food
             },
         )
     }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodSearchScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodSearchScreen.kt
@@ -140,9 +140,17 @@ fun FoodSearchScreen(navController: NavController) {
                     }
                 } else {
                     Spacer(modifier = Modifier.height(8.dp))
-                    TabRow(selectedTabIndex = selectedTab) {
-                        Tab(selected = selectedTab == 0, onClick = { viewModel.selectTab(0) }, text = { Text("Recent") })
-                        Tab(selected = selectedTab == 1, onClick = { viewModel.selectTab(1) }, text = { Text("All") })
+                    val tabLabels = listOf("Recent", "All")
+                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                        tabLabels.forEachIndexed { index, label ->
+                            SegmentedButton(
+                                selected = selectedTab == index,
+                                onClick = { viewModel.selectTab(index) },
+                                shape = SegmentedButtonDefaults.itemShape(index, tabLabels.size),
+                            ) {
+                                Text(label)
+                            }
+                        }
                     }
 
                     Spacer(modifier = Modifier.height(8.dp))

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodSearchScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/FoodSearchScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -226,7 +227,7 @@ fun FoodListItem(
     modifier: Modifier = Modifier,
 ) {
     ListItem(
-        headlineContent = { Text(food.name) },
+        headlineContent = { Text(food.name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
         leadingContent =
             food.imageUrl?.let { url ->
                 {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -1,46 +1,54 @@
 package com.bissbilanz.android.ui.screens
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.EaseOutCubic
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.clipRect
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bissbilanz.android.sync.RefreshManager
 import com.bissbilanz.android.ui.components.CalendarHeatmap
-import com.bissbilanz.android.ui.components.ChartTooltip
 import com.bissbilanz.android.ui.components.CollapsibleCard
 import com.bissbilanz.android.ui.components.MacroRadarChart
+import com.bissbilanz.android.ui.components.MealColors
 import com.bissbilanz.android.ui.components.PullToRefreshWrapper
 import com.bissbilanz.android.ui.components.RadarAxis
-import com.bissbilanz.android.ui.theme.*
+import com.bissbilanz.android.ui.components.SimpleLineChart
+import com.bissbilanz.android.ui.components.SimplePieChart
+import com.bissbilanz.android.ui.theme.CaloriesBlue
+import com.bissbilanz.android.ui.theme.CarbsOrange
+import com.bissbilanz.android.ui.theme.FatYellow
+import com.bissbilanz.android.ui.theme.FiberGreen
+import com.bissbilanz.android.ui.theme.GentleSpring
+import com.bissbilanz.android.ui.theme.ProteinRed
 import com.bissbilanz.android.ui.viewmodels.InsightsViewModel
 import com.bissbilanz.model.DailyStatsEntry
 import com.bissbilanz.model.Goals
@@ -283,109 +291,6 @@ fun InsightsScreen() {
     }
 }
 
-@Composable
-fun SimpleLineChart(
-    data: List<Float>,
-    color: Color,
-    modifier: Modifier = Modifier,
-    unit: String = "",
-) {
-    if (data.isEmpty()) return
-    val maxVal = data.max().coerceAtLeast(1f)
-    val minVal = data.min()
-
-    val revealFraction = remember { Animatable(0f) }
-    LaunchedEffect(data) {
-        revealFraction.snapTo(0f)
-        revealFraction.animateTo(1f, animationSpec = tween(500, easing = EaseOutCubic))
-    }
-
-    var containerSize by remember { mutableStateOf(IntSize.Zero) }
-    var selectedIndex by remember { mutableStateOf<Int?>(null) }
-    var touchOffset by remember { mutableStateOf<Offset?>(null) }
-
-    Box(modifier = modifier.onSizeChanged { containerSize = it }) {
-        Canvas(
-            modifier =
-                Modifier
-                    .matchParentSize()
-                    .pointerInput(data) {
-                        detectDragGestures(
-                            onDragStart = { offset ->
-                                val stepX = size.width.toFloat() / (data.size - 1).coerceAtLeast(1)
-                                val idx = (offset.x / stepX).toInt().coerceIn(0, data.lastIndex)
-                                selectedIndex = idx
-                                touchOffset = offset
-                            },
-                            onDrag = { change, _ ->
-                                change.consume()
-                                val stepX = size.width.toFloat() / (data.size - 1).coerceAtLeast(1)
-                                val idx = (change.position.x / stepX).toInt().coerceIn(0, data.lastIndex)
-                                selectedIndex = idx
-                                touchOffset = change.position
-                            },
-                            onDragEnd = {
-                                selectedIndex = null
-                                touchOffset = null
-                            },
-                            onDragCancel = {
-                                selectedIndex = null
-                                touchOffset = null
-                            },
-                        )
-                    },
-        ) {
-            clipRect(right = size.width * revealFraction.value) {
-                val stepX = size.width / (data.size - 1).coerceAtLeast(1)
-                val range = (maxVal - minVal).coerceAtLeast(1f)
-                val padding = 8f
-
-                val path = Path()
-                data.forEachIndexed { i, value ->
-                    val x = i * stepX
-                    val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
-                    if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
-                }
-
-                drawPath(path, color = color, style = Stroke(width = 3f, cap = StrokeCap.Round))
-
-                data.forEachIndexed { i, value ->
-                    val x = i * stepX
-                    val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
-                    val isSelected = selectedIndex == i
-                    drawCircle(color = color, radius = if (isSelected) 6f else 3f, center = Offset(x, y))
-                    if (isSelected) {
-                        drawCircle(color = Color.White, radius = 3f, center = Offset(x, y))
-                        drawLine(
-                            color = Color.Gray.copy(alpha = 0.4f),
-                            start = Offset(x, 0f),
-                            end = Offset(x, size.height),
-                            strokeWidth = 1f,
-                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 3f)),
-                        )
-                    }
-                }
-            }
-        }
-
-        val selIdx = selectedIndex
-        val tOff = touchOffset
-        ChartTooltip(
-            visible = selIdx != null && tOff != null,
-            touchOffset = tOff ?: Offset.Zero,
-            containerSize = containerSize,
-        ) {
-            if (selIdx != null && selIdx in data.indices) {
-                Text(
-                    "${data[selIdx].roundToInt()}${ if (unit.isNotEmpty()) " $unit" else "" }",
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.inverseOnSurface,
-                )
-            }
-        }
-    }
-}
 
 @Composable
 private fun ComparisonRow(
@@ -497,140 +402,6 @@ private fun MacroTrendRow(
     }
 }
 
-private val MealColors =
-    listOf(
-        Color(0xFF3B82F6),
-        Color(0xFFEF4444),
-        Color(0xFFF97316),
-        Color(0xFFEAB308),
-        Color(0xFF22C55E),
-        Color(0xFF8B5CF6),
-        Color(0xFFEC4899),
-        Color(0xFF14B8A6),
-    )
-
-@Composable
-private fun SimplePieChart(
-    entries: List<MealBreakdownEntry>,
-    modifier: Modifier = Modifier,
-) {
-    val total = entries.sumOf { it.calories }.toFloat()
-    if (total <= 0f) return
-    val surfaceColor = MaterialTheme.colorScheme.surfaceContainerLow
-
-    val sweepFraction = remember { Animatable(0f) }
-    LaunchedEffect(entries) {
-        sweepFraction.snapTo(0f)
-        sweepFraction.animateTo(1f, animationSpec = tween(600, easing = EaseOutCubic))
-    }
-
-    var containerSize by remember { mutableStateOf(IntSize.Zero) }
-    var selectedIndex by remember { mutableStateOf<Int?>(null) }
-    var tapOffset by remember { mutableStateOf(Offset.Zero) }
-
-    Box(modifier = modifier.onSizeChanged { containerSize = it }) {
-        Canvas(
-            modifier =
-                Modifier
-                    .matchParentSize()
-                    .pointerInput(entries) {
-                        detectTapGestures { offset ->
-                            val cx = size.width / 2f
-                            val cy = size.height / 2f
-                            val diameter = minOf(size.width, size.height) * 0.8f
-                            val radius = diameter / 2f
-                            val innerRadius = radius * 0.5f
-
-                            val dx = offset.x - cx
-                            val dy = offset.y - cy
-                            val dist = kotlin.math.sqrt(dx * dx + dy * dy)
-
-                            if (dist < innerRadius || dist > radius) {
-                                selectedIndex = null
-                                return@detectTapGestures
-                            }
-
-                            var angle = Math.toDegrees(kotlin.math.atan2(dy.toDouble(), dx.toDouble())).toFloat()
-                            angle = (angle + 90f + 360f) % 360f
-
-                            var cumulative = 0f
-                            var found = -1
-                            for (i in entries.indices) {
-                                val sweep = (entries[i].calories.toFloat() / total) * 360f
-                                if (angle >= cumulative && angle < cumulative + sweep) {
-                                    found = i
-                                    break
-                                }
-                                cumulative += sweep
-                            }
-
-                            if (found >= 0) {
-                                if (selectedIndex == found) {
-                                    selectedIndex = null
-                                } else {
-                                    selectedIndex = found
-                                    tapOffset = offset
-                                }
-                            } else {
-                                selectedIndex = null
-                            }
-                        }
-                    },
-        ) {
-            val diameter = minOf(size.width, size.height) * 0.8f
-            val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
-            var startAngle = -90f
-
-            entries.forEachIndexed { index, entry ->
-                val sweep = (entry.calories.toFloat() / total) * 360f * sweepFraction.value
-                val isSelected = selectedIndex == index
-                val arcColor = MealColors[index % MealColors.size]
-                drawArc(
-                    color = if (isSelected) arcColor else arcColor.copy(alpha = if (selectedIndex != null) 0.5f else 1f),
-                    startAngle = startAngle,
-                    sweepAngle = sweep,
-                    useCenter = true,
-                    topLeft = topLeft,
-                    size = Size(diameter, diameter),
-                )
-                startAngle += sweep
-            }
-
-            val innerDiameter = diameter * 0.5f
-            val innerTopLeft = Offset((size.width - innerDiameter) / 2f, (size.height - innerDiameter) / 2f)
-            drawOval(
-                color = surfaceColor,
-                topLeft = innerTopLeft,
-                size = Size(innerDiameter, innerDiameter),
-            )
-        }
-
-        val selIdx = selectedIndex
-        ChartTooltip(
-            visible = selIdx != null,
-            touchOffset = tapOffset,
-            containerSize = containerSize,
-        ) {
-            if (selIdx != null && selIdx in entries.indices) {
-                val entry = entries[selIdx]
-                val pct = (entry.calories / total * 100).roundToInt()
-                Column {
-                    Text(
-                        entry.mealType.replaceFirstChar { it.uppercase() },
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.inverseOnSurface,
-                    )
-                    Text(
-                        "${entry.calories.roundToInt()} kcal ($pct%)",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
-                    )
-                }
-            }
-        }
-    }
-}
 
 @Composable
 private fun MealBreakdownLegend(

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -2,30 +2,13 @@ package com.bissbilanz.android.ui.screens
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -291,7 +274,6 @@ fun InsightsScreen() {
     }
 }
 
-
 @Composable
 private fun ComparisonRow(
     label: String,
@@ -401,7 +383,6 @@ private fun MacroTrendRow(
         )
     }
 }
-
 
 @Composable
 private fun MealBreakdownLegend(

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -20,15 +22,20 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bissbilanz.android.sync.RefreshManager
 import com.bissbilanz.android.ui.components.CalendarHeatmap
+import com.bissbilanz.android.ui.components.ChartTooltip
 import com.bissbilanz.android.ui.components.CollapsibleCard
 import com.bissbilanz.android.ui.components.MacroRadarChart
 import com.bissbilanz.android.ui.components.PullToRefreshWrapper
@@ -142,6 +149,7 @@ fun InsightsScreen() {
                         data = dailyStats.map { it.calories.toFloat() },
                         color = CaloriesBlue,
                         modifier = Modifier.fillMaxWidth().height(120.dp),
+                        unit = "cal",
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -280,6 +288,7 @@ fun SimpleLineChart(
     data: List<Float>,
     color: Color,
     modifier: Modifier = Modifier,
+    unit: String = "",
 ) {
     if (data.isEmpty()) return
     val maxVal = data.max().coerceAtLeast(1f)
@@ -291,25 +300,88 @@ fun SimpleLineChart(
         revealFraction.animateTo(1f, animationSpec = tween(500, easing = EaseOutCubic))
     }
 
-    Canvas(modifier = modifier) {
-        clipRect(right = size.width * revealFraction.value) {
-            val stepX = size.width / (data.size - 1).coerceAtLeast(1)
-            val range = (maxVal - minVal).coerceAtLeast(1f)
-            val padding = 8f
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var selectedIndex by remember { mutableStateOf<Int?>(null) }
+    var touchOffset by remember { mutableStateOf<Offset?>(null) }
 
-            val path = Path()
-            data.forEachIndexed { i, value ->
-                val x = i * stepX
-                val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
-                if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+    Box(modifier = modifier.onSizeChanged { containerSize = it }) {
+        Canvas(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .pointerInput(data) {
+                        detectDragGestures(
+                            onDragStart = { offset ->
+                                val stepX = size.width.toFloat() / (data.size - 1).coerceAtLeast(1)
+                                val idx = (offset.x / stepX).toInt().coerceIn(0, data.lastIndex)
+                                selectedIndex = idx
+                                touchOffset = offset
+                            },
+                            onDrag = { change, _ ->
+                                change.consume()
+                                val stepX = size.width.toFloat() / (data.size - 1).coerceAtLeast(1)
+                                val idx = (change.position.x / stepX).toInt().coerceIn(0, data.lastIndex)
+                                selectedIndex = idx
+                                touchOffset = change.position
+                            },
+                            onDragEnd = {
+                                selectedIndex = null
+                                touchOffset = null
+                            },
+                            onDragCancel = {
+                                selectedIndex = null
+                                touchOffset = null
+                            },
+                        )
+                    },
+        ) {
+            clipRect(right = size.width * revealFraction.value) {
+                val stepX = size.width / (data.size - 1).coerceAtLeast(1)
+                val range = (maxVal - minVal).coerceAtLeast(1f)
+                val padding = 8f
+
+                val path = Path()
+                data.forEachIndexed { i, value ->
+                    val x = i * stepX
+                    val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
+                    if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                }
+
+                drawPath(path, color = color, style = Stroke(width = 3f, cap = StrokeCap.Round))
+
+                data.forEachIndexed { i, value ->
+                    val x = i * stepX
+                    val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
+                    val isSelected = selectedIndex == i
+                    drawCircle(color = color, radius = if (isSelected) 6f else 3f, center = Offset(x, y))
+                    if (isSelected) {
+                        drawCircle(color = Color.White, radius = 3f, center = Offset(x, y))
+                        drawLine(
+                            color = Color.Gray.copy(alpha = 0.4f),
+                            start = Offset(x, 0f),
+                            end = Offset(x, size.height),
+                            strokeWidth = 1f,
+                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 3f)),
+                        )
+                    }
+                }
             }
+        }
 
-            drawPath(path, color = color, style = Stroke(width = 3f, cap = StrokeCap.Round))
-
-            data.forEachIndexed { i, value ->
-                val x = i * stepX
-                val y = size.height - padding - ((value - minVal) / range) * (size.height - padding * 2)
-                drawCircle(color = color, radius = 3f, center = Offset(x, y))
+        val selIdx = selectedIndex
+        val tOff = touchOffset
+        ChartTooltip(
+            visible = selIdx != null && tOff != null,
+            touchOffset = tOff ?: Offset.Zero,
+            containerSize = containerSize,
+        ) {
+            if (selIdx != null && selIdx in data.indices) {
+                Text(
+                    "${data[selIdx].roundToInt()}${ if (unit.isNotEmpty()) " $unit" else "" }",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                )
             }
         }
     }
@@ -420,6 +492,7 @@ private fun MacroTrendRow(
             data = data,
             color = color,
             modifier = Modifier.fillMaxWidth().height(60.dp),
+            unit = unit,
         )
     }
 }
@@ -451,31 +524,111 @@ private fun SimplePieChart(
         sweepFraction.animateTo(1f, animationSpec = tween(600, easing = EaseOutCubic))
     }
 
-    Canvas(modifier = modifier) {
-        val diameter = minOf(size.width, size.height) * 0.8f
-        val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
-        var startAngle = -90f
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var selectedIndex by remember { mutableStateOf<Int?>(null) }
+    var tapOffset by remember { mutableStateOf(Offset.Zero) }
 
-        entries.forEachIndexed { index, entry ->
-            val sweep = (entry.calories.toFloat() / total) * 360f * sweepFraction.value
-            drawArc(
-                color = MealColors[index % MealColors.size],
-                startAngle = startAngle,
-                sweepAngle = sweep,
-                useCenter = true,
-                topLeft = topLeft,
-                size = Size(diameter, diameter),
+    Box(modifier = modifier.onSizeChanged { containerSize = it }) {
+        Canvas(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .pointerInput(entries) {
+                        detectTapGestures { offset ->
+                            val cx = size.width / 2f
+                            val cy = size.height / 2f
+                            val diameter = minOf(size.width, size.height) * 0.8f
+                            val radius = diameter / 2f
+                            val innerRadius = radius * 0.5f
+
+                            val dx = offset.x - cx
+                            val dy = offset.y - cy
+                            val dist = kotlin.math.sqrt(dx * dx + dy * dy)
+
+                            if (dist < innerRadius || dist > radius) {
+                                selectedIndex = null
+                                return@detectTapGestures
+                            }
+
+                            var angle = Math.toDegrees(kotlin.math.atan2(dy.toDouble(), dx.toDouble())).toFloat()
+                            angle = (angle + 90f + 360f) % 360f
+
+                            var cumulative = 0f
+                            var found = -1
+                            for (i in entries.indices) {
+                                val sweep = (entries[i].calories.toFloat() / total) * 360f
+                                if (angle >= cumulative && angle < cumulative + sweep) {
+                                    found = i
+                                    break
+                                }
+                                cumulative += sweep
+                            }
+
+                            if (found >= 0) {
+                                if (selectedIndex == found) {
+                                    selectedIndex = null
+                                } else {
+                                    selectedIndex = found
+                                    tapOffset = offset
+                                }
+                            } else {
+                                selectedIndex = null
+                            }
+                        }
+                    },
+        ) {
+            val diameter = minOf(size.width, size.height) * 0.8f
+            val topLeft = Offset((size.width - diameter) / 2f, (size.height - diameter) / 2f)
+            var startAngle = -90f
+
+            entries.forEachIndexed { index, entry ->
+                val sweep = (entry.calories.toFloat() / total) * 360f * sweepFraction.value
+                val isSelected = selectedIndex == index
+                val arcColor = MealColors[index % MealColors.size]
+                drawArc(
+                    color = if (isSelected) arcColor else arcColor.copy(alpha = if (selectedIndex != null) 0.5f else 1f),
+                    startAngle = startAngle,
+                    sweepAngle = sweep,
+                    useCenter = true,
+                    topLeft = topLeft,
+                    size = Size(diameter, diameter),
+                )
+                startAngle += sweep
+            }
+
+            val innerDiameter = diameter * 0.5f
+            val innerTopLeft = Offset((size.width - innerDiameter) / 2f, (size.height - innerDiameter) / 2f)
+            drawOval(
+                color = surfaceColor,
+                topLeft = innerTopLeft,
+                size = Size(innerDiameter, innerDiameter),
             )
-            startAngle += sweep
         }
 
-        val innerDiameter = diameter * 0.5f
-        val innerTopLeft = Offset((size.width - innerDiameter) / 2f, (size.height - innerDiameter) / 2f)
-        drawOval(
-            color = surfaceColor,
-            topLeft = innerTopLeft,
-            size = Size(innerDiameter, innerDiameter),
-        )
+        val selIdx = selectedIndex
+        ChartTooltip(
+            visible = selIdx != null,
+            touchOffset = tapOffset,
+            containerSize = containerSize,
+        ) {
+            if (selIdx != null && selIdx in entries.indices) {
+                val entry = entries[selIdx]
+                val pct = (entry.calories / total * 100).roundToInt()
+                Column {
+                    Text(
+                        entry.mealType.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                    )
+                    Text(
+                        "${entry.calories.roundToInt()} kcal ($pct%)",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.7f),
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -102,8 +102,8 @@ fun InsightsScreen() {
 
             // Streaks
             streaks?.let { s ->
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    Column(modifier = Modifier.padding(16.dp)) {
+                ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(20.dp)) {
                         Text("Streaks", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                         Spacer(modifier = Modifier.height(12.dp))
                         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
@@ -138,7 +138,7 @@ fun InsightsScreen() {
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
             // 1. Trends
             if (dailyStats.isNotEmpty()) {
@@ -180,7 +180,7 @@ fun InsightsScreen() {
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
             // 2. Goal Adherence
             if (goals != null && dailyStats.isNotEmpty()) {
@@ -278,7 +278,7 @@ fun InsightsScreen() {
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(24.dp))
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
@@ -242,7 +242,7 @@ fun SettingsScreen(navController: NavController) {
                                             }
                                         }
                                     },
-                                    enabled = if (isSelected) selectedTabs.size > 1 else selectedTabs.size < 3,
+                                    enabled = if (isSelected) selectedTabs.size >= 3 else selectedTabs.size < 3,
                                 )
                                 Text(label, style = MaterialTheme.typography.bodyMedium)
                             }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
@@ -23,45 +23,34 @@ import androidx.health.connect.client.PermissionController
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import com.bissbilanz.ErrorReporter
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.android.BuildConfig
-import com.bissbilanz.android.sync.RefreshManager
 import com.bissbilanz.android.ui.components.PullToRefreshWrapper
-import com.bissbilanz.api.BissbilanzApi
-import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.android.ui.viewmodels.SettingsViewModel
 import com.bissbilanz.model.Goals
-import com.bissbilanz.model.MealType
-import com.bissbilanz.model.MealTypeCreate
 import com.bissbilanz.model.PreferencesUpdate
-import com.bissbilanz.repository.GoalsRepository
-import com.bissbilanz.repository.PreferencesRepository
 import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 import com.bissbilanz.api.generated.model.PreferencesUpdate as GenPreferencesUpdate
 
 @Composable
 fun SettingsScreen(navController: NavController) {
-    val authManager: AuthManager = koinInject()
-    val goalsRepo: GoalsRepository = koinInject()
-    val prefsRepo: PreferencesRepository = koinInject()
-    val api: BissbilanzApi = koinInject()
+    val viewModel: SettingsViewModel = koinViewModel()
     val healthSync: HealthSyncService = koinInject()
-    val refreshManager: RefreshManager = koinInject()
-    val errorReporter: ErrorReporter = koinInject()
-    val goals by goalsRepo.goals().collectAsStateWithLifecycle(null)
-    val prefs by prefsRepo.preferences().collectAsStateWithLifecycle(null)
-    val scope = rememberCoroutineScope()
+    val goals by viewModel.goals.collectAsStateWithLifecycle()
+    val prefs by viewModel.prefs.collectAsStateWithLifecycle()
+    val customMealTypes by viewModel.customMealTypes.collectAsStateWithLifecycle()
+    val healthAvailable by viewModel.healthAvailable.collectAsStateWithLifecycle()
+    val healthPermGranted by viewModel.healthPermGranted.collectAsStateWithLifecycle()
+    val snackbarMessage by viewModel.snackbarMessage.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     var showMealTypeDialog by remember { mutableStateOf(false) }
-    var customMealTypes by remember { mutableStateOf<List<MealType>>(emptyList()) }
     var editedNutrients by remember { mutableStateOf<Set<String>?>(null) }
     var nutrientsDirty by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val healthPrefs = context.getSharedPreferences("health_connect", Context.MODE_PRIVATE)
-    var healthAvailable by remember { mutableStateOf(false) }
-    var healthPermGranted by remember { mutableStateOf(false) }
     var healthSyncEnabled by remember { mutableStateOf(healthPrefs.getBoolean("sync_enabled", false)) }
     val tabPrefs = context.getSharedPreferences("nav_tabs", Context.MODE_PRIVATE)
     var selectedTabs by remember {
@@ -74,30 +63,19 @@ fun SettingsScreen(navController: NavController) {
         rememberLauncherForActivityResult(
             PermissionController.createRequestPermissionResultContract(),
         ) {
-            scope.launch {
-                healthPermGranted = healthSync.hasPermissions()
-            }
+            viewModel.refreshHealthPermissions()
         }
+
+    LaunchedEffect(snackbarMessage) {
+        snackbarMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSnackbar()
+        }
+    }
 
     LaunchedEffect(prefs) {
         if (editedNutrients == null && prefs != null) {
             editedNutrients = prefs!!.visibleNutrients.toSet()
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        goalsRepo.refresh()
-        prefsRepo.refresh()
-        try {
-            val response = api.getMealTypes()
-            customMealTypes = response.mealTypes
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            errorReporter.captureException(e)
-        }
-        healthAvailable = healthSync.isAvailable()
-        if (healthAvailable) {
-            healthPermGranted = healthSync.hasPermissions()
         }
     }
 
@@ -118,18 +96,7 @@ fun SettingsScreen(navController: NavController) {
             confirmButton = {
                 TextButton(onClick = {
                     if (newMealName.isNotBlank()) {
-                        scope.launch {
-                            try {
-                                api.createMealType(MealTypeCreate(name = newMealName.trim(), sortOrder = customMealTypes.size))
-                                val response = api.getMealTypes()
-                                customMealTypes = response.mealTypes
-                                snackbarHostState.showSnackbar("Meal type added")
-                            } catch (e: Exception) {
-                                if (e is kotlinx.coroutines.CancellationException) throw e
-                                errorReporter.captureException(e)
-                                snackbarHostState.showSnackbar("Failed to add meal type")
-                            }
-                        }
+                        viewModel.addMealType(newMealName.trim())
                     }
                     showMealTypeDialog = false
                 }) { Text("Add") }
@@ -144,7 +111,7 @@ fun SettingsScreen(navController: NavController) {
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
         PullToRefreshWrapper(
-            onRefresh = { refreshManager.refreshAll() },
+            onRefresh = { viewModel.refreshAll() },
             modifier = Modifier.fillMaxSize().padding(padding),
         ) {
             Column(
@@ -374,24 +341,15 @@ fun SettingsScreen(navController: NavController) {
                             }
                             Button(
                                 onClick = {
-                                    scope.launch {
-                                        try {
-                                            goalsRepo.setGoals(
-                                                Goals(
-                                                    calorieGoal = cals.toDouble(),
-                                                    proteinGoal = proteinG.toDouble(),
-                                                    carbGoal = carbsG.toDouble(),
-                                                    fatGoal = fatG.toDouble(),
-                                                    fiberGoal = editFiberG.toDouble(),
-                                                ),
-                                            )
-                                            snackbarHostState.showSnackbar("Goals updated")
-                                        } catch (e: Exception) {
-                                            if (e is kotlinx.coroutines.CancellationException) throw e
-                                            errorReporter.captureException(e)
-                                            snackbarHostState.showSnackbar("Failed to update goals")
-                                        }
-                                    }
+                                    viewModel.setGoals(
+                                        Goals(
+                                            calorieGoal = cals.toDouble(),
+                                            proteinGoal = proteinG.toDouble(),
+                                            carbGoal = carbsG.toDouble(),
+                                            fatGoal = fatG.toDouble(),
+                                            fiberGoal = editFiberG.toDouble(),
+                                        ),
+                                    )
                                 },
                                 enabled = isValid,
                             ) {
@@ -506,70 +464,22 @@ fun SettingsScreen(navController: NavController) {
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             WidgetToggle("Chart", p.showChartWidget) { value ->
-                                scope.launch {
-                                    try {
-                                        prefsRepo.updatePreferences(PreferencesUpdate(showChartWidget = value))
-                                    } catch (e: Exception) {
-                                        if (e is kotlinx.coroutines.CancellationException) throw e
-                                        errorReporter.captureException(e)
-                                        snackbarHostState.showSnackbar("Failed to update preference")
-                                    }
-                                }
+                                viewModel.updatePreference(PreferencesUpdate(showChartWidget = value))
                             }
                             WidgetToggle("Favorites", p.showFavoritesWidget) { value ->
-                                scope.launch {
-                                    try {
-                                        prefsRepo.updatePreferences(PreferencesUpdate(showFavoritesWidget = value))
-                                    } catch (e: Exception) {
-                                        if (e is kotlinx.coroutines.CancellationException) throw e
-                                        errorReporter.captureException(e)
-                                        snackbarHostState.showSnackbar("Failed to update preference")
-                                    }
-                                }
+                                viewModel.updatePreference(PreferencesUpdate(showFavoritesWidget = value))
                             }
                             WidgetToggle("Supplements", p.showSupplementsWidget) { value ->
-                                scope.launch {
-                                    try {
-                                        prefsRepo.updatePreferences(PreferencesUpdate(showSupplementsWidget = value))
-                                    } catch (e: Exception) {
-                                        if (e is kotlinx.coroutines.CancellationException) throw e
-                                        errorReporter.captureException(e)
-                                        snackbarHostState.showSnackbar("Failed to update preference")
-                                    }
-                                }
+                                viewModel.updatePreference(PreferencesUpdate(showSupplementsWidget = value))
                             }
                             WidgetToggle("Weight", p.showWeightWidget) { value ->
-                                scope.launch {
-                                    try {
-                                        prefsRepo.updatePreferences(PreferencesUpdate(showWeightWidget = value))
-                                    } catch (e: Exception) {
-                                        if (e is kotlinx.coroutines.CancellationException) throw e
-                                        errorReporter.captureException(e)
-                                        snackbarHostState.showSnackbar("Failed to update preference")
-                                    }
-                                }
+                                viewModel.updatePreference(PreferencesUpdate(showWeightWidget = value))
                             }
                             WidgetToggle("Meal Breakdown", p.showMealBreakdownWidget) { value ->
-                                scope.launch {
-                                    try {
-                                        prefsRepo.updatePreferences(PreferencesUpdate(showMealBreakdownWidget = value))
-                                    } catch (e: Exception) {
-                                        if (e is kotlinx.coroutines.CancellationException) throw e
-                                        errorReporter.captureException(e)
-                                        snackbarHostState.showSnackbar("Failed to update preference")
-                                    }
-                                }
+                                viewModel.updatePreference(PreferencesUpdate(showMealBreakdownWidget = value))
                             }
                             WidgetToggle("Top Foods", p.showTopFoodsWidget) { value ->
-                                scope.launch {
-                                    try {
-                                        prefsRepo.updatePreferences(PreferencesUpdate(showTopFoodsWidget = value))
-                                    } catch (e: Exception) {
-                                        if (e is kotlinx.coroutines.CancellationException) throw e
-                                        errorReporter.captureException(e)
-                                        snackbarHostState.showSnackbar("Failed to update preference")
-                                    }
-                                }
+                                viewModel.updatePreference(PreferencesUpdate(showTopFoodsWidget = value))
                             }
                         }
                     }
@@ -592,21 +502,9 @@ fun SettingsScreen(navController: NavController) {
                                 RadioButton(
                                     selected = p.favoriteMealAssignmentMode == "time_based",
                                     onClick = {
-                                        scope.launch {
-                                            try {
-                                                prefsRepo.updatePreferences(
-                                                    PreferencesUpdate(
-                                                        favoriteMealAssignmentMode =
-                                                            GenPreferencesUpdate.FavoriteMealAssignmentMode.time_based,
-                                                    ),
-                                                )
-                                                snackbarHostState.showSnackbar("Meal assignment updated")
-                                            } catch (e: Exception) {
-                                                if (e is kotlinx.coroutines.CancellationException) throw e
-                                                errorReporter.captureException(e)
-                                                snackbarHostState.showSnackbar("Failed to update preference")
-                                            }
-                                        }
+                                        viewModel.updateFavoriteMealAssignmentMode(
+                                            GenPreferencesUpdate.FavoriteMealAssignmentMode.time_based,
+                                        )
                                     },
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
@@ -619,21 +517,9 @@ fun SettingsScreen(navController: NavController) {
                                 RadioButton(
                                     selected = p.favoriteMealAssignmentMode == "ask_meal",
                                     onClick = {
-                                        scope.launch {
-                                            try {
-                                                prefsRepo.updatePreferences(
-                                                    PreferencesUpdate(
-                                                        favoriteMealAssignmentMode =
-                                                            GenPreferencesUpdate.FavoriteMealAssignmentMode.ask_meal,
-                                                    ),
-                                                )
-                                                snackbarHostState.showSnackbar("Meal assignment updated")
-                                            } catch (e: Exception) {
-                                                if (e is kotlinx.coroutines.CancellationException) throw e
-                                                errorReporter.captureException(e)
-                                                snackbarHostState.showSnackbar("Failed to update preference")
-                                            }
-                                        }
+                                        viewModel.updateFavoriteMealAssignmentMode(
+                                            GenPreferencesUpdate.FavoriteMealAssignmentMode.ask_meal,
+                                        )
                                     },
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
@@ -708,19 +594,8 @@ fun SettingsScreen(navController: NavController) {
                                 Spacer(modifier = Modifier.height(12.dp))
                                 Button(
                                     onClick = {
-                                        scope.launch {
-                                            try {
-                                                prefsRepo.updatePreferences(
-                                                    PreferencesUpdate(visibleNutrients = editedNutrients?.toList() ?: emptyList()),
-                                                )
-                                                nutrientsDirty = false
-                                                snackbarHostState.showSnackbar("Visible nutrients updated")
-                                            } catch (e: Exception) {
-                                                if (e is kotlinx.coroutines.CancellationException) throw e
-                                                errorReporter.captureException(e)
-                                                snackbarHostState.showSnackbar("Failed to update nutrients")
-                                            }
-                                        }
+                                        viewModel.updateVisibleNutrients(editedNutrients?.toList() ?: emptyList())
+                                        nutrientsDirty = false
                                     },
                                     modifier = Modifier.fillMaxWidth(),
                                 ) { Text("Save") }
@@ -737,7 +612,7 @@ fun SettingsScreen(navController: NavController) {
                         Text("Account", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                         Spacer(modifier = Modifier.height(16.dp))
                         OutlinedButton(
-                            onClick = { authManager.logout() },
+                            onClick = { viewModel.logout() },
                             modifier = Modifier.fillMaxWidth(),
                             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
                         ) {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SupplementsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SupplementsScreen.kt
@@ -171,17 +171,19 @@ fun SupplementsScreen(navController: NavController) {
                                 onEdit = { editingSupplementId = supplement.id },
                                 modifier = Modifier.animateItem(),
                                 onToggle = {
+                                    takenIds =
+                                        if (isTaken) takenIds - supplement.id else takenIds + supplement.id
                                     scope.launch {
                                         try {
                                             if (isTaken) {
                                                 supplementRepo.unlogSupplement(supplement.id, today)
-                                                takenIds = takenIds - supplement.id
                                             } else {
                                                 supplementRepo.logSupplement(supplement.id, today)
-                                                takenIds = takenIds + supplement.id
                                             }
                                         } catch (e: Exception) {
                                             if (e is kotlinx.coroutines.CancellationException) throw e
+                                            takenIds =
+                                                if (isTaken) takenIds + supplement.id else takenIds - supplement.id
                                             errorReporter.captureException(e)
                                             snackbarHostState.showSnackbar("Failed to update supplement")
                                         }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/DashboardViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/DashboardViewModel.kt
@@ -3,10 +3,13 @@ package com.bissbilanz.android.ui.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bissbilanz.ErrorReporter
+import com.bissbilanz.android.sync.RefreshManager
+import com.bissbilanz.api.generated.model.Preferences
 import com.bissbilanz.model.Entry
 import com.bissbilanz.model.Goals
 import com.bissbilanz.repository.EntryRepository
 import com.bissbilanz.repository.GoalsRepository
+import com.bissbilanz.repository.PreferencesRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -22,6 +25,8 @@ import kotlinx.datetime.*
 class DashboardViewModel(
     private val entryRepo: EntryRepository,
     private val goalsRepo: GoalsRepository,
+    private val prefsRepo: PreferencesRepository,
+    private val refreshManager: RefreshManager,
     private val errorReporter: ErrorReporter,
 ) : ViewModel() {
     private val _selectedDate = MutableStateFlow(Clock.System.todayIn(TimeZone.currentSystemDefault()))
@@ -48,6 +53,11 @@ class DashboardViewModel(
     val goals: StateFlow<Goals?> =
         goalsRepo
             .goals()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val prefs: StateFlow<Preferences?> =
+        prefsRepo
+            .preferences()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     init {
@@ -83,6 +93,32 @@ class DashboardViewModel(
                 _snackbarMessage.value = "Failed to load data"
             } finally {
                 _isLoading.value = false
+            }
+        }
+    }
+
+    fun refreshAll() {
+        viewModelScope.launch {
+            try {
+                refreshManager.refreshAll(_selectedDate.value.toString())
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+            }
+        }
+    }
+
+    fun copyEntriesFromYesterday() {
+        viewModelScope.launch {
+            try {
+                val yesterday = _selectedDate.value.minus(1, DateTimeUnit.DAY).toString()
+                val count = entryRepo.copyEntries(yesterday, _selectedDate.value.toString())
+                _snackbarMessage.value = "Copied $count entries from yesterday"
+                loadData()
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                _snackbarMessage.value = "No entries to copy from yesterday"
             }
         }
     }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/DayLogViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/DayLogViewModel.kt
@@ -3,7 +3,6 @@ package com.bissbilanz.android.ui.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bissbilanz.ErrorReporter
-import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.model.Entry
 import com.bissbilanz.repository.EntryRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -19,7 +18,6 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalCoroutinesApi::class)
 class DayLogViewModel(
     private val entryRepo: EntryRepository,
-    private val api: BissbilanzApi,
     private val errorReporter: ErrorReporter,
 ) : ViewModel() {
     private val _isLoading = MutableStateFlow(true)
@@ -74,7 +72,7 @@ class DayLogViewModel(
 
     private suspend fun loadFastingDay(date: String) {
         try {
-            val props = api.getDayProperties(date)
+            val props = entryRepo.getDayProperties(date)
             _isFastingDay.value = props?.isFastingDay ?: false
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
@@ -89,9 +87,9 @@ class DayLogViewModel(
         viewModelScope.launch {
             try {
                 if (newValue) {
-                    api.setDayProperties(date, isFastingDay = true)
+                    entryRepo.setDayProperties(date, isFastingDay = true)
                 } else {
-                    api.deleteDayProperties(date)
+                    entryRepo.deleteDayProperties(date)
                 }
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/FoodSearchViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/FoodSearchViewModel.kt
@@ -8,6 +8,7 @@ import com.bissbilanz.model.Food
 import com.bissbilanz.repository.EntryRepository
 import com.bissbilanz.repository.FoodRepository
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -34,6 +35,7 @@ class FoodSearchViewModel(
 
     private var allFoodsOffset = 0
     private var paginationJob: Job? = null
+    private var searchJob: Job? = null
     private val pageSize = 20
 
     private val _query = MutableStateFlow("")
@@ -94,23 +96,26 @@ class FoodSearchViewModel(
 
     fun updateQuery(newQuery: String) {
         _query.value = newQuery
-        viewModelScope.launch {
-            if (newQuery.length >= 2) {
-                _isSearching.value = true
-                _searchResults.value =
-                    try {
-                        foodRepo.searchFoods(newQuery)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        errorReporter.captureException(e)
-                        _snackbarMessage.value = "Search failed"
-                        emptyList()
-                    }
-                _isSearching.value = false
-            } else {
-                _searchResults.value = emptyList()
+        searchJob?.cancel()
+        searchJob =
+            viewModelScope.launch {
+                if (newQuery.length >= 2) {
+                    delay(300)
+                    _isSearching.value = true
+                    _searchResults.value =
+                        try {
+                            foodRepo.searchFoods(newQuery)
+                        } catch (e: Exception) {
+                            if (e is kotlinx.coroutines.CancellationException) throw e
+                            errorReporter.captureException(e)
+                            _snackbarMessage.value = "Search failed"
+                            emptyList()
+                        }
+                    _isSearching.value = false
+                } else {
+                    _searchResults.value = emptyList()
+                }
             }
-        }
     }
 
     fun selectTab(index: Int) {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModel.kt
@@ -1,0 +1,163 @@
+package com.bissbilanz.android.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bissbilanz.ErrorReporter
+import com.bissbilanz.HealthSyncService
+import com.bissbilanz.android.sync.RefreshManager
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.Preferences
+import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.model.Goals
+import com.bissbilanz.model.MealType
+import com.bissbilanz.model.MealTypeCreate
+import com.bissbilanz.model.PreferencesUpdate
+import com.bissbilanz.repository.GoalsRepository
+import com.bissbilanz.repository.PreferencesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import com.bissbilanz.api.generated.model.PreferencesUpdate as GenPreferencesUpdate
+
+class SettingsViewModel(
+    private val authManager: AuthManager,
+    private val goalsRepo: GoalsRepository,
+    private val prefsRepo: PreferencesRepository,
+    private val api: BissbilanzApi,
+    private val healthSync: HealthSyncService,
+    private val refreshManager: RefreshManager,
+    private val errorReporter: ErrorReporter,
+) : ViewModel() {
+    val goals: StateFlow<Goals?> =
+        goalsRepo
+            .goals()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val prefs: StateFlow<Preferences?> =
+        prefsRepo
+            .preferences()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    private val _customMealTypes = MutableStateFlow<List<MealType>>(emptyList())
+    val customMealTypes: StateFlow<List<MealType>> = _customMealTypes.asStateFlow()
+
+    private val _healthAvailable = MutableStateFlow(false)
+    val healthAvailable: StateFlow<Boolean> = _healthAvailable.asStateFlow()
+
+    private val _healthPermGranted = MutableStateFlow(false)
+    val healthPermGranted: StateFlow<Boolean> = _healthPermGranted.asStateFlow()
+
+    private val _snackbarMessage = MutableStateFlow<String?>(null)
+    val snackbarMessage: StateFlow<String?> = _snackbarMessage.asStateFlow()
+
+    init {
+        loadData()
+    }
+
+    fun loadData() {
+        viewModelScope.launch {
+            goalsRepo.refresh()
+            prefsRepo.refresh()
+            try {
+                val response = api.getMealTypes()
+                _customMealTypes.value = response.mealTypes
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+            }
+            _healthAvailable.value = healthSync.isAvailable()
+            if (_healthAvailable.value) {
+                _healthPermGranted.value = healthSync.hasPermissions()
+            }
+        }
+    }
+
+    fun refreshAll() {
+        viewModelScope.launch {
+            refreshManager.refreshAll()
+        }
+    }
+
+    fun refreshHealthPermissions() {
+        viewModelScope.launch {
+            _healthPermGranted.value = healthSync.hasPermissions()
+        }
+    }
+
+    fun setGoals(goals: Goals) {
+        viewModelScope.launch {
+            try {
+                goalsRepo.setGoals(goals)
+                _snackbarMessage.value = "Goals updated"
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                _snackbarMessage.value = "Failed to update goals"
+            }
+        }
+    }
+
+    fun updatePreference(update: PreferencesUpdate) {
+        viewModelScope.launch {
+            try {
+                prefsRepo.updatePreferences(update)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                _snackbarMessage.value = "Failed to update preference"
+            }
+        }
+    }
+
+    fun updateFavoriteMealAssignmentMode(mode: GenPreferencesUpdate.FavoriteMealAssignmentMode) {
+        viewModelScope.launch {
+            try {
+                prefsRepo.updatePreferences(PreferencesUpdate(favoriteMealAssignmentMode = mode))
+                _snackbarMessage.value = "Meal assignment updated"
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                _snackbarMessage.value = "Failed to update preference"
+            }
+        }
+    }
+
+    fun updateVisibleNutrients(nutrients: List<String>) {
+        viewModelScope.launch {
+            try {
+                prefsRepo.updatePreferences(PreferencesUpdate(visibleNutrients = nutrients))
+                _snackbarMessage.value = "Visible nutrients updated"
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                _snackbarMessage.value = "Failed to update nutrients"
+            }
+        }
+    }
+
+    fun addMealType(name: String) {
+        viewModelScope.launch {
+            try {
+                api.createMealType(MealTypeCreate(name = name, sortOrder = _customMealTypes.value.size))
+                val response = api.getMealTypes()
+                _customMealTypes.value = response.mealTypes
+                _snackbarMessage.value = "Meal type added"
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                _snackbarMessage.value = "Failed to add meal type"
+            }
+        }
+    }
+
+    fun logout() {
+        authManager.logout()
+    }
+
+    fun clearSnackbar() {
+        _snackbarMessage.value = null
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/CheckmarkRenderer.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/CheckmarkRenderer.kt
@@ -1,0 +1,50 @@
+package com.bissbilanz.android.widget
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+
+object CheckmarkRenderer {
+    fun render(sizePx: Int): Bitmap {
+        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        val bgColor = 0xFF2E7D32.toInt()
+        val cornerRadius = sizePx / 6f
+
+        val bgPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = bgColor
+                style = Paint.Style.FILL
+            }
+        canvas.drawRoundRect(
+            RectF(0f, 0f, sizePx.toFloat(), sizePx.toFloat()),
+            cornerRadius,
+            cornerRadius,
+            bgPaint,
+        )
+
+        val checkPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = 0xFFFFFFFF.toInt()
+                style = Paint.Style.STROKE
+                strokeWidth = sizePx * 0.1f
+                strokeCap = Paint.Cap.ROUND
+                strokeJoin = Paint.Join.ROUND
+            }
+
+        val cx = sizePx / 2f
+        val cy = sizePx / 2f
+        val arm = sizePx * 0.2f
+
+        val path = Path()
+        path.moveTo(cx - arm, cy)
+        path.lineTo(cx - arm * 0.2f, cy + arm * 0.7f)
+        path.lineTo(cx + arm, cy - arm * 0.6f)
+        canvas.drawPath(path, checkPaint)
+
+        return bitmap
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritePlaceholderRenderer.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritePlaceholderRenderer.kt
@@ -1,0 +1,40 @@
+package com.bissbilanz.android.widget
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+
+object FavoritePlaceholderRenderer {
+    fun render(name: String, sizePx: Int, isDarkMode: Boolean): Bitmap {
+        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        val bgColor = if (isDarkMode) 0xFF3A3A3A.toInt() else 0xFFE0E0E0.toInt()
+        val textColor = if (isDarkMode) 0xFFAAAAAA.toInt() else 0xFF666666.toInt()
+        val cornerRadius = sizePx / 6f
+
+        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = bgColor
+            style = Paint.Style.FILL
+        }
+        canvas.drawRoundRect(RectF(0f, 0f, sizePx.toFloat(), sizePx.toFloat()), cornerRadius, cornerRadius, bgPaint)
+
+        val initial = name.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = textColor
+            textSize = sizePx * 0.4f
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL)
+            textAlign = Paint.Align.CENTER
+        }
+
+        val textBounds = android.graphics.Rect()
+        textPaint.getTextBounds(initial, 0, initial.length, textBounds)
+        val x = sizePx / 2f
+        val y = sizePx / 2f - textBounds.exactCenterY()
+        canvas.drawText(initial, x, y, textPaint)
+
+        return bitmap
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritePlaceholderRenderer.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritePlaceholderRenderer.kt
@@ -7,7 +7,11 @@ import android.graphics.RectF
 import android.graphics.Typeface
 
 object FavoritePlaceholderRenderer {
-    fun render(name: String, sizePx: Int, isDarkMode: Boolean): Bitmap {
+    fun render(
+        name: String,
+        sizePx: Int,
+        isDarkMode: Boolean,
+    ): Bitmap {
         val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
 
@@ -15,19 +19,21 @@ object FavoritePlaceholderRenderer {
         val textColor = if (isDarkMode) 0xFFAAAAAA.toInt() else 0xFF666666.toInt()
         val cornerRadius = sizePx / 6f
 
-        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = bgColor
-            style = Paint.Style.FILL
-        }
+        val bgPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = bgColor
+                style = Paint.Style.FILL
+            }
         canvas.drawRoundRect(RectF(0f, 0f, sizePx.toFloat(), sizePx.toFloat()), cornerRadius, cornerRadius, bgPaint)
 
         val initial = name.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
-        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = textColor
-            textSize = sizePx * 0.4f
-            typeface = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL)
-            textAlign = Paint.Align.CENTER
-        }
+        val textPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = textColor
+                textSize = sizePx * 0.4f
+                typeface = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL)
+                textAlign = Paint.Align.CENTER
+            }
 
         val textBounds = android.graphics.Rect()
         textPaint.getTextBounds(initial, 0, initial.length, textBounds)

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -177,6 +177,8 @@ private fun FavoritesContent(tiles: List<FavoriteTile>) {
                                             ),
                                         ),
                             )
+                        } else {
+                            Spacer(modifier = GlanceModifier.fillMaxSize())
                         }
                     }
                 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -11,6 +11,7 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.actionStartActivity
@@ -37,6 +38,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
 import com.bissbilanz.android.MainActivity
+import com.bissbilanz.android.R
 import com.bissbilanz.api.generated.model.Food
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.util.decodeOrNull
@@ -109,6 +111,7 @@ class FavoritesWidget : GlanceAppWidget() {
 
 @Composable
 private fun FavoritesContent(tiles: List<FavoriteTile>) {
+    val context = LocalContext.current
     val size = LocalSize.current
     val rows = if (size.height >= 200.dp) 4 else 2
     val columns = 5
@@ -124,7 +127,7 @@ private fun FavoritesContent(tiles: List<FavoriteTile>) {
             contentAlignment = Alignment.Center,
         ) {
             Text(
-                text = "No favorites yet",
+                text = context.getString(R.string.favorites_widget_empty),
                 style =
                     TextStyle(
                         color = GlanceTheme.colors.onSurface,

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -33,6 +33,7 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.size
 import androidx.glance.layout.width
 import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
@@ -51,12 +52,16 @@ private data class FavoriteTile(
     val imageProvider: ImageProvider,
 )
 
+private val tileSize = 52.dp
+private val tileGap = 4.dp
+
 class FavoritesWidget : GlanceAppWidget() {
     override val sizeMode =
         SizeMode.Responsive(
             setOf(
-                DpSize(300.dp, 120.dp),
-                DpSize(300.dp, 240.dp),
+                DpSize(250.dp, 100.dp),
+                DpSize(250.dp, 160.dp),
+                DpSize(250.dp, 220.dp),
             ),
         )
 
@@ -75,7 +80,7 @@ class FavoritesWidget : GlanceAppWidget() {
 
         val imageDir = File(context.cacheDir, "widget_food_images")
         val density = context.resources.displayMetrics.density
-        val tilePx = (56 * density).toInt()
+        val tilePx = (48 * density).toInt()
         val isDark =
             (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
                 Configuration.UI_MODE_NIGHT_YES
@@ -93,9 +98,12 @@ class FavoritesWidget : GlanceAppWidget() {
                 FavoriteTile(food.id, food.name, ImageProvider(bitmap))
             }
 
+        val plusBitmap = PlusPlaceholderRenderer.render(tilePx, isDark)
+        val plusProvider = ImageProvider(plusBitmap)
+
         provideContent {
             GlanceTheme {
-                FavoritesContent(tiles)
+                FavoritesContent(tiles, plusProvider)
             }
         }
     }
@@ -110,13 +118,20 @@ class FavoritesWidget : GlanceAppWidget() {
 }
 
 @Composable
-private fun FavoritesContent(tiles: List<FavoriteTile>) {
+private fun FavoritesContent(
+    tiles: List<FavoriteTile>,
+    plusProvider: ImageProvider,
+) {
     val context = LocalContext.current
     val size = LocalSize.current
-    val maxRows = if (size.height >= 200.dp) 4 else 2
     val columns = 5
-    val totalRows = ((tiles.size + columns - 1) / columns).coerceIn(1, maxRows)
-    val visibleTiles = tiles.take(totalRows * columns)
+    val maxRows =
+        when {
+            size.height >= 200.dp -> 4
+            size.height >= 140.dp -> 3
+            else -> 2
+        }
+    val totalSlots = maxRows * columns
 
     if (tiles.isEmpty()) {
         Box(
@@ -146,31 +161,29 @@ private fun FavoritesContent(tiles: List<FavoriteTile>) {
                 .fillMaxSize()
                 .cornerRadius(16.dp)
                 .background(GlanceTheme.colors.background)
-                .padding(6.dp),
-        verticalAlignment = Alignment.Top,
+                .padding(horizontal = 4.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        for (row in 0 until totalRows) {
-            if (row > 0) Spacer(modifier = GlanceModifier.height(4.dp))
-            val rowStart = row * columns
-            val rowEnd = (rowStart + columns).coerceAtMost(visibleTiles.size)
-            val rowTiles = visibleTiles.subList(rowStart, rowEnd)
+        for (row in 0 until maxRows) {
+            if (row > 0) Spacer(modifier = GlanceModifier.height(tileGap))
             Row(
-                modifier = GlanceModifier.fillMaxWidth().defaultWeight(),
-                horizontalAlignment = Alignment.Start,
+                modifier = GlanceModifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 for (col in 0 until columns) {
-                    if (col > 0) Spacer(modifier = GlanceModifier.width(4.dp))
-                    if (col < rowTiles.size) {
-                        val tile = rowTiles[col]
+                    if (col > 0) Spacer(modifier = GlanceModifier.width(tileGap))
+                    val index = row * columns + col
+                    if (index < tiles.size) {
+                        val tile = tiles[index]
                         Image(
                             provider = tile.imageProvider,
                             contentDescription = tile.name,
                             contentScale = ContentScale.Crop,
                             modifier =
                                 GlanceModifier
-                                    .defaultWeight()
-                                    .fillMaxSize()
-                                    .cornerRadius(8.dp)
+                                    .size(tileSize)
+                                    .cornerRadius(12.dp)
                                     .clickable(
                                         actionRunCallback<LogFavoriteFoodAction>(
                                             actionParametersOf(
@@ -180,8 +193,17 @@ private fun FavoritesContent(tiles: List<FavoriteTile>) {
                                         ),
                                     ),
                         )
-                    } else {
-                        Box(modifier = GlanceModifier.defaultWeight()) {}
+                    } else if (index < totalSlots) {
+                        Image(
+                            provider = plusProvider,
+                            contentDescription = "Add favorite",
+                            contentScale = ContentScale.Crop,
+                            modifier =
+                                GlanceModifier
+                                    .size(tileSize)
+                                    .cornerRadius(12.dp)
+                                    .clickable(actionStartActivity<MainActivity>()),
+                        )
                     }
                 }
             }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -1,0 +1,182 @@
+package com.bissbilanz.android.widget
+
+import android.content.Context
+import android.content.res.Configuration
+import android.graphics.BitmapFactory
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.LocalSize
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.text.Text
+import androidx.glance.text.TextAlign
+import androidx.glance.text.TextStyle
+import com.bissbilanz.android.MainActivity
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.util.decodeOrNull
+import kotlinx.serialization.json.Json
+import java.io.File
+
+private data class FavoriteTile(
+    val id: String,
+    val name: String,
+    val imageProvider: ImageProvider,
+)
+
+class FavoritesWidget : GlanceAppWidget() {
+    override val sizeMode =
+        SizeMode.Responsive(
+            setOf(
+                DpSize(300.dp, 120.dp),
+                DpSize(300.dp, 240.dp),
+            ),
+        )
+
+    override suspend fun provideGlance(
+        context: Context,
+        id: GlanceId,
+    ) {
+        val koin =
+            org.koin.java.KoinJavaComponent
+                .getKoin()
+        val db = koin.get<BissbilanzDatabase>()
+        val json = koin.get<Json>()
+
+        val rows = db.bissbilanzDatabaseQueries.selectFavorites().executeAsList()
+        val favorites = rows.mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
+
+        val imageDir = File(context.cacheDir, "widget_food_images")
+        val density = context.resources.displayMetrics.density
+        val tilePx = (56 * density).toInt()
+        val isDark =
+            (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+                Configuration.UI_MODE_NIGHT_YES
+
+        val tiles =
+            favorites.map { food ->
+                val cachedFile = File(imageDir, "${food.id}.png")
+                val bitmap =
+                    if (cachedFile.exists()) {
+                        BitmapFactory.decodeFile(cachedFile.absolutePath)
+                            ?: FavoritePlaceholderRenderer.render(food.name, tilePx, isDark)
+                    } else {
+                        FavoritePlaceholderRenderer.render(food.name, tilePx, isDark)
+                    }
+                FavoriteTile(food.id, food.name, ImageProvider(bitmap))
+            }
+
+        provideContent {
+            GlanceTheme {
+                FavoritesContent(tiles)
+            }
+        }
+    }
+
+    companion object {
+        suspend fun updateAllWidgets(context: Context) {
+            val manager = GlanceAppWidgetManager(context)
+            val ids = manager.getGlanceIds(FavoritesWidget::class.java)
+            ids.forEach { id -> FavoritesWidget().update(context, id) }
+        }
+    }
+}
+
+@Composable
+private fun FavoritesContent(tiles: List<FavoriteTile>) {
+    val size = LocalSize.current
+    val rows = if (size.height >= 200.dp) 4 else 2
+    val columns = 5
+
+    if (tiles.isEmpty()) {
+        Box(
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .cornerRadius(16.dp)
+                    .background(GlanceTheme.colors.background)
+                    .clickable(actionStartActivity<MainActivity>()),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "No favorites yet",
+                style =
+                    TextStyle(
+                        color = GlanceTheme.colors.onSurface,
+                        textAlign = TextAlign.Center,
+                    ),
+            )
+        }
+        return
+    }
+
+    Column(
+        modifier =
+            GlanceModifier
+                .fillMaxSize()
+                .cornerRadius(16.dp)
+                .background(GlanceTheme.colors.background)
+                .padding(6.dp),
+    ) {
+        for (row in 0 until rows) {
+            if (row > 0) Spacer(modifier = GlanceModifier.height(4.dp))
+            Row(
+                modifier = GlanceModifier.fillMaxWidth().defaultWeight(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                for (col in 0 until columns) {
+                    if (col > 0) Spacer(modifier = GlanceModifier.width(4.dp))
+                    val index = row * columns + col
+                    if (index < tiles.size) {
+                        val tile = tiles[index]
+                        Image(
+                            provider = tile.imageProvider,
+                            contentDescription = tile.name,
+                            contentScale = ContentScale.Crop,
+                            modifier =
+                                GlanceModifier
+                                    .defaultWeight()
+                                    .fillMaxSize()
+                                    .cornerRadius(8.dp)
+                                    .clickable(
+                                        actionRunCallback<LogFavoriteFoodAction>(
+                                            actionParametersOf(
+                                                FoodIdKey to tile.id,
+                                                FoodNameKey to tile.name,
+                                            ),
+                                        ),
+                                    ),
+                        )
+                    } else {
+                        Box(modifier = GlanceModifier.defaultWeight()) {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -155,28 +155,29 @@ private fun FavoritesContent(tiles: List<FavoriteTile>) {
                 for (col in 0 until columns) {
                     if (col > 0) Spacer(modifier = GlanceModifier.width(4.dp))
                     val index = row * columns + col
-                    if (index < tiles.size) {
-                        val tile = tiles[index]
-                        Image(
-                            provider = tile.imageProvider,
-                            contentDescription = tile.name,
-                            contentScale = ContentScale.Crop,
-                            modifier =
-                                GlanceModifier
-                                    .defaultWeight()
-                                    .fillMaxSize()
-                                    .cornerRadius(8.dp)
-                                    .clickable(
-                                        actionRunCallback<LogFavoriteFoodAction>(
-                                            actionParametersOf(
-                                                FoodIdKey to tile.id,
-                                                FoodNameKey to tile.name,
+                    Box(
+                        modifier = GlanceModifier.defaultWeight().fillMaxSize(),
+                    ) {
+                        if (index < tiles.size) {
+                            val tile = tiles[index]
+                            Image(
+                                provider = tile.imageProvider,
+                                contentDescription = tile.name,
+                                contentScale = ContentScale.Crop,
+                                modifier =
+                                    GlanceModifier
+                                        .fillMaxSize()
+                                        .cornerRadius(8.dp)
+                                        .clickable(
+                                            actionRunCallback<LogFavoriteFoodAction>(
+                                                actionParametersOf(
+                                                    FoodIdKey to tile.id,
+                                                    FoodNameKey to tile.name,
+                                                ),
                                             ),
                                         ),
-                                    ),
-                        )
-                    } else {
-                        Box(modifier = GlanceModifier.defaultWeight()) {}
+                            )
+                        }
                     }
                 }
             }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -100,9 +100,13 @@ class FavoritesWidget : GlanceAppWidget() {
         val plusBitmap = PlusPlaceholderRenderer.render(tilePx, isDark)
         val plusProvider = ImageProvider(plusBitmap)
 
+        val loggedId = LogFavoriteFoodAction.loggedFoodId
+        val checkBitmap = CheckmarkRenderer.render(tilePx)
+        val checkProvider = ImageProvider(checkBitmap)
+
         provideContent {
             GlanceTheme {
-                FavoritesContent(tiles, plusProvider)
+                FavoritesContent(tiles, plusProvider, loggedId, checkProvider)
             }
         }
     }
@@ -120,6 +124,8 @@ class FavoritesWidget : GlanceAppWidget() {
 private fun FavoritesContent(
     tiles: List<FavoriteTile>,
     plusProvider: ImageProvider,
+    loggedFoodId: String?,
+    checkProvider: ImageProvider,
 ) {
     val context = LocalContext.current
     val size = LocalSize.current
@@ -174,9 +180,10 @@ private fun FavoritesContent(
                     val index = row * columns + col
                     if (index < tiles.size) {
                         val tile = tiles[index]
+                        val isLogged = tile.id == loggedFoodId
                         Image(
-                            provider = tile.imageProvider,
-                            contentDescription = tile.name,
+                            provider = if (isLogged) checkProvider else tile.imageProvider,
+                            contentDescription = if (isLogged) "Logged" else tile.name,
                             contentScale = ContentScale.Crop,
                             modifier =
                                 GlanceModifier

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -113,8 +113,10 @@ class FavoritesWidget : GlanceAppWidget() {
 private fun FavoritesContent(tiles: List<FavoriteTile>) {
     val context = LocalContext.current
     val size = LocalSize.current
-    val rows = if (size.height >= 200.dp) 4 else 2
+    val maxRows = if (size.height >= 200.dp) 4 else 2
     val columns = 5
+    val totalRows = ((tiles.size + columns - 1) / columns).coerceIn(1, maxRows)
+    val visibleTiles = tiles.take(totalRows * columns)
 
     if (tiles.isEmpty()) {
         Box(
@@ -145,41 +147,41 @@ private fun FavoritesContent(tiles: List<FavoriteTile>) {
                 .cornerRadius(16.dp)
                 .background(GlanceTheme.colors.background)
                 .padding(6.dp),
+        verticalAlignment = Alignment.Top,
     ) {
-        for (row in 0 until rows) {
+        for (row in 0 until totalRows) {
             if (row > 0) Spacer(modifier = GlanceModifier.height(4.dp))
+            val rowStart = row * columns
+            val rowEnd = (rowStart + columns).coerceAtMost(visibleTiles.size)
+            val rowTiles = visibleTiles.subList(rowStart, rowEnd)
             Row(
                 modifier = GlanceModifier.fillMaxWidth().defaultWeight(),
-                horizontalAlignment = Alignment.CenterHorizontally,
+                horizontalAlignment = Alignment.Start,
             ) {
                 for (col in 0 until columns) {
                     if (col > 0) Spacer(modifier = GlanceModifier.width(4.dp))
-                    val index = row * columns + col
-                    Box(
-                        modifier = GlanceModifier.defaultWeight().fillMaxSize(),
-                    ) {
-                        if (index < tiles.size) {
-                            val tile = tiles[index]
-                            Image(
-                                provider = tile.imageProvider,
-                                contentDescription = tile.name,
-                                contentScale = ContentScale.Crop,
-                                modifier =
-                                    GlanceModifier
-                                        .fillMaxSize()
-                                        .cornerRadius(8.dp)
-                                        .clickable(
-                                            actionRunCallback<LogFavoriteFoodAction>(
-                                                actionParametersOf(
-                                                    FoodIdKey to tile.id,
-                                                    FoodNameKey to tile.name,
-                                                ),
+                    if (col < rowTiles.size) {
+                        val tile = rowTiles[col]
+                        Image(
+                            provider = tile.imageProvider,
+                            contentDescription = tile.name,
+                            contentScale = ContentScale.Crop,
+                            modifier =
+                                GlanceModifier
+                                    .defaultWeight()
+                                    .fillMaxSize()
+                                    .cornerRadius(8.dp)
+                                    .clickable(
+                                        actionRunCallback<LogFavoriteFoodAction>(
+                                            actionParametersOf(
+                                                FoodIdKey to tile.id,
+                                                FoodNameKey to tile.name,
                                             ),
                                         ),
-                            )
-                        } else {
-                            Spacer(modifier = GlanceModifier.fillMaxSize())
-                        }
+                                    ),
+                        )
+                    } else {
+                        Box(modifier = GlanceModifier.defaultWeight()) {}
                     }
                 }
             }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -32,7 +32,6 @@ import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
-import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.width
 import androidx.glance.text.Text
@@ -160,8 +159,7 @@ private fun FavoritesContent(
             GlanceModifier
                 .fillMaxSize()
                 .cornerRadius(16.dp)
-                .background(GlanceTheme.colors.background)
-                .padding(horizontal = 4.dp, vertical = 6.dp),
+                .background(GlanceTheme.colors.background),
         verticalAlignment = Alignment.CenterVertically,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetReceiver.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetReceiver.kt
@@ -1,0 +1,37 @@
+package com.bissbilanz.android.widget
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+class FavoritesWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget = FavoritesWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        val work =
+            PeriodicWorkRequestBuilder<FavoritesWidgetWorker>(
+                30,
+                TimeUnit.MINUTES,
+                15,
+                TimeUnit.MINUTES,
+            ).build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            work,
+        )
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
+
+    companion object {
+        const val WORK_NAME = "favorites_widget_refresh"
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
@@ -6,6 +6,7 @@ import android.graphics.BitmapFactory
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.bissbilanz.ErrorReporter
+import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.Food
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.repository.FoodRepository
@@ -14,8 +15,6 @@ import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.json.Json
 import java.io.File
 import java.io.FileOutputStream
-import java.net.HttpURLConnection
-import java.net.URL
 
 class FavoritesWidgetWorker(
     context: Context,
@@ -30,6 +29,7 @@ class FavoritesWidgetWorker(
         val prefsRepo = koin.get<PreferencesRepository>()
         val db = koin.get<BissbilanzDatabase>()
         val json = koin.get<Json>()
+        val api = koin.get<BissbilanzApi>()
 
         try {
             foodRepo.refreshFavorites()
@@ -57,19 +57,18 @@ class FavoritesWidgetWorker(
                 val ageMs = System.currentTimeMillis() - file.lastModified()
                 if (file.exists() && ageMs < 24 * 60 * 60 * 1000L) return@forEach
 
-                val conn = URL(imageUrl).openConnection() as HttpURLConnection
-                conn.connectTimeout = 5000
-                conn.readTimeout = 10000
-                try {
-                    if (conn.responseCode != HttpURLConnection.HTTP_OK) return@forEach
-                    val bitmap = conn.inputStream.use { BitmapFactory.decodeStream(it) } ?: return@forEach
-                    val scaled = Bitmap.createScaledBitmap(bitmap, tilePx, tilePx, true)
-                    FileOutputStream(file).use { scaled.compress(Bitmap.CompressFormat.PNG, 90, it) }
-                    if (scaled !== bitmap) bitmap.recycle()
-                    scaled.recycle()
-                } finally {
-                    conn.disconnect()
-                }
+                val bytes =
+                    try {
+                        api.downloadBytes(imageUrl)
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        return@forEach
+                    }
+                val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return@forEach
+                val scaled = Bitmap.createScaledBitmap(bitmap, tilePx, tilePx, true)
+                FileOutputStream(file).use { scaled.compress(Bitmap.CompressFormat.PNG, 90, it) }
+                if (scaled !== bitmap) bitmap.recycle()
+                scaled.recycle()
             }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
@@ -1,0 +1,75 @@
+package com.bissbilanz.android.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.bissbilanz.ErrorReporter
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.repository.FoodRepository
+import com.bissbilanz.repository.PreferencesRepository
+import com.bissbilanz.util.decodeOrNull
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+class FavoritesWidgetWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result {
+        val koin =
+            org.koin.java.KoinJavaComponent
+                .getKoin()
+        val errorReporter = koin.get<ErrorReporter>()
+        val foodRepo = koin.get<FoodRepository>()
+        val prefsRepo = koin.get<PreferencesRepository>()
+        val db = koin.get<BissbilanzDatabase>()
+        val json = koin.get<Json>()
+
+        try {
+            foodRepo.refreshFavorites()
+            prefsRepo.refresh()
+
+            val favorites =
+                db.bissbilanzDatabaseQueries
+                    .selectFavorites()
+                    .executeAsList()
+                    .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
+
+            val density = applicationContext.resources.displayMetrics.density
+            val tilePx = (56 * density).toInt()
+            val imageDir = File(applicationContext.cacheDir, "widget_food_images").also { it.mkdirs() }
+            val favoriteIds = favorites.map { it.id }.toSet()
+
+            imageDir.listFiles()?.forEach { file ->
+                val id = file.nameWithoutExtension
+                if (id !in favoriteIds) file.delete()
+            }
+
+            favorites.forEach { food ->
+                val imageUrl = food.imageUrl ?: return@forEach
+                val file = File(imageDir, "${food.id}.png")
+                val ageMs = System.currentTimeMillis() - file.lastModified()
+                if (file.exists() && ageMs < 24 * 60 * 60 * 1000L) return@forEach
+
+                val conn = URL(imageUrl).openConnection() as HttpURLConnection
+                conn.connectTimeout = 5000
+                conn.readTimeout = 10000
+                val bitmap = conn.inputStream.use { BitmapFactory.decodeStream(it) } ?: return@forEach
+                val scaled = Bitmap.createScaledBitmap(bitmap, tilePx, tilePx, true)
+                FileOutputStream(file).use { scaled.compress(Bitmap.CompressFormat.PNG, 90, it) }
+            }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            errorReporter.captureException(e)
+        }
+
+        FavoritesWidget.updateAllWidgets(applicationContext)
+        return Result.success()
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
@@ -60,9 +60,16 @@ class FavoritesWidgetWorker(
                 val conn = URL(imageUrl).openConnection() as HttpURLConnection
                 conn.connectTimeout = 5000
                 conn.readTimeout = 10000
-                val bitmap = conn.inputStream.use { BitmapFactory.decodeStream(it) } ?: return@forEach
-                val scaled = Bitmap.createScaledBitmap(bitmap, tilePx, tilePx, true)
-                FileOutputStream(file).use { scaled.compress(Bitmap.CompressFormat.PNG, 90, it) }
+                try {
+                    if (conn.responseCode != HttpURLConnection.HTTP_OK) return@forEach
+                    val bitmap = conn.inputStream.use { BitmapFactory.decodeStream(it) } ?: return@forEach
+                    val scaled = Bitmap.createScaledBitmap(bitmap, tilePx, tilePx, true)
+                    FileOutputStream(file).use { scaled.compress(Bitmap.CompressFormat.PNG, 90, it) }
+                    if (scaled !== bitmap) bitmap.recycle()
+                    scaled.recycle()
+                } finally {
+                    conn.disconnect()
+                }
             }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
@@ -2,20 +2,17 @@ package com.bissbilanz.android.widget
 
 import android.content.Context
 import android.content.Intent
-import android.widget.Toast
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.android.MainActivity
-import com.bissbilanz.android.R
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.model.EntryCreate
 import com.bissbilanz.repository.EntryRepository
 import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.resolveDefaultMeal
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
@@ -50,14 +47,15 @@ class LogFavoriteFoodAction : ActionCallback {
                 val today = Clock.System.todayIn(TimeZone.currentSystemDefault()).toString()
                 val entry = EntryCreate(foodId = foodId, mealType = meal, servings = 1.0, date = today)
                 entryRepo.createEntry(entry)
-                withContext(Dispatchers.Main) {
-                    Toast
-                        .makeText(
-                            context,
-                            context.getString(R.string.favorites_widget_logged, foodName),
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                }
+
+                loggedFoodId = foodId
+                FavoritesWidget.updateAllWidgets(context)
+
+                delay(1200)
+
+                loggedFoodId = null
+                FavoritesWidget.updateAllWidgets(context)
+
                 MacroWidget.updateAllWidgets(context)
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
@@ -72,5 +70,10 @@ class LogFavoriteFoodAction : ActionCallback {
                 }
             context.startActivity(intent)
         }
+    }
+
+    companion object {
+        @Volatile
+        var loggedFoodId: String? = null
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
@@ -8,6 +8,7 @@ import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.android.MainActivity
+import com.bissbilanz.android.R
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.model.EntryCreate
 import com.bissbilanz.repository.EntryRepository
@@ -50,7 +51,12 @@ class LogFavoriteFoodAction : ActionCallback {
                 val entry = EntryCreate(foodId = foodId, mealType = meal, servings = 1.0, date = today)
                 entryRepo.createEntry(entry)
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(context, "Logged $foodName", Toast.LENGTH_SHORT).show()
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(R.string.favorites_widget_logged, foodName),
+                            Toast.LENGTH_SHORT,
+                        ).show()
                 }
                 MacroWidget.updateAllWidgets(context)
             } catch (e: Exception) {
@@ -61,7 +67,7 @@ class LogFavoriteFoodAction : ActionCallback {
             val intent =
                 Intent(context, MainActivity::class.java).apply {
                     putExtra(MainActivity.EXTRA_NAVIGATE_TO, "favorites")
-                    putExtra("food_id", foodId)
+                    putExtra(MainActivity.EXTRA_FOOD_ID, foodId)
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
                 }
             context.startActivity(intent)

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
@@ -32,7 +32,9 @@ class LogFavoriteFoodAction : ActionCallback {
         val foodId = parameters[FoodIdKey] ?: return
         val foodName = parameters[FoodNameKey] ?: ""
 
-        val koin = org.koin.java.KoinJavaComponent.getKoin()
+        val koin =
+            org.koin.java.KoinJavaComponent
+                .getKoin()
         val entryRepo = koin.get<EntryRepository>()
         val db = koin.get<BissbilanzDatabase>()
         val json = koin.get<Json>()
@@ -56,11 +58,12 @@ class LogFavoriteFoodAction : ActionCallback {
                 errorReporter.captureException(e)
             }
         } else {
-            val intent = Intent(context, MainActivity::class.java).apply {
-                putExtra(MainActivity.EXTRA_NAVIGATE_TO, "favorites")
-                putExtra("food_id", foodId)
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            }
+            val intent =
+                Intent(context, MainActivity::class.java).apply {
+                    putExtra(MainActivity.EXTRA_NAVIGATE_TO, "favorites")
+                    putExtra("food_id", foodId)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
             context.startActivity(intent)
         }
     }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
@@ -1,0 +1,67 @@
+package com.bissbilanz.android.widget
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.glance.GlanceId
+import androidx.glance.action.ActionParameters
+import androidx.glance.appwidget.action.ActionCallback
+import com.bissbilanz.ErrorReporter
+import com.bissbilanz.android.MainActivity
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.model.EntryCreate
+import com.bissbilanz.repository.EntryRepository
+import com.bissbilanz.util.decodeOrNull
+import com.bissbilanz.util.resolveDefaultMeal
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import kotlinx.serialization.json.Json
+
+val FoodIdKey = ActionParameters.Key<String>("food_id")
+val FoodNameKey = ActionParameters.Key<String>("food_name")
+
+class LogFavoriteFoodAction : ActionCallback {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters,
+    ) {
+        val foodId = parameters[FoodIdKey] ?: return
+        val foodName = parameters[FoodNameKey] ?: ""
+
+        val koin = org.koin.java.KoinJavaComponent.getKoin()
+        val entryRepo = koin.get<EntryRepository>()
+        val db = koin.get<BissbilanzDatabase>()
+        val json = koin.get<Json>()
+        val errorReporter = koin.get<ErrorReporter>()
+
+        val cached = db.bissbilanzDatabaseQueries.selectPreferences().executeAsOneOrNull()
+        val prefs = cached?.let { json.decodeOrNull<com.bissbilanz.api.generated.model.Preferences>(it.jsonData) }
+        val meal = resolveDefaultMeal(prefs)
+
+        if (meal != null) {
+            try {
+                val today = Clock.System.todayIn(TimeZone.currentSystemDefault()).toString()
+                val entry = EntryCreate(foodId = foodId, mealType = meal, servings = 1.0, date = today)
+                entryRepo.createEntry(entry)
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, "Logged $foodName", Toast.LENGTH_SHORT).show()
+                }
+                MacroWidget.updateAllWidgets(context)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+            }
+        } else {
+            val intent = Intent(context, MainActivity::class.java).apply {
+                putExtra(MainActivity.EXTRA_NAVIGATE_TO, "favorites")
+                putExtra("food_id", foodId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            context.startActivity(intent)
+        }
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/PlusPlaceholderRenderer.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/PlusPlaceholderRenderer.kt
@@ -1,0 +1,46 @@
+package com.bissbilanz.android.widget
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+
+object PlusPlaceholderRenderer {
+    fun render(
+        sizePx: Int,
+        isDarkMode: Boolean,
+    ): Bitmap {
+        val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        val bgColor = if (isDarkMode) 0xFF2A2A2A.toInt() else 0xFFF0F0F0.toInt()
+        val iconColor = if (isDarkMode) 0xFF666666.toInt() else 0xFFBBBBBB.toInt()
+        val cornerRadius = sizePx / 6f
+
+        val bgPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = bgColor
+                style = Paint.Style.FILL
+            }
+        canvas.drawRoundRect(
+            RectF(0f, 0f, sizePx.toFloat(), sizePx.toFloat()),
+            cornerRadius,
+            cornerRadius,
+            bgPaint,
+        )
+
+        val linePaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = iconColor
+                strokeWidth = sizePx * 0.08f
+                strokeCap = Paint.Cap.ROUND
+            }
+
+        val center = sizePx / 2f
+        val armLen = sizePx * 0.18f
+        canvas.drawLine(center, center - armLen, center, center + armLen, linePaint)
+        canvas.drawLine(center - armLen, center, center + armLen, center, linePaint)
+
+        return bitmap
+    }
+}

--- a/mobile/androidApp/src/androidMain/res/layout/favorites_widget_preview.xml
+++ b/mobile/androidApp/src/androidMain/res/layout/favorites_widget_preview.xml
@@ -17,35 +17,35 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
     </LinearLayout>
 
@@ -60,35 +60,35 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
-            android:background="#1F2937" />
+            android:background="?android:attr/colorControlNormal" />
 
     </LinearLayout>
 

--- a/mobile/androidApp/src/androidMain/res/layout/favorites_widget_preview.xml
+++ b/mobile/androidApp/src/androidMain/res/layout/favorites_widget_preview.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:background="#1F2937" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile/androidApp/src/androidMain/res/values/strings.xml
+++ b/mobile/androidApp/src/androidMain/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="weight_cancel">Cancel</string>
     <string name="fasting_day">Fasting Day</string>
     <string name="fasting_day_description">Include this 0-calorie day in stats</string>
+    <string name="favorites_widget_description">Quick-log favorite foods with one tap</string>
+    <string name="favorites_widget_empty">No favorites yet</string>
+    <string name="favorites_widget_logged">Logged %1$s</string>
 </resources>

--- a/mobile/androidApp/src/androidMain/res/values/strings.xml
+++ b/mobile/androidApp/src/androidMain/res/values/strings.xml
@@ -18,4 +18,13 @@
     <string name="favorites_widget_description">Quick-log favorite foods with one tap</string>
     <string name="favorites_widget_empty">No favorites yet</string>
     <string name="favorites_widget_logged">Logged %1$s</string>
+    <string name="chart_weight_format">%.1f kg</string>
+    <string name="chart_weight_avg_format">Avg: %.1f kg</string>
+    <string name="chart_percent_of_goal">%1$d%% of goal</string>
+    <string name="chart_no_data">No data</string>
+    <string name="chart_kcal_format">%1$d kcal</string>
+    <string name="chart_kcal_pct_format">%1$d kcal (%2$d%%)</string>
+    <string name="chart_supplements">Supplements</string>
+    <string name="chart_supplements_taken">%1$d of %2$d taken</string>
+    <string name="chart_view_all">View All</string>
 </resources>

--- a/mobile/androidApp/src/androidMain/res/xml/favorites_widget_info.xml
+++ b/mobile/androidApp/src/androidMain/res/xml/favorites_widget_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="300dp"
+    android:minHeight="120dp"
+    android:targetCellWidth="5"
+    android:targetCellHeight="2"
+    android:minResizeWidth="250dp"
+    android:minResizeHeight="120dp"
+    android:resizeMode="vertical"
+    android:updatePeriodMillis="0"
+    android:previewImage="@mipmap/ic_launcher_round"
+    android:previewLayout="@layout/favorites_widget_preview"
+    android:description="@string/favorites_widget_description"
+    android:widgetCategory="home_screen" />

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/DayLogViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/DayLogViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.android.ui.viewmodels
 
-import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.model.Entry
 import com.bissbilanz.model.Food
 import com.bissbilanz.repository.EntryRepository
@@ -25,7 +24,6 @@ import kotlin.test.assertNull
 class DayLogViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var entryRepo: EntryRepository
-    private lateinit var api: BissbilanzApi
     private lateinit var entriesFlow: MutableStateFlow<List<Entry>>
 
     @BeforeTest
@@ -36,7 +34,6 @@ class DayLogViewModelTest {
             mockk(relaxed = true) {
                 every { entriesByDate(any()) } returns entriesFlow
             }
-        api = mockk(relaxed = true)
     }
 
     @AfterTest
@@ -51,7 +48,7 @@ class DayLogViewModelTest {
                 entriesFlow.value = listOf(testEntry("1"))
             }
 
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             viewModel.loadEntries("2024-01-15")
 
             coVerify { entryRepo.refresh("2024-01-15") }
@@ -63,7 +60,7 @@ class DayLogViewModelTest {
         runTest {
             coEvery { entryRepo.refresh("2024-01-15") } throws RuntimeException("Network error")
 
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             viewModel.loadEntries("2024-01-15")
 
             assertEquals("Failed to load entries", viewModel.error.value)
@@ -77,7 +74,7 @@ class DayLogViewModelTest {
                 entriesFlow.value = listOf(testEntry("1"))
             }
 
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             viewModel.loadEntries("2024-01-15")
             viewModel.loadEntries("2024-01-15")
 
@@ -87,7 +84,7 @@ class DayLogViewModelTest {
     @Test
     fun deleteEntryCallsRepository() =
         runTest {
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             viewModel.deleteEntry("entry-1")
 
             coVerify { entryRepo.deleteEntry("entry-1") }
@@ -98,7 +95,7 @@ class DayLogViewModelTest {
         runTest {
             coEvery { entryRepo.deleteEntry("entry-1") } throws RuntimeException("Delete failed")
 
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             viewModel.deleteEntry("entry-1")
 
             assertEquals("Failed to delete entry", viewModel.error.value)
@@ -109,7 +106,7 @@ class DayLogViewModelTest {
         runTest {
             coEvery { entryRepo.refresh("2024-01-15") } throws RuntimeException("Error")
 
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             viewModel.loadEntries("2024-01-15")
             assertEquals("Failed to load entries", viewModel.error.value)
 
@@ -120,19 +117,19 @@ class DayLogViewModelTest {
     @Test
     fun toggleFastingDayOnCallsSetDayProperties() =
         runTest {
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             assertEquals(false, viewModel.isFastingDay.value)
 
             viewModel.toggleFastingDay("2024-01-15")
 
             assertEquals(true, viewModel.isFastingDay.value)
-            coVerify { api.setDayProperties("2024-01-15", isFastingDay = true) }
+            coVerify { entryRepo.setDayProperties("2024-01-15", isFastingDay = true) }
         }
 
     @Test
     fun toggleFastingDayOffCallsDeleteDayProperties() =
         runTest {
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             // Toggle on first
             viewModel.toggleFastingDay("2024-01-15")
             assertEquals(true, viewModel.isFastingDay.value)
@@ -141,15 +138,15 @@ class DayLogViewModelTest {
             viewModel.toggleFastingDay("2024-01-15")
 
             assertEquals(false, viewModel.isFastingDay.value)
-            coVerify { api.deleteDayProperties("2024-01-15") }
+            coVerify { entryRepo.deleteDayProperties("2024-01-15") }
         }
 
     @Test
     fun toggleFastingDayRevertsOnError() =
         runTest {
-            coEvery { api.setDayProperties(any(), any()) } throws RuntimeException("Network error")
+            coEvery { entryRepo.setDayProperties(any(), any()) } throws RuntimeException("Network error")
 
-            val viewModel = DayLogViewModel(entryRepo, api)
+            val viewModel = DayLogViewModel(entryRepo)
             viewModel.toggleFastingDay("2024-01-15")
 
             // Should revert to false after failure

--- a/mobile/shared/src/androidMain/kotlin/com/bissbilanz/sync/ConnectivityProvider.kt
+++ b/mobile/shared/src/androidMain/kotlin/com/bissbilanz/sync/ConnectivityProvider.kt
@@ -18,6 +18,17 @@ actual class ConnectivityProvider(
     private val _isOnline = MutableStateFlow(checkCurrentConnectivity())
     actual val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
 
+    private val networkCallback =
+        object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                _isOnline.value = true
+            }
+
+            override fun onLost(network: Network) {
+                _isOnline.value = checkCurrentConnectivity()
+            }
+        }
+
     init {
         val request =
             NetworkRequest
@@ -25,18 +36,11 @@ actual class ConnectivityProvider(
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .build()
 
-        connectivityManager.registerNetworkCallback(
-            request,
-            object : ConnectivityManager.NetworkCallback() {
-                override fun onAvailable(network: Network) {
-                    _isOnline.value = true
-                }
+        connectivityManager.registerNetworkCallback(request, networkCallback)
+    }
 
-                override fun onLost(network: Network) {
-                    _isOnline.value = checkCurrentConnectivity()
-                }
-            },
-        )
+    fun cleanup() {
+        connectivityManager.unregisterNetworkCallback(networkCallback)
     }
 
     private fun checkCurrentConnectivity(): Boolean {

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/BissbilanzApi.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/BissbilanzApi.kt
@@ -165,6 +165,23 @@ class BissbilanzApi(
         return response.body()
     }
 
+    private suspend inline fun <reified T> patch(
+        path: String,
+        body: Any,
+    ): T {
+        val response =
+            client.patch(path) {
+                setBody(body)
+            }
+        if (!response.status.isSuccess()) {
+            throw ApiException(
+                "PATCH $path failed: HTTP ${response.status.value} ${response.bodyAsText()}",
+                response.status.value,
+            )
+        }
+        return response.body()
+    }
+
     private suspend fun delete(path: String) {
         val response = client.delete(path)
         if (!response.status.isSuccess()) {
@@ -208,7 +225,7 @@ class BissbilanzApi(
         id: String,
         food: FoodCreate,
     ): Food {
-        val response: FoodResponse = put("/api/foods/$id", food)
+        val response: FoodResponse = patch("/api/foods/$id", food)
         return response.food
     }
 
@@ -303,7 +320,7 @@ class BissbilanzApi(
         id: String,
         entry: EntryUpdate,
     ): Entry {
-        val response: EntryResponse = put("/api/entries/$id", entry)
+        val response: EntryResponse = patch("/api/entries/$id", entry)
         val e = response.entry
         return Entry(
             id = e.id,
@@ -348,7 +365,7 @@ class BissbilanzApi(
         id: String,
         recipe: RecipeUpdate,
     ): RecipeDetail {
-        val response: RecipeResponse = put("/api/recipes/$id", recipe)
+        val response: RecipeResponse = patch("/api/recipes/$id", recipe)
         return response.recipe
     }
 
@@ -365,7 +382,7 @@ class BissbilanzApi(
         }
 
     suspend fun setGoals(goals: Goals): Goals {
-        val response: GoalsSetResponse = put("/api/goals", goals)
+        val response: GoalsSetResponse = post("/api/goals", goals)
         return response.goals
     }
 
@@ -384,7 +401,7 @@ class BissbilanzApi(
         id: String,
         entry: WeightUpdate,
     ): WeightEntry {
-        val response: WeightEntryResponse = put("/api/weight/$id", entry)
+        val response: WeightEntryResponse = patch("/api/weight/$id", entry)
         return response.entry
     }
 
@@ -471,7 +488,7 @@ class BissbilanzApi(
     }
 
     suspend fun updatePreferences(prefs: PreferencesUpdate): Preferences {
-        val response: PreferencesResponse = put("/api/preferences", prefs)
+        val response: PreferencesResponse = patch("/api/preferences", prefs)
         return response.preferences
     }
 
@@ -530,7 +547,7 @@ class BissbilanzApi(
         id: String,
         supplement: SupplementCreate,
     ): Supplement {
-        val response: SupplementResponse = put("/api/supplements/$id", supplement)
+        val response: SupplementResponse = patch("/api/supplements/$id", supplement)
         return response.supplement
     }
 

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/BissbilanzApi.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/BissbilanzApi.kt
@@ -553,6 +553,14 @@ class BissbilanzApi(
         val response: SupplementChecklistResponse = get("/api/supplements/$date/checklist")
         return response.checklist
     }
+
+    suspend fun downloadBytes(url: String): ByteArray {
+        val response = client.get(url)
+        if (!response.status.isSuccess()) {
+            throw ApiException("GET $url failed: HTTP ${response.status.value}", response.status.value)
+        }
+        return response.body()
+    }
 }
 
 class UnauthorizedException : Exception("Not authenticated")

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/auth/AuthManager.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/auth/AuthManager.kt
@@ -129,7 +129,6 @@ class AuthManager(
                 true
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                _authState.value = AuthState.Authenticated
                 false
             }
         }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
@@ -9,15 +9,17 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.model.*
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.totalMacros
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
-import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class EntryRepository(
     private val api: BissbilanzApi,
@@ -182,13 +184,14 @@ class EntryRepository(
         }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     private fun entryCreateToEntry(
         entry: EntryCreate,
         food: Food? = null,
         recipe: Recipe? = null,
     ): Entry =
         Entry(
-            id = "temp_${Clock.System.now().toEpochMilliseconds()}",
+            id = "temp_${Uuid.random()}",
             userId = "",
             foodId = entry.foodId,
             recipeId = entry.recipeId,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
@@ -104,6 +104,15 @@ class EntryRepository(
         onEntryChanged?.invoke()
     }
 
+    suspend fun getDayProperties(date: String) = api.getDayProperties(date)
+
+    suspend fun setDayProperties(
+        date: String,
+        isFastingDay: Boolean,
+    ) = api.setDayProperties(date, isFastingDay)
+
+    suspend fun deleteDayProperties(date: String) = api.deleteDayProperties(date)
+
     suspend fun copyEntries(
         fromDate: String,
         toDate: String,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
@@ -10,6 +10,7 @@ import com.bissbilanz.api.generated.model.FoodsListResponse
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.async
@@ -20,9 +21,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
-import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class FoodRepository(
     private val api: BissbilanzApi,
@@ -201,9 +203,10 @@ class FoodRepository(
         }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     private fun foodCreateToFood(
         food: FoodCreate,
-        id: String = "temp_${Clock.System.now().toEpochMilliseconds()}",
+        id: String = "temp_${Uuid.random()}",
     ): Food =
         Food(
             id = id,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
@@ -34,6 +34,7 @@ class FoodRepository(
     private val errorReporter: ErrorReporter,
     private val ioDispatcher: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.IO,
 ) {
+    var onFoodChanged: (suspend () -> Unit)? = null
     private val _recentFoods = MutableStateFlow<List<Food>>(emptyList())
     val recentFoods: StateFlow<List<Food>> = _recentFoods.asStateFlow()
 
@@ -120,6 +121,7 @@ class FoodRepository(
         val tempFood = foodCreateToFood(food)
         cacheFood(tempFood)
         syncQueue.enqueue(SyncOperation.CreateFood(json.encodeToString(food)))
+        onFoodChanged?.invoke()
         return tempFood
     }
 
@@ -130,12 +132,14 @@ class FoodRepository(
         val tempFood = foodCreateToFood(food, id)
         cacheFood(tempFood)
         syncQueue.enqueue(SyncOperation.UpdateFood(id, json.encodeToString(food)))
+        onFoodChanged?.invoke()
         return tempFood
     }
 
     suspend fun deleteFood(id: String) {
         db.bissbilanzDatabaseQueries.deleteFood(id)
         syncQueue.enqueue(SyncOperation.DeleteFood(id))
+        onFoodChanged?.invoke()
     }
 
     suspend fun searchFoods(query: String): List<Food> =

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
@@ -111,6 +111,11 @@ class FoodRepository(
             cached?.let { json.decodeOrNull<Food>(it.jsonData) } ?: throw e
         }
 
+    fun getFoodCached(id: String): Food? {
+        val cached = db.bissbilanzDatabaseQueries.selectFoodById(id).executeAsOneOrNull()
+        return cached?.let { json.decodeOrNull<Food>(it.jsonData) }
+    }
+
     suspend fun createFood(food: FoodCreate): Food {
         val tempFood = foodCreateToFood(food)
         cacheFood(tempFood)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
@@ -8,12 +8,12 @@ import com.bissbilanz.api.generated.model.PreferencesUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
-import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
@@ -10,14 +10,16 @@ import com.bissbilanz.api.generated.model.RecipeUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
-import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class RecipeRepository(
     private val api: BissbilanzApi,
@@ -149,9 +151,10 @@ class RecipeRepository(
         )
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     private fun recipeCreateToRecipe(recipe: RecipeCreate): RecipeDetail =
         RecipeDetail(
-            id = "temp_${Clock.System.now().toEpochMilliseconds()}",
+            id = "temp_${Uuid.random()}",
             userId = "",
             name = recipe.name,
             totalServings = recipe.totalServings,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/StatsRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/StatsRepository.kt
@@ -4,11 +4,11 @@ import com.bissbilanz.ErrorReporter
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.model.*
+import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.totalMacros
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
-import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.json.Json
 
 class StatsRepository(

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
@@ -11,14 +11,16 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.model.SupplementHistoryEntry
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
-import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class SupplementRepository(
     private val api: BissbilanzApi,
@@ -99,6 +101,7 @@ class SupplementRepository(
             }
         }
 
+    @OptIn(ExperimentalUuidApi::class)
     suspend fun logSupplement(
         supplementId: String,
         date: String?,
@@ -107,7 +110,7 @@ class SupplementRepository(
         val logDate = date ?: now.substring(0, 10)
         val temp =
             SupplementLog(
-                id = "temp_${Clock.System.now().toEpochMilliseconds()}",
+                id = "temp_${Uuid.random()}",
                 supplementId = supplementId,
                 userId = "",
                 date = logDate,
@@ -210,9 +213,10 @@ class SupplementRepository(
         }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     private fun supplementCreateToSupplement(
         supplement: SupplementCreate,
-        id: String = "temp_${Clock.System.now().toEpochMilliseconds()}",
+        id: String = "temp_${Uuid.random()}",
     ): Supplement =
         Supplement(
             id = id,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
@@ -12,14 +12,16 @@ import com.bissbilanz.api.generated.model.WeightUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
-import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class WeightRepository(
     private val api: BissbilanzApi,
@@ -138,9 +140,10 @@ class WeightRepository(
         }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     private fun weightCreateToEntry(entry: WeightCreate): WeightEntry =
         WeightEntry(
-            id = "temp_${Clock.System.now().toEpochMilliseconds()}",
+            id = "temp_${Uuid.random()}",
             userId = "",
             weightKg = entry.weightKg,
             entryDate = entry.entryDate,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncManager.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncManager.kt
@@ -107,7 +107,7 @@ class SyncManager(
                     break
                 }
 
-                _state.value = _state.value.copy(pendingCount = (queued.size - synced).toLong())
+                _state.value = _state.value.copy(pendingCount = syncQueue.pendingCount())
             }
         } finally {
             val pending = syncQueue.pendingCount()

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/util/NutritionUtils.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/util/NutritionUtils.kt
@@ -3,12 +3,22 @@ package com.bissbilanz.util
 import com.bissbilanz.model.Entry
 import com.bissbilanz.model.MacroTotals
 
+object DefaultGoals {
+    const val CALORIES = 2000.0
+    const val PROTEIN = 150.0
+    const val CARBS = 250.0
+    const val FAT = 65.0
+    const val FIBER = 30.0
+}
+
 fun Entry.resolvedName(): String = food?.name ?: recipe?.name ?: foodName ?: quickName ?: "Unknown"
 
 fun Entry.resolvedCalories(): Double {
     val food = food
+    val recipe = recipe
     return when {
         food != null -> food.calories * servings
+        recipe != null -> recipe.calories * servings
         calories != null -> calories * servings
         else -> (quickCalories ?: 0.0) * servings
     }
@@ -16,8 +26,10 @@ fun Entry.resolvedCalories(): Double {
 
 fun Entry.resolvedProtein(): Double {
     val food = food
+    val recipe = recipe
     return when {
         food != null -> food.protein * servings
+        recipe != null -> recipe.protein * servings
         protein != null -> protein * servings
         else -> (quickProtein ?: 0.0) * servings
     }
@@ -25,8 +37,10 @@ fun Entry.resolvedProtein(): Double {
 
 fun Entry.resolvedCarbs(): Double {
     val food = food
+    val recipe = recipe
     return when {
         food != null -> food.carbs * servings
+        recipe != null -> recipe.carbs * servings
         carbs != null -> carbs * servings
         else -> (quickCarbs ?: 0.0) * servings
     }
@@ -34,8 +48,10 @@ fun Entry.resolvedCarbs(): Double {
 
 fun Entry.resolvedFat(): Double {
     val food = food
+    val recipe = recipe
     return when {
         food != null -> food.fat * servings
+        recipe != null -> recipe.fat * servings
         fat != null -> fat * servings
         else -> (quickFat ?: 0.0) * servings
     }
@@ -43,8 +59,10 @@ fun Entry.resolvedFat(): Double {
 
 fun Entry.resolvedFiber(): Double {
     val food = food
+    val recipe = recipe
     return when {
         food != null -> food.fiber * servings
+        recipe != null -> recipe.fiber * servings
         fiber != null -> fiber * servings
         else -> (quickFiber ?: 0.0) * servings
     }

--- a/src/lib/components/barcode/BarcodeScanModal.svelte
+++ b/src/lib/components/barcode/BarcodeScanModal.svelte
@@ -9,9 +9,10 @@
 		open?: boolean;
 		onClose: () => void;
 		onBarcode: (barcode: string) => void;
+		onClosed?: () => void;
 	};
 
-	let { open = $bindable(false), onClose, onBarcode }: Props = $props();
+	let { open = $bindable(false), onClose, onBarcode, onClosed }: Props = $props();
 
 	let error = $state('');
 
@@ -33,7 +34,14 @@
 	};
 </script>
 
-<ResponsiveModal bind:open title={m.barcode_title()} openFull>
+<ResponsiveModal
+	bind:open
+	title={m.barcode_title()}
+	openFull
+	onAnimationEnd={(isOpen) => {
+		if (!isOpen) onClosed?.();
+	}}
+>
 	{#if error}
 		<Alert.Root variant="destructive">
 			<AlertCircle class="size-4" />

--- a/src/lib/components/dashboard/DashboardCard.svelte
+++ b/src/lib/components/dashboard/DashboardCard.svelte
@@ -82,7 +82,7 @@
 				<Icon class="size-4" />
 			</div>
 			<div class="min-w-0">
-				<div class={cn('truncate text-sm font-semibold tracking-tight', toneClasses[tone].title)}>
+				<div class={cn('truncate text-sm font-medium', toneClasses[tone].title)}>
 					{title}
 				</div>
 			</div>

--- a/src/lib/components/dashboard/TopFoodsWidget.svelte
+++ b/src/lib/components/dashboard/TopFoodsWidget.svelte
@@ -65,7 +65,7 @@
 					</span>
 					<span class="min-w-0 flex-1 truncate text-sm font-medium">{food.foodName}</span>
 					<span class="text-muted-foreground shrink-0 text-xs">{food.count}x</span>
-					<span class="shrink-0 text-right text-xs tabular-nums"
+					<span class="shrink-0 text-right text-xs font-medium tabular-nums"
 						>{Math.round(food.calories)} kcal</span
 					>
 				</div>

--- a/src/lib/components/entries/DayLog.svelte
+++ b/src/lib/components/entries/DayLog.svelte
@@ -58,6 +58,7 @@
 		quickName?: string | null;
 	} | null = $state(null);
 
+	let pendingBarcodeAction: (() => void) | null = $state(null);
 	let isFastingDay = $state(false);
 	let fastingLoading = $state(false);
 
@@ -141,9 +142,13 @@
 	const handleBarcodeScan = async (barcode: string) => {
 		const food = await foodService.findByBarcode(barcode);
 		if (food) {
-			addModalOpen = true;
+			pendingBarcodeAction = () => {
+				addModalOpen = true;
+			};
 		} else {
-			goto(`/foods?barcode=${encodeURIComponent(barcode)}`);
+			pendingBarcodeAction = () => {
+				goto(`/foods?barcode=${encodeURIComponent(barcode)}`);
+			};
 		}
 	};
 
@@ -219,5 +224,12 @@
 		bind:open={scanModalOpen}
 		onClose={() => (scanModalOpen = false)}
 		onBarcode={handleBarcodeScan}
+		onClosed={() => {
+			if (pendingBarcodeAction) {
+				const action = pendingBarcodeAction;
+				pendingBarcodeAction = null;
+				action();
+			}
+		}}
 	/>
 </div>

--- a/src/lib/components/entries/DayLog.svelte
+++ b/src/lib/components/entries/DayLog.svelte
@@ -139,17 +139,15 @@
 		editModalOpen = true;
 	};
 
-	const handleBarcodeScan = async (barcode: string) => {
-		const food = await foodService.findByBarcode(barcode);
-		if (food) {
-			pendingBarcodeAction = () => {
+	const handleBarcodeScan = (barcode: string) => {
+		pendingBarcodeAction = async () => {
+			const food = await foodService.findByBarcode(barcode);
+			if (food) {
 				addModalOpen = true;
-			};
-		} else {
-			pendingBarcodeAction = () => {
+			} else {
 				goto(`/foods?barcode=${encodeURIComponent(barcode)}`);
-			};
-		}
+			}
+		};
 	};
 
 	const totals = $derived(sumEntries(entries));

--- a/src/lib/components/entries/MacroSummaryCard.svelte
+++ b/src/lib/components/entries/MacroSummaryCard.svelte
@@ -19,7 +19,7 @@
 			<div class="text-[11px] font-medium text-blue-700/80 dark:text-blue-300/80">
 				{m.macro_calories()}
 			</div>
-			<div class="mt-1 text-lg font-semibold tabular-nums text-blue-600 dark:text-blue-400">
+			<div class="mt-1 text-lg font-bold tabular-nums text-blue-600 dark:text-blue-400">
 				{Math.round(totals.calories)}
 			</div>
 		</div>
@@ -29,7 +29,7 @@
 			<div class="text-[11px] font-medium text-red-700/80 dark:text-red-300/80">
 				{m.macro_protein()}
 			</div>
-			<div class="mt-1 font-semibold tabular-nums text-red-600 dark:text-red-400">
+			<div class="mt-1 text-base font-bold tabular-nums text-red-600 dark:text-red-400">
 				{Math.round(totals.protein)}g
 			</div>
 		</div>
@@ -39,7 +39,7 @@
 			<div class="text-[11px] font-medium text-orange-700/80 dark:text-orange-300/80">
 				{m.macro_carbs()}
 			</div>
-			<div class="mt-1 font-semibold tabular-nums text-orange-600 dark:text-orange-400">
+			<div class="mt-1 text-base font-bold tabular-nums text-orange-600 dark:text-orange-400">
 				{Math.round(totals.carbs)}g
 			</div>
 		</div>
@@ -49,7 +49,7 @@
 			<div class="text-[11px] font-medium text-yellow-700/80 dark:text-yellow-300/80">
 				{m.macro_fat()}
 			</div>
-			<div class="mt-1 font-semibold tabular-nums text-yellow-700 dark:text-yellow-300">
+			<div class="mt-1 text-base font-bold tabular-nums text-yellow-700 dark:text-yellow-300">
 				{Math.round(totals.fat)}g
 			</div>
 		</div>
@@ -59,7 +59,7 @@
 			<div class="text-[11px] font-medium text-green-700/80 dark:text-green-300/80">
 				{m.macro_fiber()}
 			</div>
-			<div class="mt-1 font-semibold tabular-nums text-green-600 dark:text-green-400">
+			<div class="mt-1 text-base font-bold tabular-nums text-green-600 dark:text-green-400">
 				{Math.round(totals.fiber)}g
 			</div>
 		</div>

--- a/src/lib/components/entries/MealSection.svelte
+++ b/src/lib/components/entries/MealSection.svelte
@@ -124,7 +124,7 @@
 								>
 							{/if}
 						</div>
-						<span class="shrink-0 text-muted-foreground"
+						<span class="shrink-0 tabular-nums text-muted-foreground"
 							>{Math.round((entry.calories ?? 0) * entry.servings)} kcal</span
 						>
 					</div>

--- a/src/lib/components/insights/CalendarHeatmap.svelte
+++ b/src/lib/components/insights/CalendarHeatmap.svelte
@@ -12,10 +12,12 @@
 
 	type CalendarDay = { calories: number; hasEntries: boolean };
 
+	let { initialDays }: { initialDays?: Record<string, CalendarDay> } = $props();
+
 	let currentYear = $state(new Date().getFullYear());
 	let currentMonth = $state(new Date().getMonth());
-	let days: Record<string, CalendarDay> = $state({});
-	let loading = $state(true);
+	let days: Record<string, CalendarDay> = $state(initialDays ?? {});
+	let loading = $state(!initialDays);
 
 	const goalsQuery = useLiveQuery(() => goalsService.goals(), undefined);
 	const calorieGoal = $derived(goalsQuery.value?.calorieGoal ?? 0);
@@ -38,8 +40,17 @@
 		}
 	};
 
+	let initialized = !!initialDays;
 	$effect(() => {
-		fetchData(monthStr);
+		const ms = monthStr;
+		const now = new Date();
+		const currentMonthStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+		if (initialized && ms === currentMonthStr) {
+			initialized = false;
+			return;
+		}
+		initialized = false;
+		fetchData(ms);
 	});
 
 	function prevMonth() {

--- a/src/lib/components/insights/GoalAdherence.svelte
+++ b/src/lib/components/insights/GoalAdherence.svelte
@@ -15,11 +15,13 @@
 	} from '$lib/utils/insights';
 	import * as m from '$lib/paraglide/messages';
 
+	let { initialData }: { initialData?: { data: DayRow[]; goals: Goals | null } } = $props();
+
 	type RangeKey = '7d' | '30d' | '90d';
 	let range: RangeKey = $state('7d');
-	let data: DayRow[] = $state([]);
-	let goals = $state<Goals | null>(null);
-	let loading = $state(true);
+	let data: DayRow[] = $state(initialData?.data ?? []);
+	let goals = $state<Goals | null>(initialData?.goals ?? null);
+	let loading = $state(!initialData);
 
 	const rangeDays: Record<RangeKey, number> = { '7d': 6, '30d': 29, '90d': 89 };
 	const rangeLabels: Record<RangeKey, () => string> = {
@@ -53,8 +55,15 @@
 		}
 	};
 
+	let initialized = !!initialData;
 	$effect(() => {
-		fetchData(range);
+		const r = range;
+		if (initialized && r === '7d') {
+			initialized = false;
+			return;
+		}
+		initialized = false;
+		fetchData(r);
 	});
 
 	const daysWithEntries = $derived(filterDaysWithEntries(data));

--- a/src/lib/components/insights/MacroRadar.svelte
+++ b/src/lib/components/insights/MacroRadar.svelte
@@ -6,11 +6,13 @@
 	import { radarAverages, type DayRow, type Goals, type MacroKey } from '$lib/utils/insights';
 	import * as m from '$lib/paraglide/messages';
 
+	let { initialData }: { initialData?: { data: DayRow[]; goals: Goals | null } } = $props();
+
 	type RangeKey = '7d' | '30d' | '90d';
 	let range: RangeKey = $state('7d');
-	let data: DayRow[] = $state([]);
-	let goals = $state<Goals | null>(null);
-	let loading = $state(true);
+	let data: DayRow[] = $state(initialData?.data ?? []);
+	let goals = $state<Goals | null>(initialData?.goals ?? null);
+	let loading = $state(!initialData);
 
 	const rangeDays: Record<RangeKey, number> = { '7d': 6, '30d': 29, '90d': 89 };
 	const rangeLabels: Record<RangeKey, () => string> = {
@@ -68,8 +70,15 @@
 		}
 	};
 
+	let initialized = !!initialData;
 	$effect(() => {
-		fetchData(range);
+		const r = range;
+		if (initialized && r === '7d') {
+			initialized = false;
+			return;
+		}
+		initialized = false;
+		fetchData(r);
 	});
 
 	const averages = $derived(radarAverages(data));

--- a/src/lib/components/insights/TrendsChart.svelte
+++ b/src/lib/components/insights/TrendsChart.svelte
@@ -24,12 +24,14 @@
 		fiberGoal: number;
 	} | null;
 
+	let { initialData }: { initialData?: { data: DayRow[]; goals: Goals | null } } = $props();
+
 	type RangeKey = '7d' | '30d' | '90d';
 	let range: RangeKey = $state('7d');
 	let metric: MacroKey = $state('calories');
-	let data: DayRow[] = $state([]);
-	let goals = $state<Goals>(null);
-	let loading = $state(true);
+	let data: DayRow[] = $state(initialData?.data ?? []);
+	let goals = $state<Goals>(initialData?.goals ?? null);
+	let loading = $state(!initialData);
 
 	const macroLabels: Record<MacroKey, () => string> = {
 		calories: () => m.macro_calories(),
@@ -77,8 +79,15 @@
 		}
 	};
 
+	let initialized = !!initialData;
 	$effect(() => {
-		fetchData(range);
+		const r = range;
+		if (initialized && r === '7d') {
+			initialized = false;
+			return;
+		}
+		initialized = false;
+		fetchData(r);
 	});
 
 	const shortLabels = $derived(data.length > 10);

--- a/src/lib/components/navigation/app-sidebar.svelte
+++ b/src/lib/components/navigation/app-sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { beforeNavigate } from '$app/navigation';
-	import { getNavItems } from '$lib/config/navigation';
+	import { getNavGroups } from '$lib/config/navigation';
 	import { Button } from '$lib/components/ui/button/index.js';
 
 	import X from '@lucide/svelte/icons/x';
@@ -13,7 +13,7 @@
 
 	let { ...restProps }: ComponentProps<typeof Sidebar.Root> = $props();
 
-	const navItems = getNavItems();
+	const navGroups = getNavGroups();
 	const sidebar = useSidebar();
 
 	beforeNavigate(() => {
@@ -101,32 +101,44 @@
 			</Sidebar.MenuItem>
 		</Sidebar.Menu>
 	</Sidebar.Header>
-	<Sidebar.Content class="gap-3 px-1 pb-1 md:gap-2 md:px-0 md:pb-0">
-		<Sidebar.Group class="p-0 md:p-2">
-			<Sidebar.GroupContent>
-				<Sidebar.Menu class="gap-1.5 md:gap-1.5">
-					{#each navItems as item (item.href)}
-						<Sidebar.MenuItem>
-							<Sidebar.MenuButton
-								isActive={isActive(item.href, $page.url.pathname)}
-								tooltipContent={item.title()}
-								class={menuButtonClass(item, $page.url.pathname)}
-							>
-								{#snippet child({ props })}
-									<a href={item.href} {...withMobileCloseClick(props)}>
-										<span
-											class="{item.badgeColor} flex size-8 shrink-0 items-center justify-center rounded-lg"
-										>
-											<item.icon class="size-4.5 md:size-4" />
-										</span>
-										<span class="truncate font-semibold">{item.title()}</span>
-									</a>
-								{/snippet}
-							</Sidebar.MenuButton>
-						</Sidebar.MenuItem>
-					{/each}
-				</Sidebar.Menu>
-			</Sidebar.GroupContent>
-		</Sidebar.Group>
+	<Sidebar.Content class="gap-0 px-1 pb-1 md:px-0 md:pb-0">
+		{#each navGroups as group, gi}
+			<Sidebar.Group class="p-0 px-0 py-1.5 md:px-2 md:py-1">
+				{#if group.label}
+					<Sidebar.GroupLabel
+						class="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/60 px-3 md:px-2 pb-0.5"
+					>
+						{group.label()}
+					</Sidebar.GroupLabel>
+				{/if}
+				<Sidebar.GroupContent>
+					<Sidebar.Menu class="gap-1 md:gap-1">
+						{#each group.items as item (item.href)}
+							<Sidebar.MenuItem>
+								<Sidebar.MenuButton
+									isActive={isActive(item.href, $page.url.pathname)}
+									tooltipContent={item.title()}
+									class={menuButtonClass(item, $page.url.pathname)}
+								>
+									{#snippet child({ props })}
+										<a href={item.href} {...withMobileCloseClick(props)}>
+											<span
+												class="{item.badgeColor} flex size-8 shrink-0 items-center justify-center rounded-lg"
+											>
+												<item.icon class="size-4.5 md:size-4" />
+											</span>
+											<span class="truncate font-semibold">{item.title()}</span>
+										</a>
+									{/snippet}
+								</Sidebar.MenuButton>
+							</Sidebar.MenuItem>
+						{/each}
+					</Sidebar.Menu>
+				</Sidebar.GroupContent>
+			</Sidebar.Group>
+			{#if gi < navGroups.length - 1}
+				<Sidebar.Separator class="mx-3 md:mx-2" />
+			{/if}
+		{/each}
 	</Sidebar.Content>
 </Sidebar.Root>

--- a/src/lib/components/ui/responsive-modal/ResponsiveModal.svelte
+++ b/src/lib/components/ui/responsive-modal/ResponsiveModal.svelte
@@ -36,7 +36,12 @@
 </script>
 
 {#if isDesktop.current}
-	<Dialog.Root bind:open>
+	<Dialog.Root
+		bind:open
+		onOpenChange={(isOpen) => {
+			if (!isOpen) onAnimationEnd?.(false);
+		}}
+	>
 		<Dialog.Content class="max-h-[85dvh] overflow-y-auto sm:max-w-4xl">
 			<Dialog.Header>
 				<Dialog.Title>{title}</Dialog.Title>

--- a/src/lib/components/ui/responsive-modal/ResponsiveModal.svelte
+++ b/src/lib/components/ui/responsive-modal/ResponsiveModal.svelte
@@ -9,10 +9,18 @@
 		title: string;
 		description?: string;
 		openFull?: boolean;
+		onAnimationEnd?: (open: boolean) => void;
 		children: Snippet;
 	};
 
-	let { open = $bindable(false), title, description, openFull = false, children }: Props = $props();
+	let {
+		open = $bindable(false),
+		title,
+		description,
+		openFull = false,
+		onAnimationEnd,
+		children
+	}: Props = $props();
 
 	const isDesktop = new MediaQuery('(min-width: 768px)');
 	const snapPoints = [0.7, 1];
@@ -40,7 +48,7 @@
 		</Dialog.Content>
 	</Dialog.Root>
 {:else if openFull}
-	<Drawer.Root bind:open>
+	<Drawer.Root bind:open {onAnimationEnd}>
 		<Drawer.Content class="data-[vaul-drawer-direction=bottom]:max-h-[100dvh] mt-0!">
 			<Drawer.Header class="min-w-0 text-left">
 				<Drawer.Title class="truncate">{title}</Drawer.Title>
@@ -54,7 +62,7 @@
 		</Drawer.Content>
 	</Drawer.Root>
 {:else}
-	<Drawer.Root bind:open {snapPoints} bind:activeSnapPoint fadeFromIndex={1}>
+	<Drawer.Root bind:open {snapPoints} bind:activeSnapPoint fadeFromIndex={1} {onAnimationEnd}>
 		<Drawer.Content
 			class="data-[vaul-drawer-direction=bottom]:max-h-[100dvh] {isExpanded ? 'mt-0!' : ''}"
 		>

--- a/src/lib/components/weight/WeightWidget.svelte
+++ b/src/lib/components/weight/WeightWidget.svelte
@@ -44,7 +44,7 @@
 		{/if}
 	{/snippet}
 	{#if weightKg != null}
-		<p class="text-2xl font-semibold">
+		<p class="text-3xl font-bold tabular-nums">
 			{m.dashboard_weight_latest({ value: weightKg.toFixed(1) })}
 		</p>
 	{:else}

--- a/src/lib/config/navigation.ts
+++ b/src/lib/config/navigation.ts
@@ -20,6 +20,11 @@ export type NavItem = {
 	activeRing: string;
 };
 
+export type NavGroup = {
+	label?: () => string;
+	items: NavItem[];
+};
+
 export const breadcrumbLabelKeys = [
 	'app',
 	'foods',
@@ -36,84 +41,106 @@ export const breadcrumbLabelKeys = [
 	'mcp'
 ] as const;
 
-export function getNavItems(): NavItem[] {
+export function getNavGroups(): NavGroup[] {
 	return [
 		{
-			title: () => m.nav_dashboard(),
-			href: '/',
-			icon: Home,
-			badgeColor: 'bg-blue-100 text-blue-600',
-			activeRing: 'ring-2 ring-inset ring-blue-300/80 dark:ring-blue-700/80'
+			items: [
+				{
+					title: () => m.nav_dashboard(),
+					href: '/',
+					icon: Home,
+					badgeColor: 'bg-blue-100 text-blue-600',
+					activeRing: 'ring-2 ring-inset ring-blue-300/80 dark:ring-blue-700/80'
+				},
+				{
+					title: () => m.nav_favorites(),
+					href: '/favorites',
+					icon: Heart,
+					badgeColor: 'bg-red-100 text-red-600',
+					activeRing: 'ring-2 ring-inset ring-red-300/80 dark:ring-red-700/80'
+				},
+				{
+					title: () => m.nav_history(),
+					href: '/history',
+					icon: Calendar,
+					badgeColor: 'bg-indigo-100 text-indigo-600',
+					activeRing: 'ring-2 ring-inset ring-indigo-300/80 dark:ring-indigo-700/80'
+				}
+			]
 		},
 		{
-			title: () => m.nav_favorites(),
-			href: '/favorites',
-			icon: Heart,
-			badgeColor: 'bg-red-100 text-red-600',
-			activeRing: 'ring-2 ring-inset ring-red-300/80 dark:ring-red-700/80'
+			label: () => m.nav_group_manage(),
+			items: [
+				{
+					title: () => m.nav_foods(),
+					href: '/foods',
+					icon: Utensils,
+					badgeColor: 'bg-orange-100 text-orange-600',
+					activeRing: 'ring-2 ring-inset ring-orange-300/80 dark:ring-orange-700/80'
+				},
+				{
+					title: () => m.nav_recipes(),
+					href: '/recipes',
+					icon: CookingPot,
+					badgeColor: 'bg-green-100 text-green-600',
+					activeRing: 'ring-2 ring-inset ring-green-300/80 dark:ring-green-700/80'
+				},
+				{
+					title: () => m.nav_supplements(),
+					href: '/supplements',
+					icon: Pill,
+					badgeColor: 'bg-purple-100 text-purple-600',
+					activeRing: 'ring-2 ring-inset ring-purple-300/80 dark:ring-purple-700/80'
+				}
+			]
 		},
 		{
-			title: () => m.nav_foods(),
-			href: '/foods',
-			icon: Utensils,
-			badgeColor: 'bg-orange-100 text-orange-600',
-			activeRing: 'ring-2 ring-inset ring-orange-300/80 dark:ring-orange-700/80'
+			label: () => m.nav_group_analyze(),
+			items: [
+				{
+					title: () => m.nav_insights(),
+					href: '/insights',
+					icon: ChartBar,
+					badgeColor: 'bg-pink-100 text-pink-600',
+					activeRing: 'ring-2 ring-inset ring-pink-300/80 dark:ring-pink-700/80'
+				},
+				{
+					title: () => m.nav_goals(),
+					href: '/goals',
+					icon: Target,
+					badgeColor: 'bg-amber-100 text-amber-600',
+					activeRing: 'ring-2 ring-inset ring-amber-300/80 dark:ring-amber-700/80'
+				},
+				{
+					title: () => m.nav_weight(),
+					href: '/weight',
+					icon: Weight,
+					badgeColor: 'bg-teal-100 text-teal-600',
+					activeRing: 'ring-2 ring-inset ring-teal-300/80 dark:ring-teal-700/80'
+				},
+				{
+					title: () => m.nav_maintenance(),
+					href: '/maintenance',
+					icon: Calculator,
+					badgeColor: 'bg-cyan-100 text-cyan-600',
+					activeRing: 'ring-2 ring-inset ring-cyan-300/80 dark:ring-cyan-700/80'
+				}
+			]
 		},
 		{
-			title: () => m.nav_recipes(),
-			href: '/recipes',
-			icon: CookingPot,
-			badgeColor: 'bg-green-100 text-green-600',
-			activeRing: 'ring-2 ring-inset ring-green-300/80 dark:ring-green-700/80'
-		},
-		{
-			title: () => m.nav_supplements(),
-			href: '/supplements',
-			icon: Pill,
-			badgeColor: 'bg-purple-100 text-purple-600',
-			activeRing: 'ring-2 ring-inset ring-purple-300/80 dark:ring-purple-700/80'
-		},
-		{
-			title: () => m.nav_weight(),
-			href: '/weight',
-			icon: Weight,
-			badgeColor: 'bg-teal-100 text-teal-600',
-			activeRing: 'ring-2 ring-inset ring-teal-300/80 dark:ring-teal-700/80'
-		},
-		{
-			title: () => m.nav_insights(),
-			href: '/insights',
-			icon: ChartBar,
-			badgeColor: 'bg-pink-100 text-pink-600',
-			activeRing: 'ring-2 ring-inset ring-pink-300/80 dark:ring-pink-700/80'
-		},
-		{
-			title: () => m.nav_goals(),
-			href: '/goals',
-			icon: Target,
-			badgeColor: 'bg-amber-100 text-amber-600',
-			activeRing: 'ring-2 ring-inset ring-amber-300/80 dark:ring-amber-700/80'
-		},
-		{
-			title: () => m.nav_history(),
-			href: '/history',
-			icon: Calendar,
-			badgeColor: 'bg-indigo-100 text-indigo-600',
-			activeRing: 'ring-2 ring-inset ring-indigo-300/80 dark:ring-indigo-700/80'
-		},
-		{
-			title: () => m.nav_maintenance(),
-			href: '/maintenance',
-			icon: Calculator,
-			badgeColor: 'bg-cyan-100 text-cyan-600',
-			activeRing: 'ring-2 ring-inset ring-cyan-300/80 dark:ring-cyan-700/80'
-		},
-		{
-			title: () => m.nav_settings(),
-			href: '/settings',
-			icon: Settings,
-			badgeColor: 'bg-slate-100 text-slate-600',
-			activeRing: 'ring-2 ring-inset ring-slate-300/80 dark:ring-slate-600/80'
+			items: [
+				{
+					title: () => m.nav_settings(),
+					href: '/settings',
+					icon: Settings,
+					badgeColor: 'bg-slate-100 text-slate-600',
+					activeRing: 'ring-2 ring-inset ring-slate-300/80 dark:ring-slate-600/80'
+				}
+			]
 		}
 	];
+}
+
+export function getNavItems(): NavItem[] {
+	return getNavGroups().flatMap((g) => g.items);
 }

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -11,7 +11,13 @@ let db: Database | null = null;
 
 export function getDB(): Database {
 	if (!db) {
-		const client = new SQL(config.database.url);
+		const client = new SQL({
+			url: config.database.url,
+			max: config.database.poolMax,
+			idleTimeout: config.database.idleTimeoutSeconds,
+			maxLifetime: config.database.maxLifetimeSeconds,
+			connectionTimeout: config.database.connectTimeoutSeconds
+		});
 		db = drizzle({ client, schema });
 	}
 	return db;

--- a/src/lib/server/entries.ts
+++ b/src/lib/server/entries.ts
@@ -28,24 +28,25 @@ const buildRecipeMacrosCte = (db: ReturnType<typeof getDB>) =>
 		db
 			.select({
 				recipeId: recipeIngredients.recipeId,
-				calories:
+				rmCalories:
 					sql<number>`SUM(${foods.calories} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
-						'calories'
+						'rm_calories'
 					),
-				protein:
+				rmProtein:
 					sql<number>`SUM(${foods.protein} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
-						'protein'
+						'rm_protein'
 					),
-				carbs:
+				rmCarbs:
 					sql<number>`SUM(${foods.carbs} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
-						'carbs'
+						'rm_carbs'
 					),
-				fat: sql<number>`SUM(${foods.fat} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
-					'fat'
-				),
-				fiber:
+				rmFat:
+					sql<number>`SUM(${foods.fat} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
+						'rm_fat'
+					),
+				rmFiber:
 					sql<number>`SUM(${foods.fiber} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
-						'fiber'
+						'rm_fiber'
 					)
 			})
 			.from(recipeIngredients)
@@ -62,15 +63,15 @@ const entryMacroColumns = (rm: RecipeMacrosCte) => ({
 	>`COALESCE(${foodEntries.quickName}, ${foods.name}, ${recipes.name})`.as('food_name'),
 	calories: sql<
 		number | null
-	>`COALESCE(${foodEntries.quickCalories}, ${foods.calories}, ${rm.calories})`.as('calories'),
+	>`COALESCE(${foodEntries.quickCalories}, ${foods.calories}, ${rm.rmCalories})`.as('calories'),
 	protein: sql<
 		number | null
-	>`COALESCE(${foodEntries.quickProtein}, ${foods.protein}, ${rm.protein})`.as('protein'),
-	carbs: sql<number | null>`COALESCE(${foodEntries.quickCarbs}, ${foods.carbs}, ${rm.carbs})`.as(
+	>`COALESCE(${foodEntries.quickProtein}, ${foods.protein}, ${rm.rmProtein})`.as('protein'),
+	carbs: sql<number | null>`COALESCE(${foodEntries.quickCarbs}, ${foods.carbs}, ${rm.rmCarbs})`.as(
 		'carbs'
 	),
-	fat: sql<number | null>`COALESCE(${foodEntries.quickFat}, ${foods.fat}, ${rm.fat})`.as('fat'),
-	fiber: sql<number | null>`COALESCE(${foodEntries.quickFiber}, ${foods.fiber}, ${rm.fiber})`.as(
+	fat: sql<number | null>`COALESCE(${foodEntries.quickFat}, ${foods.fat}, ${rm.rmFat})`.as('fat'),
+	fiber: sql<number | null>`COALESCE(${foodEntries.quickFiber}, ${foods.fiber}, ${rm.rmFiber})`.as(
 		'fiber'
 	)
 });

--- a/src/lib/server/entries.ts
+++ b/src/lib/server/entries.ts
@@ -1,7 +1,13 @@
 import { getDB } from '$lib/server/db';
-import { foodEntries, foods, recipes, customMealTypes } from '$lib/server/schema';
+import {
+	foodEntries,
+	foods,
+	recipes,
+	recipeIngredients,
+	customMealTypes
+} from '$lib/server/schema';
 import { entryCreateSchema, entryUpdateSchema } from '$lib/server/validation';
-import { type AnyColumn, and, count, eq, gte, lte, sql } from 'drizzle-orm';
+import { and, count, eq, gte, lte, sql } from 'drizzle-orm';
 import type { Result } from '$lib/server/types';
 import { DEFAULT_MEAL_TYPES } from '$lib/utils/meals';
 import { roundNutrition } from '$lib/utils/round-nutrition';
@@ -17,31 +23,56 @@ const validateMealType = async (userId: string, mealType: string): Promise<boole
 	return !!found;
 };
 
-/**
- * SQL helper: resolves a macro value from quick entry, food, or recipe subquery.
- * Eliminates duplication across listEntriesByDate and listEntriesByDateRange.
- */
-const entryMacroSql = (
-	quickCol: AnyColumn,
-	foodCol: AnyColumn,
-	recipeMacro: string,
-	alias: string
-) =>
-	sql<
-		number | null
-	>`COALESCE(${quickCol}, ${foodCol}, (SELECT COALESCE(SUM(f2.${sql.raw(recipeMacro)} * ri.quantity / f2.serving_size), 0) / NULLIF(${recipes.totalServings}, 0) FROM recipe_ingredients ri JOIN foods f2 ON f2.id = ri.food_id WHERE ri.recipe_id = ${foodEntries.recipeId}))`.as(
-		alias
+const buildRecipeMacrosCte = (db: ReturnType<typeof getDB>) =>
+	db.$with('recipe_macros').as(
+		db
+			.select({
+				recipeId: recipeIngredients.recipeId,
+				calories:
+					sql<number>`SUM(${foods.calories} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
+						'calories'
+					),
+				protein:
+					sql<number>`SUM(${foods.protein} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
+						'protein'
+					),
+				carbs:
+					sql<number>`SUM(${foods.carbs} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
+						'carbs'
+					),
+				fat: sql<number>`SUM(${foods.fat} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
+					'fat'
+				),
+				fiber:
+					sql<number>`SUM(${foods.fiber} * ${recipeIngredients.quantity} / ${foods.servingSize}) / NULLIF(${recipes.totalServings}, 0)`.as(
+						'fiber'
+					)
+			})
+			.from(recipeIngredients)
+			.innerJoin(foods, eq(foods.id, recipeIngredients.foodId))
+			.innerJoin(recipes, eq(recipes.id, recipeIngredients.recipeId))
+			.groupBy(recipeIngredients.recipeId, recipes.totalServings)
 	);
 
-const entryMacroColumns = () => ({
+type RecipeMacrosCte = ReturnType<typeof buildRecipeMacrosCte>;
+
+const entryMacroColumns = (rm: RecipeMacrosCte) => ({
 	foodName: sql<
 		string | null
 	>`COALESCE(${foodEntries.quickName}, ${foods.name}, ${recipes.name})`.as('food_name'),
-	calories: entryMacroSql(foodEntries.quickCalories, foods.calories, 'calories', 'calories'),
-	protein: entryMacroSql(foodEntries.quickProtein, foods.protein, 'protein', 'protein'),
-	carbs: entryMacroSql(foodEntries.quickCarbs, foods.carbs, 'carbs', 'carbs'),
-	fat: entryMacroSql(foodEntries.quickFat, foods.fat, 'fat', 'fat'),
-	fiber: entryMacroSql(foodEntries.quickFiber, foods.fiber, 'fiber', 'fiber')
+	calories: sql<
+		number | null
+	>`COALESCE(${foodEntries.quickCalories}, ${foods.calories}, ${rm.calories})`.as('calories'),
+	protein: sql<
+		number | null
+	>`COALESCE(${foodEntries.quickProtein}, ${foods.protein}, ${rm.protein})`.as('protein'),
+	carbs: sql<number | null>`COALESCE(${foodEntries.quickCarbs}, ${foods.carbs}, ${rm.carbs})`.as(
+		'carbs'
+	),
+	fat: sql<number | null>`COALESCE(${foodEntries.quickFat}, ${foods.fat}, ${rm.fat})`.as('fat'),
+	fiber: sql<number | null>`COALESCE(${foodEntries.quickFiber}, ${foods.fiber}, ${rm.fiber})`.as(
+		'fiber'
+	)
 });
 
 export const listEntriesByDate = async (
@@ -54,9 +85,11 @@ export const listEntriesByDate = async (
 	const offset = options?.offset ?? 0;
 
 	const whereClause = and(eq(foodEntries.userId, userId), eq(foodEntries.date, date));
+	const recipeMacrosCte = buildRecipeMacrosCte(db);
 
 	const [items, countResult] = await Promise.all([
 		db
+			.with(recipeMacrosCte)
 			.select({
 				id: foodEntries.id,
 				mealType: foodEntries.mealType,
@@ -70,7 +103,7 @@ export const listEntriesByDate = async (
 				quickCarbs: foodEntries.quickCarbs,
 				quickFat: foodEntries.quickFat,
 				quickFiber: foodEntries.quickFiber,
-				...entryMacroColumns(),
+				...entryMacroColumns(recipeMacrosCte),
 				eatenAt: foodEntries.eatenAt,
 				createdAt: foodEntries.createdAt,
 				servingSize: foods.servingSize,
@@ -79,6 +112,7 @@ export const listEntriesByDate = async (
 			.from(foodEntries)
 			.leftJoin(foods, eq(foodEntries.foodId, foods.id))
 			.leftJoin(recipes, eq(foodEntries.recipeId, recipes.id))
+			.leftJoin(recipeMacrosCte, eq(recipeMacrosCte.recipeId, foodEntries.recipeId))
 			.where(whereClause)
 			.limit(limit)
 			.offset(offset),
@@ -180,7 +214,9 @@ export const listEntriesByDateRange = async (
 	endDate: string
 ) => {
 	const db = getDB();
+	const recipeMacrosCte = buildRecipeMacrosCte(db);
 	const rows = await db
+		.with(recipeMacrosCte)
 		.select({
 			id: foodEntries.id,
 			date: foodEntries.date,
@@ -189,11 +225,12 @@ export const listEntriesByDateRange = async (
 			notes: foodEntries.notes,
 			foodId: foodEntries.foodId,
 			recipeId: foodEntries.recipeId,
-			...entryMacroColumns()
+			...entryMacroColumns(recipeMacrosCte)
 		})
 		.from(foodEntries)
 		.leftJoin(foods, eq(foodEntries.foodId, foods.id))
 		.leftJoin(recipes, eq(foodEntries.recipeId, recipes.id))
+		.leftJoin(recipeMacrosCte, eq(recipeMacrosCte.recipeId, foodEntries.recipeId))
 		.where(
 			and(
 				eq(foodEntries.userId, userId),

--- a/src/lib/server/foods.ts
+++ b/src/lib/server/foods.ts
@@ -1,7 +1,7 @@
 import { getDB } from '$lib/server/db';
 import { foods, foodEntries } from '$lib/server/schema';
 import { foodCreateSchema, foodUpdateSchema } from '$lib/server/validation';
-import { and, count, desc, eq, ilike } from 'drizzle-orm';
+import { and, count, desc, eq, getTableColumns, ilike, isNotNull, sql } from 'drizzle-orm';
 import { ApiError } from '$lib/server/errors';
 import { pickNutrients } from '$lib/nutrients';
 import type { Result, DeleteResult } from '$lib/server/types';
@@ -189,29 +189,22 @@ export const findFoodByBarcode = async (userId: string, barcode: string) => {
 
 export const listRecentFoods = async (userId: string, limit = 25) => {
 	const db = getDB();
-	const rows = await db
+	const recentSq = db
 		.select({
-			id: foods.id,
-			userId: foods.userId,
-			name: foods.name,
-			brand: foods.brand,
-			servingSize: foods.servingSize,
-			servingUnit: foods.servingUnit,
-			calories: foods.calories,
-			protein: foods.protein,
-			carbs: foods.carbs,
-			fat: foods.fat,
-			fiber: foods.fiber,
-			barcode: foods.barcode,
-			isFavorite: foods.isFavorite,
-			imageUrl: foods.imageUrl,
-			createdAt: foods.createdAt,
-			updatedAt: foods.updatedAt
+			foodId: foodEntries.foodId,
+			lastUsed: sql<Date>`MAX(${foodEntries.createdAt})`.as('last_used')
 		})
 		.from(foodEntries)
-		.innerJoin(foods, eq(foodEntries.foodId, foods.id))
-		.where(eq(foodEntries.userId, userId))
-		.orderBy(desc(foodEntries.createdAt))
+		.where(and(eq(foodEntries.userId, userId), isNotNull(foodEntries.foodId)))
+		.groupBy(foodEntries.foodId)
+		.as('recent');
+
+	const rows = await db
+		.select({ ...getTableColumns(foods) })
+		.from(foods)
+		.innerJoin(recentSq, eq(foods.id, recentSq.foodId))
+		.where(eq(foods.userId, userId))
+		.orderBy(desc(recentSq.lastUsed))
 		.limit(limit);
 	return roundNutrition(rows);
 };

--- a/src/lib/server/recipes.ts
+++ b/src/lib/server/recipes.ts
@@ -104,31 +104,33 @@ export const createRecipe = async (
 
 export const getRecipe = async (userId: string, id: string) => {
 	const db = getDB();
-	const [recipe] = await db
-		.select({
-			id: recipes.id,
-			userId: recipes.userId,
-			name: recipes.name,
-			totalServings: recipes.totalServings,
-			isFavorite: recipes.isFavorite,
-			imageUrl: recipes.imageUrl,
-			...macroAggregations,
-			createdAt: recipes.createdAt,
-			updatedAt: recipes.updatedAt
-		})
-		.from(recipes)
-		.leftJoin(recipeIngredients, eq(recipeIngredients.recipeId, recipes.id))
-		.leftJoin(foods, eq(foods.id, recipeIngredients.foodId))
-		.where(and(eq(recipes.id, id), eq(recipes.userId, userId)))
-		.groupBy(recipes.id);
+	const [recipeResult, ingredients] = await Promise.all([
+		db
+			.select({
+				id: recipes.id,
+				userId: recipes.userId,
+				name: recipes.name,
+				totalServings: recipes.totalServings,
+				isFavorite: recipes.isFavorite,
+				imageUrl: recipes.imageUrl,
+				...macroAggregations,
+				createdAt: recipes.createdAt,
+				updatedAt: recipes.updatedAt
+			})
+			.from(recipes)
+			.leftJoin(recipeIngredients, eq(recipeIngredients.recipeId, recipes.id))
+			.leftJoin(foods, eq(foods.id, recipeIngredients.foodId))
+			.where(and(eq(recipes.id, id), eq(recipes.userId, userId)))
+			.groupBy(recipes.id),
+		db
+			.select()
+			.from(recipeIngredients)
+			.where(eq(recipeIngredients.recipeId, id))
+			.orderBy(recipeIngredients.sortOrder)
+	]);
 
+	const recipe = recipeResult[0];
 	if (!recipe) return null;
-
-	const ingredients = await db
-		.select()
-		.from(recipeIngredients)
-		.where(eq(recipeIngredients.recipeId, id))
-		.orderBy(recipeIngredients.sortOrder);
 
 	return roundNutrition({ ...recipe, ingredients });
 };

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -138,7 +138,6 @@ export const foods = pgTable(
 			.on(table.userId, table.barcode)
 			.where(sql`barcode IS NOT NULL`),
 		index('idx_foods_user_name').on(table.userId, table.name),
-		index('idx_foods_image_url').on(table.imageUrl),
 		check('foods_serving_positive', sql`${table.servingSize} > 0`),
 		check(
 			'foods_nutrition_nonnegative',
@@ -288,7 +287,6 @@ export const recipes = pgTable(
 	(table) => [
 		index('idx_recipes_user_id').on(table.userId),
 		index('idx_recipes_created_at').on(table.createdAt),
-		index('idx_recipes_image_url').on(table.imageUrl),
 		check('recipes_servings_positive', sql`${table.totalServings} > 0`)
 	]
 );

--- a/src/lib/server/session.ts
+++ b/src/lib/server/session.ts
@@ -77,19 +77,13 @@ export async function deleteUserSessions(userId: string): Promise<void> {
 	await db.delete(sessions).where(eq(sessions.userId, userId));
 }
 
-export async function cleanExpiredSessions(batchSize = 500): Promise<number> {
+export async function cleanExpiredSessions(): Promise<number> {
 	const db = getDB();
-	const expired = await db
-		.select({ id: sessions.id })
-		.from(sessions)
+	const deleted = await db
+		.delete(sessions)
 		.where(lt(sessions.expiresAt, new Date()))
-		.limit(batchSize);
-
-	if (expired.length === 0) return 0;
-
-	const ids = expired.map((row) => row.id);
-	await db.delete(sessions).where(inArray(sessions.id, ids));
-	return ids.length;
+		.returning({ id: sessions.id });
+	return deleted.length;
 }
 
 type SameSiteValue = 'lax' | 'strict' | 'none' | 'Lax' | 'Strict' | 'None';

--- a/src/lib/server/stats.ts
+++ b/src/lib/server/stats.ts
@@ -64,6 +64,57 @@ const groupEntriesByDateWithFasting = (
 	return Object.values(groups);
 };
 
+type EntryRow = Array<{
+	date: string;
+	servings: number;
+	calories: number | null;
+	protein: number | null;
+	carbs: number | null;
+	fat: number | null;
+	fiber: number | null;
+}>;
+
+export const computeAverages = (entries: EntryRow, fastingDays: Set<string>) => {
+	const dailyTotals = groupEntriesByDateWithFasting(entries, fastingDays);
+	return averageTotals(dailyTotals);
+};
+
+export const computeDailyBreakdown = (
+	entries: EntryRow,
+	startDate: string,
+	endDate: string
+): Array<{ date: string } & MacroTotals> => {
+	const groups: Record<string, MacroTotals> = {};
+	for (const entry of entries) {
+		if (!groups[entry.date]) groups[entry.date] = emptyTotals();
+		groups[entry.date] = addTotals(groups[entry.date], calculateEntryMacros(entry));
+	}
+	const result: Array<{ date: string } & MacroTotals> = [];
+	const current = new Date(startDate + 'T00:00:00Z');
+	const end = new Date(endDate + 'T00:00:00Z');
+	while (current <= end) {
+		const dateStr = current.toISOString().split('T')[0];
+		result.push({ date: dateStr, ...roundTotals(groups[dateStr] ?? emptyTotals()) });
+		current.setUTCDate(current.getUTCDate() + 1);
+	}
+	return result;
+};
+
+export const computeCalendarDays = (entries: EntryRow): Record<string, CalendarDay> => {
+	const days: Record<string, CalendarDay> = {};
+	for (const entry of entries) {
+		if (!days[entry.date]) {
+			days[entry.date] = { calories: 0, hasEntries: true };
+		}
+		const macros = calculateEntryMacros(entry);
+		days[entry.date].calories += macros.calories;
+	}
+	for (const date of Object.keys(days)) {
+		days[date].calories = Math.round(days[date].calories);
+	}
+	return days;
+};
+
 export const getWeeklyStats = async (userId: string) => {
 	const endDate = today();
 	const startDate = shiftDate(endDate, -6);
@@ -71,8 +122,7 @@ export const getWeeklyStats = async (userId: string) => {
 		listEntriesByDateRange(userId, startDate, endDate),
 		getFastingDays(userId, startDate, endDate)
 	]);
-	const dailyTotals = groupEntriesByDateWithFasting(entries, fastingDaySet);
-	return averageTotals(dailyTotals);
+	return computeAverages(entries, fastingDaySet);
 };
 
 export const getMonthlyStats = async (userId: string) => {
@@ -82,8 +132,7 @@ export const getMonthlyStats = async (userId: string) => {
 		listEntriesByDateRange(userId, startDate, endDate),
 		getFastingDays(userId, startDate, endDate)
 	]);
-	const dailyTotals = groupEntriesByDateWithFasting(entries, fastingDaySet);
-	return averageTotals(dailyTotals);
+	return computeAverages(entries, fastingDaySet);
 };
 
 export const getMealBreakdown = async (
@@ -120,18 +169,7 @@ export const getCalendarStats = async (
 	const lastDay = new Date(year, month + 1, 0).getDate();
 	const endDate = `${year}-${String(month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
 	const entries = await listEntriesByDateRange(userId, startDate, endDate);
-	const days: Record<string, CalendarDay> = {};
-	for (const entry of entries) {
-		if (!days[entry.date]) {
-			days[entry.date] = { calories: 0, hasEntries: true };
-		}
-		const macros = calculateEntryMacros(entry);
-		days[entry.date].calories += macros.calories;
-	}
-	for (const date of Object.keys(days)) {
-		days[date].calories = Math.round(days[date].calories);
-	}
-	return { days };
+	return { days: computeCalendarDays(entries) };
 };
 
 export const getDailyBreakdown = async (
@@ -140,20 +178,7 @@ export const getDailyBreakdown = async (
 	endDate: string
 ): Promise<Array<{ date: string } & MacroTotals>> => {
 	const entries = await listEntriesByDateRange(userId, startDate, endDate);
-	const groups: Record<string, MacroTotals> = {};
-	for (const entry of entries) {
-		if (!groups[entry.date]) groups[entry.date] = emptyTotals();
-		groups[entry.date] = addTotals(groups[entry.date], calculateEntryMacros(entry));
-	}
-	const result: Array<{ date: string } & MacroTotals> = [];
-	const current = new Date(startDate + 'T00:00:00Z');
-	const end = new Date(endDate + 'T00:00:00Z');
-	while (current <= end) {
-		const dateStr = current.toISOString().split('T')[0];
-		result.push({ date: dateStr, ...roundTotals(groups[dateStr] ?? emptyTotals()) });
-		current.setUTCDate(current.getUTCDate() + 1);
-	}
-	return result;
+	return computeDailyBreakdown(entries, startDate, endDate);
 };
 
 export const getStreaks = async (userId: string) => {

--- a/src/lib/server/stats.ts
+++ b/src/lib/server/stats.ts
@@ -10,7 +10,7 @@ import {
 } from '$lib/utils/nutrition';
 import { today, shiftDate } from '$lib/utils/dates';
 import { getDB, foodEntries } from '$lib/server/db';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, gte, sql } from 'drizzle-orm';
 import { getFastingDays } from '$lib/server/day-properties';
 
 export type CalendarDay = { calories: number; hasEntries: boolean };
@@ -186,7 +186,7 @@ export const getStreaks = async (userId: string) => {
 	const rows = await db
 		.selectDistinct({ date: foodEntries.date })
 		.from(foodEntries)
-		.where(eq(foodEntries.userId, userId))
+		.where(and(eq(foodEntries.userId, userId), gte(foodEntries.date, shiftDate(today(), -730))))
 		.orderBy(sql`${foodEntries.date} desc`);
 
 	if (rows.length === 0) {

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -48,6 +48,9 @@
 	let addModalOpen = $state(false);
 
 	const isToday = $derived(activeDate === today());
+	const order = $derived(
+		userPrefs?.widgetOrder ?? ['chart', 'streaks', 'favorites', 'supplements', 'weight', 'daylog']
+	);
 
 	const toggleSupplement = async (supplementId: string, taken: boolean) => {
 		if (taken) {
@@ -105,7 +108,7 @@
 </script>
 
 {#if ready}
-	<div class="mx-auto max-w-4xl space-y-6">
+	<div class="mx-auto max-w-4xl">
 		<div class="flex min-w-0 items-start justify-between gap-2">
 			<DateNavigator date={activeDate} />
 			<Button variant="outline" size="sm" onclick={() => (scanModalOpen = true)}>
@@ -114,44 +117,78 @@
 			</Button>
 		</div>
 
-		{#each userPrefs?.widgetOrder ?? ['chart', 'streaks', 'favorites', 'supplements', 'weight', 'daylog'] as sectionKey (sectionKey)}
+		<!-- Hero section: chart/goals -->
+		{#each order as sectionKey (sectionKey)}
 			{#if sectionKey === 'chart' && (userPrefs?.showChartWidget ?? true)}
-				{#if userGoals}
-					<DashboardCard title={m.dashboard_goal_progress()} Icon={Target} tone="blue">
-						<GoalProgressRings totals={daylogTotals} goals={userGoals} />
-					</DashboardCard>
-				{:else}
-					<DashboardCard title={m.dashboard_summary()} Icon={ChartPie} tone="violet">
-						<div class="h-[200px] sm:h-[220px]">
-							<DailyMacroChart totals={daylogTotals} />
-						</div>
-					</DashboardCard>
+				<div class="mt-6">
+					{#if userGoals}
+						<DashboardCard title={m.dashboard_goal_progress()} Icon={Target} tone="blue">
+							<GoalProgressRings totals={daylogTotals} goals={userGoals} />
+						</DashboardCard>
+					{:else}
+						<DashboardCard title={m.dashboard_summary()} Icon={ChartPie} tone="violet">
+							<div class="h-[200px] sm:h-[220px]">
+								<DailyMacroChart totals={daylogTotals} />
+							</div>
+						</DashboardCard>
+					{/if}
+				</div>
+			{/if}
+		{/each}
+
+		<!-- Compact widgets row: streak + weight side by side on sm+ -->
+		{#if (order.includes('streaks') && streaks) || (order.includes('weight') && isToday && userPrefs?.showWeightWidget)}
+			<div class="mt-4 grid gap-4 sm:grid-cols-2">
+				{#if order.includes('streaks') && streaks}
+					<StreakWidget
+						currentStreak={streaks.currentStreak}
+						longestStreak={streaks.longestStreak}
+					/>
 				{/if}
-			{:else if sectionKey === 'streaks' && streaks}
-				<StreakWidget currentStreak={streaks.currentStreak} longestStreak={streaks.longestStreak} />
+				{#if order.includes('weight') && isToday && userPrefs?.showWeightWidget}
+					<WeightWidget
+						weightKg={latestWeight?.weightKg ?? null}
+						entryDate={latestWeight?.entryDate ?? null}
+					/>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Supplements + Favorites + other content widgets -->
+		{#each order as sectionKey (sectionKey)}
+			{#if sectionKey === 'supplements' && userPrefs?.showSupplementsWidget}
+				<div class="mt-4">
+					<SupplementChecklist checklist={supplementChecklist} onToggle={toggleSupplement} />
+				</div>
 			{:else if sectionKey === 'favorites' && isToday && userPrefs?.showFavoritesWidget}
-				<FavoritesWidget
-					onEntryLogged={() => entryService.refresh(activeDate)}
-					favoriteTapAction={(userPrefs?.favoriteTapAction ?? 'instant') as 'instant' | 'picker'}
-					favoriteMealAssignmentMode={(userPrefs?.favoriteMealAssignmentMode ?? 'time_based') as
-						| 'time_based'
-						| 'ask_meal'}
-					favoriteMealTimeframes={userPrefs?.favoriteMealTimeframes ?? []}
-				/>
-			{:else if sectionKey === 'supplements' && userPrefs?.showSupplementsWidget}
-				<SupplementChecklist checklist={supplementChecklist} onToggle={toggleSupplement} />
-			{:else if sectionKey === 'weight' && isToday && userPrefs?.showWeightWidget}
-				<WeightWidget
-					weightKg={latestWeight?.weightKg ?? null}
-					entryDate={latestWeight?.entryDate ?? null}
-				/>
+				<div class="mt-4">
+					<FavoritesWidget
+						onEntryLogged={() => entryService.refresh(activeDate)}
+						favoriteTapAction={(userPrefs?.favoriteTapAction ?? 'instant') as 'instant' | 'picker'}
+						favoriteMealAssignmentMode={(userPrefs?.favoriteMealAssignmentMode ?? 'time_based') as
+							| 'time_based'
+							| 'ask_meal'}
+						favoriteMealTimeframes={userPrefs?.favoriteMealTimeframes ?? []}
+					/>
+				</div>
 			{:else if sectionKey === 'meal-breakdown' && userPrefs?.showMealBreakdownWidget}
-				<MealBreakdownWidget date={activeDate} />
+				<div class="mt-4">
+					<MealBreakdownWidget date={activeDate} />
+				</div>
 			{:else if sectionKey === 'top-foods' && isToday && userPrefs?.showTopFoodsWidget}
-				<TopFoodsWidget />
+				<div class="mt-4">
+					<TopFoodsWidget />
+				</div>
 			{:else if sectionKey === 'summary'}
-				<MacroSummaryCard totals={daylogTotals} />
-			{:else if sectionKey === 'daylog'}
+				<div class="mt-4">
+					<MacroSummaryCard totals={daylogTotals} />
+				</div>
+			{/if}
+		{/each}
+
+		<!-- Day log: separated with more spacing -->
+		{#if order.includes('daylog')}
+			<div class="mt-8">
 				<DayLog
 					date={activeDate}
 					dashboardStyle={true}
@@ -159,7 +196,7 @@
 					bind:scanModalOpen
 					bind:addModalOpen
 				/>
-			{/if}
-		{/each}
+			</div>
+		{/if}
 	</div>
 {/if}

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -117,7 +117,6 @@
 			</Button>
 		</div>
 
-		<!-- Hero section: chart/goals -->
 		{#each order as sectionKey (sectionKey)}
 			{#if sectionKey === 'chart' && (userPrefs?.showChartWidget ?? true)}
 				<div class="mt-6">
@@ -133,30 +132,21 @@
 						</DashboardCard>
 					{/if}
 				</div>
-			{/if}
-		{/each}
-
-		<!-- Compact widgets row: streak + weight side by side on sm+ -->
-		{#if (order.includes('streaks') && streaks) || (order.includes('weight') && isToday && userPrefs?.showWeightWidget)}
-			<div class="mt-4 grid gap-4 sm:grid-cols-2">
-				{#if order.includes('streaks') && streaks}
+			{:else if sectionKey === 'streaks' && streaks}
+				<div class="mt-4">
 					<StreakWidget
 						currentStreak={streaks.currentStreak}
 						longestStreak={streaks.longestStreak}
 					/>
-				{/if}
-				{#if order.includes('weight') && isToday && userPrefs?.showWeightWidget}
+				</div>
+			{:else if sectionKey === 'weight' && isToday && userPrefs?.showWeightWidget}
+				<div class="mt-4">
 					<WeightWidget
 						weightKg={latestWeight?.weightKg ?? null}
 						entryDate={latestWeight?.entryDate ?? null}
 					/>
-				{/if}
-			</div>
-		{/if}
-
-		<!-- Supplements + Favorites + other content widgets -->
-		{#each order as sectionKey (sectionKey)}
-			{#if sectionKey === 'supplements' && userPrefs?.showSupplementsWidget}
+				</div>
+			{:else if sectionKey === 'supplements' && userPrefs?.showSupplementsWidget}
 				<div class="mt-4">
 					<SupplementChecklist checklist={supplementChecklist} onToggle={toggleSupplement} />
 				</div>
@@ -183,20 +173,17 @@
 				<div class="mt-4">
 					<MacroSummaryCard totals={daylogTotals} />
 				</div>
+			{:else if sectionKey === 'daylog'}
+				<div class="mt-8">
+					<DayLog
+						date={activeDate}
+						dashboardStyle={true}
+						onTotalsChange={(t) => (daylogTotals = t)}
+						bind:scanModalOpen
+						bind:addModalOpen
+					/>
+				</div>
 			{/if}
 		{/each}
-
-		<!-- Day log: separated with more spacing -->
-		{#if order.includes('daylog')}
-			<div class="mt-8">
-				<DayLog
-					date={activeDate}
-					dashboardStyle={true}
-					onTotalsChange={(t) => (daylogTotals = t)}
-					bind:scanModalOpen
-					bind:addModalOpen
-				/>
-			</div>
-		{/if}
 	</div>
 {/if}

--- a/src/routes/(app)/history/+page.server.ts
+++ b/src/routes/(app)/history/+page.server.ts
@@ -18,14 +18,20 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const lastDay = new Date(year, month + 1, 0).getDate();
 	const calendarEnd = `${year}-${String(month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
 
-	const [entries30, fastingDays, goals, calendarEntries] = await Promise.all([
-		listEntriesByDateRange(userId, start30, endDate),
+	const rangeStart = calendarStart < start30 ? calendarStart : start30;
+	const rangeEnd = calendarEnd > endDate ? calendarEnd : endDate;
+
+	const [allEntries, fastingDays, goals] = await Promise.all([
+		listEntriesByDateRange(userId, rangeStart, rangeEnd),
 		getFastingDays(userId, start30, endDate),
-		getGoals(userId),
-		listEntriesByDateRange(userId, calendarStart, calendarEnd)
+		getGoals(userId)
 	]);
 
-	const entries7 = entries30.filter((e) => e.date >= start7);
+	const entries30 = allEntries.filter((e) => e.date >= start30 && e.date <= endDate);
+	const entries7 = allEntries.filter((e) => e.date >= start7 && e.date <= endDate);
+	const calendarEntries = allEntries.filter(
+		(e) => e.date >= calendarStart && e.date <= calendarEnd
+	);
 	const fastingDays7 = new Set([...fastingDays].filter((d) => d >= start7));
 
 	return {

--- a/src/routes/(app)/history/+page.server.ts
+++ b/src/routes/(app)/history/+page.server.ts
@@ -1,0 +1,39 @@
+import type { PageServerLoad } from './$types';
+import { listEntriesByDateRange } from '$lib/server/entries';
+import { getFastingDays } from '$lib/server/day-properties';
+import { getGoals } from '$lib/server/goals';
+import { computeAverages, computeDailyBreakdown, computeCalendarDays } from '$lib/server/stats';
+import { today, shiftDate } from '$lib/utils/dates';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const userId = locals.user!.id;
+	const endDate = today();
+	const start30 = shiftDate(endDate, -29);
+	const start7 = shiftDate(endDate, -6);
+
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = now.getMonth();
+	const calendarStart = `${year}-${String(month + 1).padStart(2, '0')}-01`;
+	const lastDay = new Date(year, month + 1, 0).getDate();
+	const calendarEnd = `${year}-${String(month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+
+	const needsSeparateCalendar = calendarStart < start30 || calendarEnd > endDate;
+
+	const [entries30, fastingDays, goals, calendarEntries] = await Promise.all([
+		listEntriesByDateRange(userId, start30, endDate),
+		getFastingDays(userId, start30, endDate),
+		getGoals(userId),
+		needsSeparateCalendar ? listEntriesByDateRange(userId, calendarStart, calendarEnd) : null
+	]);
+
+	const entries7 = entries30.filter((e) => e.date >= start7);
+
+	return {
+		weeklyStats: computeAverages(entries7, fastingDays),
+		monthlyStats: computeAverages(entries30, fastingDays),
+		chartData: computeDailyBreakdown(entries7, start7, endDate),
+		calendarDays: computeCalendarDays(calendarEntries ?? entries30),
+		calorieGoal: goals?.calorieGoal ?? null
+	};
+};

--- a/src/routes/(app)/history/+page.server.ts
+++ b/src/routes/(app)/history/+page.server.ts
@@ -18,22 +18,21 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const lastDay = new Date(year, month + 1, 0).getDate();
 	const calendarEnd = `${year}-${String(month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
 
-	const needsSeparateCalendar = calendarStart < start30 || calendarEnd > endDate;
-
 	const [entries30, fastingDays, goals, calendarEntries] = await Promise.all([
 		listEntriesByDateRange(userId, start30, endDate),
 		getFastingDays(userId, start30, endDate),
 		getGoals(userId),
-		needsSeparateCalendar ? listEntriesByDateRange(userId, calendarStart, calendarEnd) : null
+		listEntriesByDateRange(userId, calendarStart, calendarEnd)
 	]);
 
 	const entries7 = entries30.filter((e) => e.date >= start7);
+	const fastingDays7 = new Set([...fastingDays].filter((d) => d >= start7));
 
 	return {
-		weeklyStats: computeAverages(entries7, fastingDays),
+		weeklyStats: computeAverages(entries7, fastingDays7),
 		monthlyStats: computeAverages(entries30, fastingDays),
 		chartData: computeDailyBreakdown(entries7, start7, endDate),
-		calendarDays: computeCalendarDays(calendarEntries ?? entries30),
+		calendarDays: computeCalendarDays(calendarEntries),
 		calorieGoal: goals?.calorieGoal ?? null
 	};
 };

--- a/src/routes/(app)/history/+page.svelte
+++ b/src/routes/(app)/history/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import Calendar from '$lib/components/history/Calendar.svelte';
 	import CalorieTrendChart from '$lib/components/charts/CalorieTrendChart.svelte';
 	import MacroBreakdownChart from '$lib/components/charts/MacroBreakdownChart.svelte';
@@ -9,7 +8,6 @@
 	import BarChart3 from '@lucide/svelte/icons/bar-chart-3';
 	import Target from '@lucide/svelte/icons/target';
 	import type { MacroTotals } from '$lib/utils/nutrition';
-	import { today, daysAgo } from '$lib/utils/dates';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
 	import * as m from '$lib/paraglide/messages';
@@ -17,16 +15,22 @@
 	type MacroKey = 'protein' | 'carbs' | 'fat' | 'fiber';
 	type DayStatus = 'on-target' | 'off-target' | 'logged' | 'none';
 
+	let { data } = $props();
+
 	const now = new Date();
-	let year = $state(now.getFullYear());
-	let month = $state(now.getMonth());
-	let weeklyStats: MacroTotals | null = $state(null);
-	let monthlyStats: MacroTotals | null = $state(null);
-	let chartData: Array<{ date: string } & MacroTotals> = $state([]);
-	let calorieGoal: number | undefined = $state(undefined);
+	const initialYear = now.getFullYear();
+	const initialMonth = now.getMonth();
+	let year = $state(initialYear);
+	let month = $state(initialMonth);
+	let weeklyStats: MacroTotals | null = $state(data.weeklyStats);
+	let monthlyStats: MacroTotals | null = $state(data.monthlyStats);
+	let chartData: Array<{ date: string } & MacroTotals> = $state(data.chartData);
+	let calorieGoal: number | undefined = $state(data.calorieGoal ?? undefined);
 	let chartLoading = $state(false);
-	let calendarDays: Record<string, { calories: number; hasEntries: boolean }> = $state({});
-	let goalsCalorieGoal: number | null = $state(null);
+	let calendarDays: Record<string, { calories: number; hasEntries: boolean }> = $state(
+		data.calendarDays
+	);
+	let goalsCalorieGoal: number | null = $state(data.calorieGoal);
 	let macroVisibility = $state<Record<MacroKey, boolean>>({
 		protein: true,
 		carbs: true,
@@ -63,28 +67,15 @@
 		macroVisibility[key] = !macroVisibility[key];
 	};
 
-	const loadStats = async () => {
-		try {
-			const [weeklyResult, monthlyResult] = await Promise.all([
-				api.GET('/api/stats/weekly'),
-				api.GET('/api/stats/monthly')
-			]);
-			if (weeklyResult.data) weeklyStats = weeklyResult.data.stats;
-			if (monthlyResult.data) monthlyStats = monthlyResult.data.stats;
-		} catch {
-			// Silently ignore — stats are unavailable offline
-		}
-	};
-
 	const loadChartData = async (startDate: string, endDate: string) => {
 		chartLoading = true;
 		try {
-			const { data } = await api.GET('/api/stats/daily', {
+			const { data: result } = await api.GET('/api/stats/daily', {
 				params: { query: { startDate, endDate } }
 			});
-			if (!data) return;
-			chartData = data.data ?? [];
-			calorieGoal = data.goals?.calorieGoal ?? undefined;
+			if (!result) return;
+			chartData = result.data ?? [];
+			calorieGoal = result.goals?.calorieGoal ?? undefined;
 		} catch {
 			// Silently ignore — chart data is unavailable offline
 		} finally {
@@ -92,24 +83,14 @@
 		}
 	};
 
-	const loadGoals = async () => {
-		try {
-			const { data } = await api.GET('/api/goals');
-			if (!data) return;
-			goalsCalorieGoal = data.goals?.calorieGoal ?? null;
-		} catch {
-			// Silently ignore — goals may be unavailable offline
-		}
-	};
-
 	const loadCalendarData = async (y: number, mo: number) => {
 		try {
 			const monthStr = `${y}-${String(mo + 1).padStart(2, '0')}`;
-			const { data } = await api.GET('/api/stats/calendar', {
+			const { data: result } = await api.GET('/api/stats/calendar', {
 				params: { query: { month: monthStr } }
 			});
-			if (!data) return;
-			calendarDays = data.days ?? {};
+			if (!result) return;
+			calendarDays = result.days ?? {};
 		} catch {
 			// Silently ignore — calendar data is unavailable offline
 		}
@@ -144,13 +125,9 @@
 	const fmt = (n: number) => Math.round(n).toLocaleString();
 
 	$effect(() => {
-		loadCalendarData(year, month);
-	});
-
-	onMount(() => {
-		loadStats();
-		loadGoals();
-		loadChartData(daysAgo(7), today());
+		if (year !== initialYear || month !== initialMonth) {
+			loadCalendarData(year, month);
+		}
 	});
 </script>
 

--- a/src/routes/(app)/insights/+page.server.ts
+++ b/src/routes/(app)/insights/+page.server.ts
@@ -1,0 +1,41 @@
+import type { PageServerLoad } from './$types';
+import {
+	getDailyBreakdown,
+	getCalendarStats,
+	getMealBreakdown,
+	getTopFoods
+} from '$lib/server/stats';
+import { getGoals } from '$lib/server/goals';
+import { today, shiftDate } from '$lib/utils/dates';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const userId = locals.user!.id;
+	const endDate = today();
+	const start7 = shiftDate(endDate, -6);
+	const now = new Date();
+
+	const [dailyData, goals, calendarStats, mealBreakdown, topFoods] = await Promise.all([
+		getDailyBreakdown(userId, start7, endDate),
+		getGoals(userId),
+		getCalendarStats(userId, now.getFullYear(), now.getMonth()),
+		getMealBreakdown(userId, endDate, endDate),
+		getTopFoods(userId, 7, 10)
+	]);
+
+	const goalsData = goals
+		? {
+				calorieGoal: goals.calorieGoal,
+				proteinGoal: goals.proteinGoal,
+				carbGoal: goals.carbGoal,
+				fatGoal: goals.fatGoal,
+				fiberGoal: goals.fiberGoal
+			}
+		: null;
+
+	return {
+		dailyStatus: { data: dailyData, goals: goalsData },
+		calendarDays: calendarStats.days,
+		mealBreakdown,
+		topFoods
+	};
+};

--- a/src/routes/(app)/insights/+page.svelte
+++ b/src/routes/(app)/insights/+page.svelte
@@ -12,6 +12,9 @@
 	import { statsService } from '$lib/services/stats-service.svelte';
 	import { MACRO_COLORS, MEAL_COLORS } from '$lib/colors';
 	import * as m from '$lib/paraglide/messages';
+	import type { PageData } from './$types';
+
+	let { data: pageData }: { data: PageData } = $props();
 
 	type MealData = {
 		mealType: string;
@@ -36,12 +39,12 @@
 
 	type Range = 'today' | '7d' | '30d';
 	let range: Range = $state('today');
-	let data: MealData[] = $state([]);
-	let mealLoading = $state(true);
+	let data: MealData[] = $state(pageData.mealBreakdown);
+	let mealLoading = $state(false);
 
 	let topFoodsDays = $state(7);
-	let foods: TopFood[] = $state([]);
-	let topFoodsLoading = $state(true);
+	let foods: TopFood[] = $state(pageData.topFoods);
+	let topFoodsLoading = $state(false);
 
 	const DEFAULT_COLOR = '#6B7280';
 	const getMealColor = (mealType: string) => MEAL_COLORS[mealType] ?? DEFAULT_COLOR;
@@ -83,12 +86,25 @@
 		}
 	};
 
+	let mealInitialized = true;
 	$effect(() => {
-		fetchData(range);
+		const r = range;
+		if (mealInitialized && r === 'today') {
+			mealInitialized = false;
+			return;
+		}
+		mealInitialized = false;
+		fetchData(r);
 	});
 
+	let topFoodsInitialized = true;
 	$effect(() => {
-		topFoodsDays;
+		const d = topFoodsDays;
+		if (topFoodsInitialized && d === 7) {
+			topFoodsInitialized = false;
+			return;
+		}
+		topFoodsInitialized = false;
 		loadTopFoods();
 	});
 
@@ -121,19 +137,19 @@
 
 <div class="mx-auto max-w-4xl space-y-6">
 	<CollapsibleCard title={m.insights_trends()} sectionId="trends">
-		<TrendsChart />
+		<TrendsChart initialData={pageData.dailyStatus} />
 	</CollapsibleCard>
 
 	<CollapsibleCard title={m.insights_goal_adherence()} sectionId="adherence">
-		<GoalAdherence />
+		<GoalAdherence initialData={pageData.dailyStatus} />
 	</CollapsibleCard>
 
 	<CollapsibleCard title={m.insights_calendar()} sectionId="calendar">
-		<CalendarHeatmap />
+		<CalendarHeatmap initialDays={pageData.calendarDays} />
 	</CollapsibleCard>
 
 	<CollapsibleCard title={m.insights_macro_balance()} sectionId="radar">
-		<MacroRadar />
+		<MacroRadar initialData={pageData.dailyStatus} />
 	</CollapsibleCard>
 
 	<CollapsibleCard title={m.insights_meal_distribution()} sectionId="meals">

--- a/src/routes/(app)/maintenance/+page.server.ts
+++ b/src/routes/(app)/maintenance/+page.server.ts
@@ -1,0 +1,80 @@
+import type { PageServerLoad } from './$types';
+import { listEntriesByDateRange } from '$lib/server/entries';
+import { getWeightEntriesByDateRange } from '$lib/server/weight';
+import { calculateMaintenance, DEFAULT_MUSCLE_RATIO } from '$lib/utils/maintenance';
+import { calculateEntryMacros } from '$lib/utils/nutrition';
+import { daysBetween, today, shiftDate } from '$lib/utils/dates';
+import { getFastingDays } from '$lib/server/day-properties';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const userId = locals.user!.id;
+	const endDate = today();
+	const startDate = shiftDate(endDate, -27);
+	const muscleRatio = DEFAULT_MUSCLE_RATIO;
+
+	const [entries, weights, fastingDays] = await Promise.all([
+		listEntriesByDateRange(userId, startDate, endDate),
+		getWeightEntriesByDateRange(userId, startDate, endDate),
+		getFastingDays(userId, startDate, endDate)
+	]);
+
+	if (weights.length < 2) {
+		return { initialResult: null, initialMeta: null };
+	}
+
+	const dailyTotals: Record<string, number> = {};
+	for (const entry of entries) {
+		const macros = calculateEntryMacros(entry);
+		dailyTotals[entry.date] = (dailyTotals[entry.date] ?? 0) + macros.calories;
+	}
+
+	for (const fastingDate of fastingDays) {
+		if (!(fastingDate in dailyTotals)) {
+			dailyTotals[fastingDate] = 0;
+		}
+	}
+
+	const daysWithEntries = Object.keys(dailyTotals);
+	if (daysWithEntries.length === 0) {
+		return { initialResult: null, initialMeta: null };
+	}
+
+	const days = daysBetween(startDate, endDate);
+	if (days <= 0) {
+		return { initialResult: null, initialMeta: null };
+	}
+
+	const totalCalories = Object.values(dailyTotals).reduce((sum, cal) => sum + cal, 0);
+	const avgDailyCalories = totalCalories / days;
+
+	const firstWeight = weights[0];
+	const lastWeight = weights[weights.length - 1];
+	const weightChangeKg = lastWeight.weightKg - firstWeight.weightKg;
+
+	const result = calculateMaintenance({
+		weightChangeKg,
+		avgDailyCalories,
+		days,
+		muscleRatio
+	});
+
+	if (!result) {
+		return { initialResult: null, initialMeta: null };
+	}
+
+	const coverage = daysWithEntries.length / days;
+
+	return {
+		initialResult: result,
+		initialMeta: {
+			weightEntries: weights.length,
+			foodEntryDays: daysWithEntries.length,
+			totalDays: days,
+			coverage,
+			firstWeight: firstWeight.weightKg,
+			lastWeight: lastWeight.weightKg,
+			startDate,
+			endDate
+		}
+	};
+};

--- a/src/routes/(app)/maintenance/+page.svelte
+++ b/src/routes/(app)/maintenance/+page.svelte
@@ -204,12 +204,11 @@
 				</div>
 			</div>
 
-			<Button class="w-full" onclick={calculate} disabled={loading}>
-				{#if loading}
+			{#if loading}
+				<div class="flex items-center justify-center gap-2 py-2 text-sm text-muted-foreground">
 					<Loader class="size-4 animate-spin" />
-				{/if}
-				{m.maintenance_calculate()}
-			</Button>
+				</div>
+			{/if}
 		</Card.Content>
 	</Card.Root>
 

--- a/src/routes/(app)/maintenance/+page.svelte
+++ b/src/routes/(app)/maintenance/+page.svelte
@@ -14,6 +14,7 @@
 	import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
 	import Loader from '@lucide/svelte/icons/loader';
 	import * as m from '$lib/paraglide/messages';
+	import type { PageData } from './$types';
 
 	type MaintenanceResult = {
 		maintenanceCalories: number;
@@ -40,13 +41,15 @@
 		endDate: string;
 	};
 
+	let { data }: { data: PageData } = $props();
+
 	let endDate = $state(today());
 	// svelte-ignore state_referenced_locally
 	let startDate = $state(shiftDate(endDate, -27));
 	let muscleRatio = $state(DEFAULT_MUSCLE_RATIO * 100);
 
-	let result = $state<MaintenanceResult | null>(null);
-	let meta = $state<Meta | null>(null);
+	let result = $state<MaintenanceResult | null>(data.initialResult);
+	let meta = $state<Meta | null>(data.initialMeta);
 	let loading = $state(false);
 	let error: string | null = $state(null);
 

--- a/src/routes/(app)/maintenance/+page.svelte
+++ b/src/routes/(app)/maintenance/+page.svelte
@@ -66,10 +66,23 @@
 		{ label: () => m.maintenance_12_weeks(), days: 83 }
 	];
 
+	let initialized = !!data.initialResult;
+
 	function selectPreset(days: number) {
 		endDate = today();
 		startDate = shiftDate(endDate, -days);
 	}
+
+	$effect(() => {
+		void startDate;
+		void endDate;
+		void muscleRatio;
+		if (initialized) {
+			initialized = false;
+			return;
+		}
+		calculate();
+	});
 
 	async function calculate() {
 		loading = true;

--- a/src/routes/(app)/weight/+page.server.ts
+++ b/src/routes/(app)/weight/+page.server.ts
@@ -1,0 +1,13 @@
+import type { PageServerLoad } from './$types';
+import { getWeightWithTrend } from '$lib/server/weight';
+import { daysAgo, today } from '$lib/utils/dates';
+
+type ChartPoint = { entry_date: string; weight_kg: number; moving_avg: number | null };
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const userId = locals.user!.id;
+	const from = daysAgo(30);
+	const to = today();
+	const initialChartData = (await getWeightWithTrend(userId, from, to)) as ChartPoint[];
+	return { initialChartData };
+};

--- a/src/routes/(app)/weight/+page.svelte
+++ b/src/routes/(app)/weight/+page.svelte
@@ -18,11 +18,13 @@
 		moving_avg: number | null;
 	};
 
+	let { data: pageData } = $props();
+
 	const live = useLiveQuery(() => weightService.entries(), [] as DexieWeightEntry[]);
 	const entries = $derived(live.value);
 
-	let chartData: ChartPoint[] = $state([]);
-	let loading = $state(true);
+	let chartData: ChartPoint[] = $state(pageData.initialChartData);
+	let loading = $state(false);
 
 	let chartFrom = $state(daysAgo(30));
 	let chartTo = $state(today());
@@ -50,9 +52,6 @@
 
 	$effect(() => {
 		weightService.refresh();
-		loadChart().then(() => {
-			loading = false;
-		});
 	});
 </script>
 

--- a/src/routes/api/foods/recent/+server.ts
+++ b/src/routes/api/foods/recent/+server.ts
@@ -1,14 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { listRecentFoods } from '$lib/server/foods';
-import { uniqueById } from '$lib/utils/recents';
 import { handleApiError, requireAuth } from '$lib/server/errors';
 
 export const GET: RequestHandler = async ({ locals }) => {
 	try {
 		const userId = requireAuth(locals);
-		const recentFoods = await listRecentFoods(userId);
-		const foods = uniqueById(recentFoods);
+		const foods = await listRecentFoods(userId);
 		return json({ foods });
 	} catch (error) {
 		return handleApiError(error);

--- a/tests/api/foods-id.test.ts
+++ b/tests/api/foods-id.test.ts
@@ -70,7 +70,10 @@ describe('api/foods/[id]', () => {
 
 		test('returns 404 for nonexistent food', async () => {
 			mockGetResult = null;
-			const event = createMockEvent({ user: TEST_USER, params: { id: '00000000-0000-0000-0000-000000000000' } });
+			const event = createMockEvent({
+				user: TEST_USER,
+				params: { id: '00000000-0000-0000-0000-000000000000' }
+			});
 			const response = await GET(event);
 			const data = await response.json();
 

--- a/tests/api/foods-recent.test.ts
+++ b/tests/api/foods-recent.test.ts
@@ -17,7 +17,6 @@ vi.mock('$lib/server/foods', () => ({
 	toFoodUpdate: () => ({})
 }));
 
-
 // Import route handler after mocking
 const { GET } = await import('../../src/routes/api/foods/recent/+server');
 

--- a/tests/api/foods-recent.test.ts
+++ b/tests/api/foods-recent.test.ts
@@ -17,17 +17,6 @@ vi.mock('$lib/server/foods', () => ({
 	toFoodUpdate: () => ({})
 }));
 
-// Mock utils
-vi.mock('$lib/utils/recents', () => ({
-	uniqueById: (items: any[]) => {
-		const seen = new Set();
-		return items.filter((item) => {
-			if (seen.has(item.id)) return false;
-			seen.add(item.id);
-			return true;
-		});
-	}
-}));
 
 // Import route handler after mocking
 const { GET } = await import('../../src/routes/api/foods/recent/+server');
@@ -60,8 +49,8 @@ describe('api/foods/recent', () => {
 			expect(data.foods).toEqual([]);
 		});
 
-		test('deduplicates foods by ID', async () => {
-			mockRecentResult = [TEST_FOOD, TEST_FOOD, TEST_FOOD_2];
+		test('returns all foods from listRecentFoods', async () => {
+			mockRecentResult = [TEST_FOOD, TEST_FOOD_2];
 			const event = createMockEvent({ user: TEST_USER });
 
 			const response = await GET(event);

--- a/tests/server/session-db.test.ts
+++ b/tests/server/session-db.test.ts
@@ -281,26 +281,15 @@ describe('session-db', () => {
 			expect(count).toBe(0);
 		});
 
-		test('respects batch size limit', async () => {
+		test('deletes multiple expired sessions', async () => {
 			const expiredIds = Array.from({ length: 10 }, (_, i) => ({
 				id: `10000000-0000-4000-8000-00000000005${i}`
 			}));
 			setResult(expiredIds);
 
-			const count = await cleanExpiredSessions(10);
-
-			expect(count).toBe(10);
-		});
-
-		test('uses default batch size of 500', async () => {
-			const expiredIds = Array.from({ length: 100 }, (_, i) => ({
-				id: `10000000-0000-4000-8000-0000000000${String(i).padStart(2, '0')}`
-			}));
-			setResult(expiredIds);
-
 			const count = await cleanExpiredSessions();
 
-			expect(count).toBe(100);
+			expect(count).toBe(10);
 		});
 	});
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,6 +83,17 @@ export default defineConfig({
 				navigateFallbackDenylist: [/^\/api\//, /^\/login/, /^\/authorize/, /^\/token/],
 				runtimeCaching: [
 					{
+						urlPattern: /\/__data\.json(\?.*)?$/,
+						handler: 'NetworkFirst',
+						options: {
+							cacheName: 'ssr-data-cache',
+							expiration: {
+								maxEntries: 50,
+								maxAgeSeconds: 24 * 60 * 60
+							}
+						}
+					},
+					{
 						urlPattern: /^\/api\/auth\/me$/,
 						handler: 'NetworkFirst',
 						options: {


### PR DESCRIPTION
## Summary

- **SSR data loading**: Add server-side rendering for history, insights, maintenance, and weight pages — eliminates redundant client-side fetches on page load
- **Android favorites widget**: New Glance widget with food image grid, tap-to-log action, checkmark feedback, and auto-refresh on changes
- **Android polish**: Chart touch interactions with tooltips, debounced food search, optimistic supplement toggles, R8 minification, ProGuard rules, UUID-based temp IDs, and various ViewModel refactors
- **Backend performance**: Parallelize recipe queries, replace correlated subqueries with CTEs, add date bounds to streaks, deduplicate recent foods queries, fix db pool config
- **PWA/UI fixes**: Fix overlapping drawers during barcode scan, cache `__data.json` for offline navigation, sidebar navigation grouping, dashboard layout rhythm improvements, auto-recalculate maintenance on parameter change

## Test plan

- [ ] Verify SSR pages load correctly (history, insights, maintenance, weight)
- [ ] Test Android favorites widget: add/remove favorites, tap to log, image loading
- [ ] Test chart tooltip interactions on Android
- [ ] Verify barcode scan drawer flow on desktop and mobile
- [ ] Check offline PWA navigation works with cached data
- [ ] Run `bun run check` for type checking
- [ ] Run Android lint and build: `./gradlew androidApp:assembleDebug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)