### PR TITLE
feat: optimize mcp server with 12 new tools and parameter improvements

### DIFF
--- a/src/lib/server/mcp/create-handlers.ts
+++ b/src/lib/server/mcp/create-handlers.ts
@@ -27,6 +27,7 @@ import type {
 import type {
 	createEntry,
 	listEntriesByDate,
+	listEntriesByDateRange,
 	updateEntry,
 	deleteEntry,
 	copyEntries
@@ -46,7 +47,8 @@ import type {
 	getDailyBreakdown,
 	getMealBreakdown,
 	getTopFoods,
-	getStreaks
+	getStreaks,
+	computeAverages
 } from '$lib/server/stats';
 import type {
 	createSupplement,
@@ -55,6 +57,7 @@ import type {
 	deleteSupplement,
 	unlogSupplement,
 	getLogsForDate,
+	getLogsForRange,
 	logSupplement,
 	getSupplementById,
 	getSupplementChecklist
@@ -69,6 +72,22 @@ import type {
 	updateSleepEntry,
 	deleteSleepEntry
 } from '$lib/server/sleep';
+import type {
+	getFoodDiversityData,
+	getMealTimingData,
+	getSleepFoodCorrelationData,
+	getWeightFoodSeries,
+	getExtendedNutrientEntries,
+	getDailyNutrientTotals
+} from '$lib/server/analytics';
+import type { listMealTypes } from '$lib/server/meal-types';
+import type {
+	getDayProperties,
+	setDayProperties,
+	deleteDayProperties,
+	getFastingDays
+} from '$lib/server/day-properties';
+import type { getCalendarStats } from '$lib/server/stats';
 
 export type HandlerDeps = {
 	// Foods
@@ -126,6 +145,27 @@ export type HandlerDeps = {
 	getLatestSleep: typeof getLatestSleep;
 	updateSleepEntry: typeof updateSleepEntry;
 	deleteSleepEntry: typeof deleteSleepEntry;
+	// Supplement history
+	getLogsForRange: typeof getLogsForRange;
+	// Custom range stats
+	computeAverages: typeof computeAverages;
+	listEntriesByDateRange: typeof listEntriesByDateRange;
+	getFastingDays: typeof getFastingDays;
+	// Analytics
+	getFoodDiversityData: typeof getFoodDiversityData;
+	getMealTimingData: typeof getMealTimingData;
+	getSleepFoodCorrelationData: typeof getSleepFoodCorrelationData;
+	getWeightFoodSeries: typeof getWeightFoodSeries;
+	getExtendedNutrientEntries: typeof getExtendedNutrientEntries;
+	getDailyNutrientTotals: typeof getDailyNutrientTotals;
+	// Meal types
+	listMealTypes: typeof listMealTypes;
+	// Day properties
+	getDayProperties: typeof getDayProperties;
+	setDayProperties: typeof setDayProperties;
+	deleteDayProperties: typeof deleteDayProperties;
+	// Calendar stats
+	getCalendarStats: typeof getCalendarStats;
 	// Utils
 	formatDailyStatus: typeof formatDailyStatus;
 	today: typeof today;
@@ -160,10 +200,15 @@ export function createHandlers(d: HandlerDeps) {
 		}
 	};
 
-	const handleSearchFoods = async (userId: string, query: string) => {
+	const handleSearchFoods = async (
+		userId: string,
+		query: string,
+		limit?: number,
+		offset?: number
+	) => {
 		try {
 			const [{ items: foods }, recentFoods] = await Promise.all([
-				d.listFoods(userId, { query }),
+				d.listFoods(userId, { query, limit: limit ?? 50, offset }),
 				d.listRecentFoods(userId, 100)
 			]);
 			const recentIds = new Set(recentFoods.map((f: { id: string }) => f.id));
@@ -213,9 +258,9 @@ export function createHandlers(d: HandlerDeps) {
 		}
 	};
 
-	const handleGetSupplementStatus = async (userId: string) => {
+	const handleGetSupplementStatus = async (userId: string, date?: string) => {
 		try {
-			const targetDate = d.today();
+			const targetDate = date ?? d.today();
 			const items = await d.getSupplementChecklist(userId, targetDate);
 
 			const checklist = items.map((item) => ({
@@ -454,16 +499,30 @@ export function createHandlers(d: HandlerDeps) {
 		}
 	};
 
-	const handleGetWeeklyStats = async (userId: string) => {
+	const handleGetWeeklyStats = async (userId: string, startDate?: string, endDate?: string) => {
 		try {
+			if (startDate && endDate) {
+				const [entries, fastingDaySet] = await Promise.all([
+					d.listEntriesByDateRange(userId, startDate, endDate),
+					d.getFastingDays(userId, startDate, endDate)
+				]);
+				return d.computeAverages(entries, fastingDaySet);
+			}
 			return await d.getWeeklyStats(userId);
 		} catch (e) {
 			wrapError('get weekly stats', e);
 		}
 	};
 
-	const handleGetMonthlyStats = async (userId: string) => {
+	const handleGetMonthlyStats = async (userId: string, startDate?: string, endDate?: string) => {
 		try {
+			if (startDate && endDate) {
+				const [entries, fastingDaySet] = await Promise.all([
+					d.listEntriesByDateRange(userId, startDate, endDate),
+					d.getFastingDays(userId, startDate, endDate)
+				]);
+				return d.computeAverages(entries, fastingDaySet);
+			}
 			return await d.getMonthlyStats(userId);
 		} catch (e) {
 			wrapError('get monthly stats', e);
@@ -722,7 +781,10 @@ export function createHandlers(d: HandlerDeps) {
 		}
 	};
 
-	const handleGetSleep = async (userId: string, args: { from?: string; to?: string }) => {
+	const handleGetSleep = async (
+		userId: string,
+		args: { from?: string; to?: string; limit?: number }
+	) => {
 		try {
 			if (args.from || args.to) {
 				if (!args.from || !args.to) {
@@ -731,7 +793,8 @@ export function createHandlers(d: HandlerDeps) {
 					};
 				}
 				const entries = await d.getSleepEntriesByDateRange(userId, args.from, args.to);
-				return { entries };
+				const limited = args.limit ? entries.slice(0, args.limit) : entries;
+				return { entries: limited };
 			}
 			const latest = await d.getLatestSleep(userId);
 			return latest ?? { error: 'No sleep entries found' };
@@ -746,6 +809,7 @@ export function createHandlers(d: HandlerDeps) {
 			id: string;
 			durationMinutes?: number;
 			quality?: number;
+			entryDate?: string;
 			bedtime?: string | null;
 			wakeTime?: string | null;
 			wakeUps?: number | null;
@@ -769,6 +833,136 @@ export function createHandlers(d: HandlerDeps) {
 			return { success: true };
 		} catch (e) {
 			wrapError('delete sleep', e);
+		}
+	};
+
+	// Analytics handlers
+	const handleGetFoodDiversity = async (
+		userId: string,
+		args: { startDate: string; endDate: string }
+	) => {
+		try {
+			return d.getFoodDiversityData(userId, args.startDate, args.endDate);
+		} catch (e) {
+			wrapError('get food diversity', e);
+		}
+	};
+
+	const handleGetMealTiming = async (
+		userId: string,
+		args: { startDate: string; endDate: string }
+	) => {
+		try {
+			return d.getMealTimingData(userId, args.startDate, args.endDate);
+		} catch (e) {
+			wrapError('get meal timing', e);
+		}
+	};
+
+	const handleGetSleepFoodCorrelation = async (
+		userId: string,
+		args: { startDate: string; endDate: string }
+	) => {
+		try {
+			return d.getSleepFoodCorrelationData(userId, args.startDate, args.endDate);
+		} catch (e) {
+			wrapError('get sleep-food correlation', e);
+		}
+	};
+
+	const handleGetWeightFoodSeries = async (
+		userId: string,
+		args: { startDate: string; endDate: string }
+	) => {
+		try {
+			return d.getWeightFoodSeries(userId, args.startDate, args.endDate);
+		} catch (e) {
+			wrapError('get weight-food series', e);
+		}
+	};
+
+	const handleGetExtendedNutrients = async (
+		userId: string,
+		args: { startDate: string; endDate: string }
+	) => {
+		try {
+			return d.getExtendedNutrientEntries(userId, args.startDate, args.endDate);
+		} catch (e) {
+			wrapError('get extended nutrients', e);
+		}
+	};
+
+	const handleGetDailyNutrients = async (
+		userId: string,
+		args: { startDate: string; endDate: string }
+	) => {
+		try {
+			return d.getDailyNutrientTotals(userId, args.startDate, args.endDate);
+		} catch (e) {
+			wrapError('get daily nutrients', e);
+		}
+	};
+
+	// Meal types handler
+	const handleListMealTypes = async (userId: string) => {
+		try {
+			const mealTypes = await d.listMealTypes(userId);
+			return { mealTypes };
+		} catch (e) {
+			wrapError('list meal types', e);
+		}
+	};
+
+	// Supplement history handler
+	const handleGetSupplementHistory = async (userId: string, args: { from: string; to: string }) => {
+		try {
+			const history = await d.getLogsForRange(userId, args.from, args.to);
+			return { history };
+		} catch (e) {
+			wrapError('get supplement history', e);
+		}
+	};
+
+	// Day properties handlers
+	const handleGetDayProperties = async (userId: string, args: { date: string }) => {
+		try {
+			const properties = await d.getDayProperties(userId, args.date);
+			return { date: args.date, properties };
+		} catch (e) {
+			wrapError('get day properties', e);
+		}
+	};
+
+	const handleSetDayProperties = async (
+		userId: string,
+		args: { date: string; isFastingDay: boolean }
+	) => {
+		try {
+			const properties = await d.setDayProperties(userId, args.date, args.isFastingDay);
+			return { success: true, properties };
+		} catch (e) {
+			wrapError('set day properties', e);
+		}
+	};
+
+	const handleDeleteDayProperties = async (userId: string, args: { date: string }) => {
+		try {
+			await d.deleteDayProperties(userId, args.date);
+			return { success: true };
+		} catch (e) {
+			wrapError('delete day properties', e);
+		}
+	};
+
+	// Calendar stats handler
+	const handleGetCalendarStats = async (userId: string, args: { month: string }) => {
+		try {
+			const [yearStr, monthStr] = args.month.split('-');
+			const year = parseInt(yearStr, 10);
+			const month = parseInt(monthStr, 10) - 1;
+			return d.getCalendarStats(userId, year, month);
+		} catch (e) {
+			wrapError('get calendar stats', e);
 		}
 	};
 
@@ -815,6 +1009,18 @@ export function createHandlers(d: HandlerDeps) {
 		handleLogSleep,
 		handleGetSleep,
 		handleUpdateSleep,
-		handleDeleteSleep
+		handleDeleteSleep,
+		handleGetFoodDiversity,
+		handleGetMealTiming,
+		handleGetSleepFoodCorrelation,
+		handleGetWeightFoodSeries,
+		handleGetExtendedNutrients,
+		handleGetDailyNutrients,
+		handleListMealTypes,
+		handleGetSupplementHistory,
+		handleGetDayProperties,
+		handleSetDayProperties,
+		handleDeleteDayProperties,
+		handleGetCalendarStats
 	};
 }

--- a/src/lib/server/mcp/create-handlers.ts
+++ b/src/lib/server/mcp/create-handlers.ts
@@ -179,6 +179,16 @@ export function createHandlers(d: HandlerDeps) {
 		throw new Error(`Failed to ${op}: ${e instanceof Error ? e.message : String(e)}`);
 	}
 
+	const MAX_RANGE_DAYS = 366;
+
+	function guardDateRange(startDate: string, endDate: string) {
+		const diffMs = new Date(endDate).getTime() - new Date(startDate).getTime();
+		if (diffMs < 0) return { error: 'startDate must be before endDate' };
+		if (diffMs > MAX_RANGE_DAYS * 86_400_000)
+			return { error: `Date range exceeds maximum of ${MAX_RANGE_DAYS} days` };
+		return null;
+	}
+
 	const getDailyStatusForDate = async (userId: string, date: string) => {
 		const { items: entries } = await d.listEntriesByDate(userId, date);
 		const goals = await d.getGoals(userId);
@@ -502,6 +512,8 @@ export function createHandlers(d: HandlerDeps) {
 	const handleGetWeeklyStats = async (userId: string, startDate?: string, endDate?: string) => {
 		try {
 			if (startDate && endDate) {
+				const err = guardDateRange(startDate, endDate);
+				if (err) return err;
 				const [entries, fastingDaySet] = await Promise.all([
 					d.listEntriesByDateRange(userId, startDate, endDate),
 					d.getFastingDays(userId, startDate, endDate)
@@ -517,6 +529,8 @@ export function createHandlers(d: HandlerDeps) {
 	const handleGetMonthlyStats = async (userId: string, startDate?: string, endDate?: string) => {
 		try {
 			if (startDate && endDate) {
+				const err = guardDateRange(startDate, endDate);
+				if (err) return err;
 				const [entries, fastingDaySet] = await Promise.all([
 					d.listEntriesByDateRange(userId, startDate, endDate),
 					d.getFastingDays(userId, startDate, endDate)
@@ -710,6 +724,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getDailyBreakdown(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get daily breakdown', e);
@@ -721,6 +737,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getMealBreakdown(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get meal breakdown', e);
@@ -793,8 +811,7 @@ export function createHandlers(d: HandlerDeps) {
 					};
 				}
 				const entries = await d.getSleepEntriesByDateRange(userId, args.from, args.to);
-				const limited = args.limit ? entries.slice(0, args.limit) : entries;
-				return { entries: limited };
+				return { entries: entries.slice(0, args.limit ?? 100) };
 			}
 			const latest = await d.getLatestSleep(userId);
 			return latest ?? { error: 'No sleep entries found' };
@@ -842,6 +859,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getFoodDiversityData(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get food diversity', e);
@@ -853,6 +872,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getMealTimingData(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get meal timing', e);
@@ -864,6 +885,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getSleepFoodCorrelationData(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get sleep-food correlation', e);
@@ -875,6 +898,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getWeightFoodSeries(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get weight-food series', e);
@@ -886,6 +911,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getExtendedNutrientEntries(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get extended nutrients', e);
@@ -897,6 +924,8 @@ export function createHandlers(d: HandlerDeps) {
 		args: { startDate: string; endDate: string }
 	) => {
 		try {
+			const err = guardDateRange(args.startDate, args.endDate);
+			if (err) return err;
 			return d.getDailyNutrientTotals(userId, args.startDate, args.endDate);
 		} catch (e) {
 			wrapError('get daily nutrients', e);
@@ -916,6 +945,8 @@ export function createHandlers(d: HandlerDeps) {
 	// Supplement history handler
 	const handleGetSupplementHistory = async (userId: string, args: { from: string; to: string }) => {
 		try {
+			const err = guardDateRange(args.from, args.to);
+			if (err) return err;
 			const history = await d.getLogsForRange(userId, args.from, args.to);
 			return { history };
 		} catch (e) {

--- a/src/lib/server/mcp/handlers.ts
+++ b/src/lib/server/mcp/handlers.ts
@@ -17,6 +17,7 @@ import {
 import {
 	createEntry,
 	listEntriesByDate,
+	listEntriesByDateRange,
 	updateEntry,
 	deleteEntry,
 	copyEntries
@@ -36,7 +37,8 @@ import {
 	getDailyBreakdown,
 	getMealBreakdown,
 	getTopFoods,
-	getStreaks
+	getStreaks,
+	computeAverages
 } from '$lib/server/stats';
 import { formatDailyStatus } from '$lib/server/mcp/format';
 import { today } from '$lib/utils/dates';
@@ -47,6 +49,7 @@ import {
 	deleteSupplement,
 	unlogSupplement,
 	getLogsForDate,
+	getLogsForRange,
 	logSupplement,
 	getSupplementById,
 	getSupplementChecklist
@@ -59,6 +62,22 @@ import {
 	updateSleepEntry,
 	deleteSleepEntry
 } from '$lib/server/sleep';
+import {
+	getFoodDiversityData,
+	getMealTimingData,
+	getSleepFoodCorrelationData,
+	getWeightFoodSeries,
+	getExtendedNutrientEntries,
+	getDailyNutrientTotals
+} from '$lib/server/analytics';
+import { listMealTypes } from '$lib/server/meal-types';
+import {
+	getDayProperties,
+	setDayProperties,
+	deleteDayProperties,
+	getFastingDays
+} from '$lib/server/day-properties';
+import { getCalendarStats } from '$lib/server/stats';
 import { createHandlers } from './create-handlers';
 
 export { createHandlers, type HandlerDeps } from './create-handlers';
@@ -106,7 +125,19 @@ export const {
 	handleLogSleep,
 	handleGetSleep,
 	handleUpdateSleep,
-	handleDeleteSleep
+	handleDeleteSleep,
+	handleGetFoodDiversity,
+	handleGetMealTiming,
+	handleGetSleepFoodCorrelation,
+	handleGetWeightFoodSeries,
+	handleGetExtendedNutrients,
+	handleGetDailyNutrients,
+	handleListMealTypes,
+	handleGetSupplementHistory,
+	handleGetDayProperties,
+	handleSetDayProperties,
+	handleDeleteDayProperties,
+	handleGetCalendarStats
 } = createHandlers({
 	listFoods,
 	createFood,
@@ -157,5 +188,20 @@ export const {
 	getSleepEntriesByDateRange,
 	getLatestSleep,
 	updateSleepEntry,
-	deleteSleepEntry
+	deleteSleepEntry,
+	getLogsForRange,
+	computeAverages,
+	listEntriesByDateRange,
+	getFastingDays,
+	getFoodDiversityData,
+	getMealTimingData,
+	getSleepFoodCorrelationData,
+	getWeightFoodSeries,
+	getExtendedNutrientEntries,
+	getDailyNutrientTotals,
+	listMealTypes,
+	getDayProperties,
+	setDayProperties,
+	deleteDayProperties,
+	getCalendarStats
 });

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -44,7 +44,19 @@ import {
 	handleLogSleep,
 	handleGetSleep,
 	handleUpdateSleep,
-	handleDeleteSleep
+	handleDeleteSleep,
+	handleGetFoodDiversity,
+	handleGetMealTiming,
+	handleGetSleepFoodCorrelation,
+	handleGetWeightFoodSeries,
+	handleGetExtendedNutrients,
+	handleGetDailyNutrients,
+	handleListMealTypes,
+	handleGetSupplementHistory,
+	handleGetDayProperties,
+	handleSetDayProperties,
+	handleDeleteDayProperties,
+	handleGetCalendarStats
 } from './handlers';
 import { today } from '$lib/utils/dates';
 import { ALL_NUTRIENTS } from '$lib/nutrients';
@@ -106,11 +118,24 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				"Search the user's food database by name. Returns matching foods with nutritional information, sorted by recent usage.",
 			inputSchema: {
-				query: z.string().describe('Search query to match against food names')
+				query: z.string().describe('Search query to match against food names'),
+				limit: z
+					.number()
+					.int()
+					.min(1)
+					.max(100)
+					.optional()
+					.describe('Max results to return. Defaults to 50.'),
+				offset: z
+					.number()
+					.int()
+					.min(0)
+					.optional()
+					.describe('Number of results to skip for pagination.')
 			},
 			annotations: READ_ONLY
 		},
-		safe(({ query }) => handleSearchFoods(userId, query))
+		safe(({ query, limit, offset }) => handleSearchFoods(userId, query, limit, offset))
 	);
 
 	// Build nutrient schema fields for MCP tools
@@ -255,11 +280,13 @@ export function createMcpServer(userId: string): McpServer {
 		'get_supplement_status',
 		{
 			description:
-				"Get today's supplement checklist showing which supplements are due and whether they've been taken.",
-			inputSchema: {},
+				"Get a supplement checklist showing which supplements are due and whether they've been taken.",
+			inputSchema: {
+				date: z.string().optional().describe('Date in YYYY-MM-DD format. Defaults to today.')
+			},
 			annotations: READ_ONLY
 		},
-		safe(() => handleGetSupplementStatus(userId))
+		safe(({ date }) => handleGetSupplementStatus(userId, date))
 	);
 
 	server.registerTool(
@@ -471,21 +498,41 @@ export function createMcpServer(userId: string): McpServer {
 	server.registerTool(
 		'get_weekly_stats',
 		{
-			description: 'Get average daily nutrition over the past 7 days.',
-			inputSchema: {},
+			description:
+				'Get average daily nutrition over 7 days. Defaults to the past 7 days. Use startDate and endDate for a custom range.',
+			inputSchema: {
+				startDate: z
+					.string()
+					.optional()
+					.describe('Custom start date in YYYY-MM-DD format. Omit for past 7 days.'),
+				endDate: z
+					.string()
+					.optional()
+					.describe('Custom end date in YYYY-MM-DD format. Omit for today.')
+			},
 			annotations: READ_ONLY
 		},
-		safe(() => handleGetWeeklyStats(userId))
+		safe((args) => handleGetWeeklyStats(userId, args.startDate, args.endDate))
 	);
 
 	server.registerTool(
 		'get_monthly_stats',
 		{
-			description: 'Get average daily nutrition over the past 30 days.',
-			inputSchema: {},
+			description:
+				'Get average daily nutrition over 30 days. Defaults to the past 30 days. Use startDate and endDate for a custom range.',
+			inputSchema: {
+				startDate: z
+					.string()
+					.optional()
+					.describe('Custom start date in YYYY-MM-DD format. Omit for past 30 days.'),
+				endDate: z
+					.string()
+					.optional()
+					.describe('Custom end date in YYYY-MM-DD format. Omit for today.')
+			},
 			annotations: READ_ONLY
 		},
-		safe(() => handleGetMonthlyStats(userId))
+		safe((args) => handleGetMonthlyStats(userId, args.startDate, args.endDate))
 	);
 
 	server.registerTool(
@@ -852,7 +899,14 @@ export function createMcpServer(userId: string): McpServer {
 					.string()
 					.regex(/^\d{4}-\d{2}-\d{2}$/)
 					.optional()
-					.describe('End date in YYYY-MM-DD format')
+					.describe('End date in YYYY-MM-DD format'),
+				limit: z
+					.number()
+					.int()
+					.min(1)
+					.max(365)
+					.optional()
+					.describe('Max entries to return when using date range. Defaults to 100.')
 			},
 			annotations: READ_ONLY
 		},
@@ -867,6 +921,11 @@ export function createMcpServer(userId: string): McpServer {
 				id: z.string().uuid().describe('Sleep entry ID to update'),
 				durationMinutes: z.number().int().min(1).max(1440).optional(),
 				quality: z.number().int().min(1).max(10).optional(),
+				entryDate: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/)
+					.optional()
+					.describe('New date in YYYY-MM-DD format'),
 				bedtime: z.string().optional().nullable(),
 				wakeTime: z.string().optional().nullable(),
 				wakeUps: z.number().int().min(0).optional().nullable(),
@@ -884,7 +943,7 @@ export function createMcpServer(userId: string): McpServer {
 			inputSchema: {
 				id: z.string().uuid().describe('Sleep entry ID to delete')
 			},
-			annotations: WRITE
+			annotations: DESTRUCTIVE
 		},
 		safe((args) => handleDeleteSleep(userId, args))
 	);
@@ -936,6 +995,174 @@ export function createMcpServer(userId: string): McpServer {
 			annotations: READ_ONLY
 		},
 		safe(() => handleGetStreaks(userId))
+	);
+
+	// Analytics tools
+	server.registerTool(
+		'get_food_diversity',
+		{
+			description:
+				'Analyze dietary variety over a date range. Shows unique foods consumed, diversity score, and most/least eaten foods.',
+			inputSchema: {
+				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
+				endDate: z.string().describe('End date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetFoodDiversity(userId, args))
+	);
+
+	server.registerTool(
+		'get_meal_timing',
+		{
+			description:
+				'Analyze meal timing patterns over a date range. Shows when meals are typically eaten and calorie distribution by time of day.',
+			inputSchema: {
+				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
+				endDate: z.string().describe('End date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetMealTiming(userId, args))
+	);
+
+	server.registerTool(
+		'get_sleep_food_correlation',
+		{
+			description:
+				'Analyze correlations between sleep quality/duration and daily nutrition. Shows how calorie and macro intake relates to sleep patterns.',
+			inputSchema: {
+				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
+				endDate: z.string().describe('End date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetSleepFoodCorrelation(userId, args))
+	);
+
+	server.registerTool(
+		'get_weight_food_series',
+		{
+			description:
+				'Get weight and daily calorie data over a date range for trend analysis. Shows how calorie intake correlates with weight changes.',
+			inputSchema: {
+				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
+				endDate: z.string().describe('End date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetWeightFoodSeries(userId, args))
+	);
+
+	server.registerTool(
+		'get_extended_nutrients',
+		{
+			description:
+				'Get detailed extended nutrient data (vitamins, minerals, etc.) for food entries over a date range.',
+			inputSchema: {
+				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
+				endDate: z.string().describe('End date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetExtendedNutrients(userId, args))
+	);
+
+	server.registerTool(
+		'get_daily_nutrients',
+		{
+			description:
+				'Get daily totals for all nutrients (core macros and extended) over a date range, with one row per day.',
+			inputSchema: {
+				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
+				endDate: z.string().describe('End date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetDailyNutrients(userId, args))
+	);
+
+	// Meal types
+	server.registerTool(
+		'list_meal_types',
+		{
+			description:
+				"List all meal types available to the user, including default types (Breakfast, Lunch, Dinner, Snacks) and any custom meal types they've created.",
+			inputSchema: {},
+			annotations: READ_ONLY
+		},
+		safe(() => handleListMealTypes(userId))
+	);
+
+	// Supplement history
+	server.registerTool(
+		'get_supplement_history',
+		{
+			description:
+				'Get supplement intake history over a date range. Shows which supplements were taken on which days.',
+			inputSchema: {
+				from: z.string().describe('Start date in YYYY-MM-DD format'),
+				to: z.string().describe('End date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetSupplementHistory(userId, args))
+	);
+
+	// Day properties
+	server.registerTool(
+		'get_day_properties',
+		{
+			description:
+				'Get properties for a specific day (e.g., whether it is marked as a fasting day).',
+			inputSchema: {
+				date: z.string().describe('Date in YYYY-MM-DD format')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetDayProperties(userId, args))
+	);
+
+	server.registerTool(
+		'set_day_properties',
+		{
+			description: 'Set properties for a specific day, such as marking it as a fasting day.',
+			inputSchema: {
+				date: z.string().describe('Date in YYYY-MM-DD format'),
+				isFastingDay: z.boolean().describe('Whether the day is a fasting day')
+			},
+			annotations: UPDATE
+		},
+		safe((args) => handleSetDayProperties(userId, args))
+	);
+
+	server.registerTool(
+		'delete_day_properties',
+		{
+			description: 'Remove all properties for a specific day (resets fasting status, etc.).',
+			inputSchema: {
+				date: z.string().describe('Date in YYYY-MM-DD format')
+			},
+			annotations: DESTRUCTIVE
+		},
+		safe((args) => handleDeleteDayProperties(userId, args))
+	);
+
+	// Calendar stats
+	server.registerTool(
+		'get_calendar_stats',
+		{
+			description:
+				'Get per-day entry presence for a month. Shows which days have food entries logged, useful for adherence tracking.',
+			inputSchema: {
+				month: z
+					.string()
+					.regex(/^\d{4}-\d{2}$/)
+					.describe('Month in YYYY-MM format (e.g., "2026-03")')
+			},
+			annotations: READ_ONLY
+		},
+		safe((args) => handleGetCalendarStats(userId, args))
 	);
 
 	// Static resources

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -66,6 +66,13 @@ const WRITE = { readOnlyHint: false, destructiveHint: false } as const;
 const UPDATE = { readOnlyHint: false, destructiveHint: false, idempotentHint: true } as const;
 const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true, idempotentHint: true } as const;
 
+const dateStr = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected YYYY-MM-DD format');
+
+const dateRangeSchema = {
+	startDate: dateStr.describe('Start date in YYYY-MM-DD format'),
+	endDate: dateStr.describe('End date in YYYY-MM-DD format')
+};
+
 const MCP_SERVER_NAME = 'bissbilanz';
 const MCP_SERVER_VERSION = '0.1.0';
 
@@ -501,12 +508,10 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Get average daily nutrition over 7 days. Defaults to the past 7 days. Use startDate and endDate for a custom range.',
 			inputSchema: {
-				startDate: z
-					.string()
+				startDate: dateStr
 					.optional()
 					.describe('Custom start date in YYYY-MM-DD format. Omit for past 7 days.'),
-				endDate: z
-					.string()
+				endDate: dateStr
 					.optional()
 					.describe('Custom end date in YYYY-MM-DD format. Omit for today.')
 			},
@@ -521,12 +526,10 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Get average daily nutrition over 30 days. Defaults to the past 30 days. Use startDate and endDate for a custom range.',
 			inputSchema: {
-				startDate: z
-					.string()
+				startDate: dateStr
 					.optional()
 					.describe('Custom start date in YYYY-MM-DD format. Omit for past 30 days.'),
-				endDate: z
-					.string()
+				endDate: dateStr
 					.optional()
 					.describe('Custom end date in YYYY-MM-DD format. Omit for today.')
 			},
@@ -953,8 +956,7 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Get daily nutrition totals for a date range, with one row per day.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -966,8 +968,7 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Get nutrition totals broken down by meal type for a date range.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -979,8 +980,20 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Get the most frequently logged foods over a period.',
 			inputSchema: {
-				days: z.number().optional().describe('Number of days to look back. Defaults to 7.'),
-				limit: z.number().optional().describe('Max number of foods to return. Defaults to 10.')
+				days: z
+					.number()
+					.int()
+					.min(1)
+					.max(365)
+					.optional()
+					.describe('Number of days to look back. Defaults to 7.'),
+				limit: z
+					.number()
+					.int()
+					.min(1)
+					.max(100)
+					.optional()
+					.describe('Max number of foods to return. Defaults to 10.')
 			},
 			annotations: READ_ONLY
 		},
@@ -1004,8 +1017,7 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Analyze dietary variety over a date range. Shows unique foods consumed, diversity score, and most/least eaten foods.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -1018,8 +1030,7 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Analyze meal timing patterns over a date range. Shows when meals are typically eaten and calorie distribution by time of day.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -1032,8 +1043,7 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Analyze correlations between sleep quality/duration and daily nutrition. Shows how calorie and macro intake relates to sleep patterns.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -1046,8 +1056,7 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Get weight and daily calorie data over a date range for trend analysis. Shows how calorie intake correlates with weight changes.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -1060,8 +1069,7 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Get detailed extended nutrient data (vitamins, minerals, etc.) for food entries over a date range.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -1074,8 +1082,7 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Get daily totals for all nutrients (core macros and extended) over a date range, with one row per day.',
 			inputSchema: {
-				startDate: z.string().describe('Start date in YYYY-MM-DD format'),
-				endDate: z.string().describe('End date in YYYY-MM-DD format')
+				...dateRangeSchema
 			},
 			annotations: READ_ONLY
 		},
@@ -1101,8 +1108,8 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Get supplement intake history over a date range. Shows which supplements were taken on which days.',
 			inputSchema: {
-				from: z.string().describe('Start date in YYYY-MM-DD format'),
-				to: z.string().describe('End date in YYYY-MM-DD format')
+				from: dateStr.describe('Start date in YYYY-MM-DD format'),
+				to: dateStr.describe('End date in YYYY-MM-DD format')
 			},
 			annotations: READ_ONLY
 		},
@@ -1116,7 +1123,7 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Get properties for a specific day (e.g., whether it is marked as a fasting day).',
 			inputSchema: {
-				date: z.string().describe('Date in YYYY-MM-DD format')
+				date: dateStr.describe('Date in YYYY-MM-DD format')
 			},
 			annotations: READ_ONLY
 		},
@@ -1128,7 +1135,7 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Set properties for a specific day, such as marking it as a fasting day.',
 			inputSchema: {
-				date: z.string().describe('Date in YYYY-MM-DD format'),
+				date: dateStr.describe('Date in YYYY-MM-DD format'),
 				isFastingDay: z.boolean().describe('Whether the day is a fasting day')
 			},
 			annotations: UPDATE
@@ -1141,7 +1148,7 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Remove all properties for a specific day (resets fasting status, etc.).',
 			inputSchema: {
-				date: z.string().describe('Date in YYYY-MM-DD format')
+				date: dateStr.describe('Date in YYYY-MM-DD format')
 			},
 			annotations: DESTRUCTIVE
 		},
@@ -1158,6 +1165,13 @@ export function createMcpServer(userId: string): McpServer {
 				month: z
 					.string()
 					.regex(/^\d{4}-\d{2}$/)
+					.refine(
+						(v) => {
+							const m = parseInt(v.split('-')[1], 10);
+							return m >= 1 && m <= 12;
+						},
+						{ message: 'Month must be between 01 and 12' }
+					)
 					.describe('Month in YYYY-MM format (e.g., "2026-03")')
 			},
 			annotations: READ_ONLY

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -41,5 +41,22 @@ export const toolNames = [
 	'log_sleep',
 	'get_sleep',
 	'update_sleep',
-	'delete_sleep'
+	'delete_sleep',
+	// Analytics
+	'get_food_diversity',
+	'get_meal_timing',
+	'get_sleep_food_correlation',
+	'get_weight_food_series',
+	'get_extended_nutrients',
+	'get_daily_nutrients',
+	// Meal types
+	'list_meal_types',
+	// Supplement history
+	'get_supplement_history',
+	// Day properties
+	'get_day_properties',
+	'set_day_properties',
+	'delete_day_properties',
+	// Calendar stats
+	'get_calendar_stats'
 ] as const;

--- a/tests/server/mcp-handlers.test.ts
+++ b/tests/server/mcp-handlers.test.ts
@@ -5,7 +5,8 @@ import {
 	TEST_RECIPE,
 	TEST_ENTRY,
 	TEST_GOALS,
-	TEST_SUPPLEMENT
+	TEST_SUPPLEMENT,
+	TEST_MEAL_TYPE
 } from '../helpers/fixtures';
 import { createHandlers, type HandlerDeps } from '../../src/lib/server/mcp/create-handlers';
 
@@ -49,6 +50,24 @@ let mockCreateSupplementResult: any = null;
 let mockUpdateSupplementResult: any = null;
 let mockOFFProduct: any = null;
 let mockOFFSearchResults: any[] = [];
+let mockCreateSleepResult: any = null;
+let mockSleepEntries: any[] = [];
+let mockLatestSleep: any = null;
+let mockUpdateSleepResult: any = null;
+let mockDeleteSleepResult: any = true;
+let mockSupplementHistory: any[] = [];
+let mockFoodDiversity: any = null;
+let mockMealTiming: any = null;
+let mockSleepFoodCorrelation: any = null;
+let mockWeightFoodSeries: any = null;
+let mockExtendedNutrients: any = null;
+let mockDailyNutrients: any = null;
+let mockMealTypes: any[] = [];
+let mockDayProperties: any = null;
+let mockCalendarStats: any = null;
+let mockComputedAverages: any = null;
+let mockDateRangeEntries: any[] = [];
+let mockFastingDays: Set<string> = new Set();
 
 const mockDeps = {
 	listFoods: async () => ({ items: mockFoods, total: mockFoods.length }),
@@ -150,7 +169,33 @@ const mockDeps = {
 		}));
 	},
 	fetchProduct: async () => mockOFFProduct,
-	searchProducts: async () => mockOFFSearchResults
+	searchProducts: async () => mockOFFSearchResults,
+	createSleepEntry: async () =>
+		mockCreateSleepResult
+			? { success: true, data: mockCreateSleepResult }
+			: { success: false, error: new Error('Validation failed') },
+	getSleepEntriesByDateRange: async () => mockSleepEntries,
+	getLatestSleep: async () => mockLatestSleep,
+	updateSleepEntry: async () =>
+		mockUpdateSleepResult
+			? { success: true, data: mockUpdateSleepResult }
+			: { success: false, error: new Error('Validation failed') },
+	deleteSleepEntry: async () => mockDeleteSleepResult,
+	getLogsForRange: async () => mockSupplementHistory,
+	getFoodDiversityData: async () => mockFoodDiversity,
+	getMealTimingData: async () => mockMealTiming,
+	getSleepFoodCorrelationData: async () => mockSleepFoodCorrelation,
+	getWeightFoodSeries: async () => mockWeightFoodSeries,
+	getExtendedNutrientEntries: async () => mockExtendedNutrients,
+	getDailyNutrientTotals: async () => mockDailyNutrients,
+	listMealTypes: async () => mockMealTypes,
+	getDayProperties: async () => mockDayProperties,
+	setDayProperties: async () => mockDayProperties,
+	deleteDayProperties: async () => {},
+	getCalendarStats: async () => mockCalendarStats,
+	computeAverages: () => mockComputedAverages,
+	listEntriesByDateRange: async () => mockDateRangeEntries,
+	getFastingDays: async () => mockFastingDays
 } satisfies Record<string, Function> as unknown as HandlerDeps;
 
 const {
@@ -192,7 +237,23 @@ const {
 	handleUpdateSupplement,
 	handleDeleteSupplement,
 	handleUnlogSupplement,
-	handleSearchOpenFoodFacts
+	handleSearchOpenFoodFacts,
+	handleLogSleep,
+	handleGetSleep,
+	handleUpdateSleep,
+	handleDeleteSleep,
+	handleGetFoodDiversity,
+	handleGetMealTiming,
+	handleGetSleepFoodCorrelation,
+	handleGetWeightFoodSeries,
+	handleGetExtendedNutrients,
+	handleGetDailyNutrients,
+	handleListMealTypes,
+	handleGetSupplementHistory,
+	handleGetDayProperties,
+	handleSetDayProperties,
+	handleDeleteDayProperties,
+	handleGetCalendarStats
 } = createHandlers(mockDeps);
 
 describe('MCP handlers', () => {
@@ -236,6 +297,24 @@ describe('MCP handlers', () => {
 		mockUpdateSupplementResult = null;
 		mockOFFProduct = null;
 		mockOFFSearchResults = [];
+		mockCreateSleepResult = null;
+		mockSleepEntries = [];
+		mockLatestSleep = null;
+		mockUpdateSleepResult = null;
+		mockDeleteSleepResult = true;
+		mockSupplementHistory = [];
+		mockFoodDiversity = null;
+		mockMealTiming = null;
+		mockSleepFoodCorrelation = null;
+		mockWeightFoodSeries = null;
+		mockExtendedNutrients = null;
+		mockDailyNutrients = null;
+		mockMealTypes = [];
+		mockDayProperties = null;
+		mockCalendarStats = null;
+		mockComputedAverages = null;
+		mockDateRangeEntries = [];
+		mockFastingDays = new Set();
 	});
 
 	describe('handleSearchFoods', () => {
@@ -1032,6 +1111,319 @@ describe('MCP handlers', () => {
 			const result = await handleSearchOpenFoodFacts('test', 3);
 			expect(result.products).toHaveLength(3);
 			expect(result.count).toBe(3);
+		});
+	});
+
+	describe('handleGetSupplementStatus (with date param)', () => {
+		test('returns checklist for explicit date', async () => {
+			mockSupplements = [TEST_SUPPLEMENT];
+			mockSupplementLogs = [];
+			const result = await handleGetSupplementStatus(TEST_USER.id, '2026-02-09');
+			expect(result.date).toBe('2026-02-09');
+			expect(result.total).toBe(1);
+			expect(result.pending).toBe(1);
+		});
+	});
+
+	describe('handleLogSleep', () => {
+		test('returns success with entryId and entry', async () => {
+			mockCreateSleepResult = { id: 'sleep-1', durationMinutes: 480, quality: 4 };
+			const result = await handleLogSleep(TEST_USER.id, {
+				durationMinutes: 480,
+				quality: 4
+			});
+			expect(result.success).toBe(true);
+			expect(result.entryId).toBe('sleep-1');
+			expect(result.entry).toBeDefined();
+		});
+
+		test('returns error on validation failure', async () => {
+			mockCreateSleepResult = null;
+			const result = await handleLogSleep(TEST_USER.id, {
+				durationMinutes: 480,
+				quality: 4
+			});
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleGetSleep', () => {
+		test('returns latest sleep when no range', async () => {
+			mockLatestSleep = { id: 'sleep-1', durationMinutes: 480, quality: 4 };
+			const result = (await handleGetSleep(TEST_USER.id, {})) as any;
+			expect(result.id).toBe('sleep-1');
+		});
+
+		test('returns error when no entries and no range', async () => {
+			mockLatestSleep = null;
+			const result = (await handleGetSleep(TEST_USER.id, {})) as any;
+			expect(result.error).toBe('No sleep entries found');
+		});
+
+		test('returns entries for date range', async () => {
+			mockSleepEntries = [
+				{ id: 'sleep-1', durationMinutes: 480, quality: 4, entryDate: '2026-02-10' }
+			];
+			const result = (await handleGetSleep(TEST_USER.id, {
+				from: '2026-02-01',
+				to: '2026-02-10'
+			})) as any;
+			expect(result.entries).toHaveLength(1);
+		});
+
+		test('respects limit when fetching range', async () => {
+			mockSleepEntries = [
+				{ id: 'sleep-1', durationMinutes: 480, quality: 4 },
+				{ id: 'sleep-2', durationMinutes: 420, quality: 3 },
+				{ id: 'sleep-3', durationMinutes: 360, quality: 2 }
+			];
+			const result = (await handleGetSleep(TEST_USER.id, {
+				from: '2026-02-01',
+				to: '2026-02-10',
+				limit: 2
+			})) as any;
+			expect(result.entries).toHaveLength(2);
+		});
+
+		test('returns error when only from provided', async () => {
+			const result = (await handleGetSleep(TEST_USER.id, { from: '2026-02-01' })) as any;
+			expect(result.error).toContain('Provide both');
+		});
+	});
+
+	describe('handleUpdateSleep', () => {
+		test('returns success on valid update', async () => {
+			mockUpdateSleepResult = { id: 'sleep-1', durationMinutes: 500, quality: 5 };
+			const result = await handleUpdateSleep(TEST_USER.id, {
+				id: 'sleep-1',
+				durationMinutes: 500,
+				quality: 5
+			});
+			expect(result.success).toBe(true);
+			expect(result.entryId).toBe('sleep-1');
+		});
+
+		test('accepts entryDate param', async () => {
+			mockUpdateSleepResult = { id: 'sleep-1', durationMinutes: 480, quality: 4 };
+			const result = await handleUpdateSleep(TEST_USER.id, {
+				id: 'sleep-1',
+				entryDate: '2026-02-09'
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('returns error on failure', async () => {
+			mockUpdateSleepResult = null;
+			const result = await handleUpdateSleep(TEST_USER.id, { id: 'nonexistent' });
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('handleDeleteSleep', () => {
+		test('returns success when entry found', async () => {
+			mockDeleteSleepResult = true;
+			const result = await handleDeleteSleep(TEST_USER.id, { id: 'sleep-1' });
+			expect(result.success).toBe(true);
+		});
+
+		test('returns error when not found', async () => {
+			mockDeleteSleepResult = null;
+			const result = await handleDeleteSleep(TEST_USER.id, { id: 'nonexistent' });
+			expect(result.error).toBe('Sleep entry not found');
+		});
+	});
+
+	describe('handleGetFoodDiversity', () => {
+		test('returns food diversity analytics data', async () => {
+			mockFoodDiversity = { uniqueFoods: 10, categories: [] };
+			const result = await handleGetFoodDiversity(TEST_USER.id, {
+				startDate: '2026-02-01',
+				endDate: '2026-02-28'
+			});
+			expect(result).toEqual(mockFoodDiversity);
+		});
+	});
+
+	describe('handleGetMealTiming', () => {
+		test('returns meal timing analytics data', async () => {
+			mockMealTiming = { averageMealTimes: [], mealFrequency: [] };
+			const result = await handleGetMealTiming(TEST_USER.id, {
+				startDate: '2026-02-01',
+				endDate: '2026-02-28'
+			});
+			expect(result).toEqual(mockMealTiming);
+		});
+	});
+
+	describe('handleGetSleepFoodCorrelation', () => {
+		test('returns sleep-food correlation data', async () => {
+			mockSleepFoodCorrelation = { correlation: 0.42, dataPoints: [] };
+			const result = await handleGetSleepFoodCorrelation(TEST_USER.id, {
+				startDate: '2026-02-01',
+				endDate: '2026-02-28'
+			});
+			expect(result).toEqual(mockSleepFoodCorrelation);
+		});
+	});
+
+	describe('handleGetWeightFoodSeries', () => {
+		test('returns weight-food series data', async () => {
+			mockWeightFoodSeries = { series: [] };
+			const result = await handleGetWeightFoodSeries(TEST_USER.id, {
+				startDate: '2026-02-01',
+				endDate: '2026-02-28'
+			});
+			expect(result).toEqual(mockWeightFoodSeries);
+		});
+	});
+
+	describe('handleGetExtendedNutrients', () => {
+		test('returns extended nutrient entries', async () => {
+			mockExtendedNutrients = { days: [], averages: {} };
+			const result = await handleGetExtendedNutrients(TEST_USER.id, {
+				startDate: '2026-02-01',
+				endDate: '2026-02-28'
+			});
+			expect(result).toEqual(mockExtendedNutrients);
+		});
+	});
+
+	describe('handleGetDailyNutrients', () => {
+		test('returns daily nutrient totals', async () => {
+			mockDailyNutrients = [{ date: '2026-02-10', vitaminD: 20, calcium: 800 }];
+			const result = await handleGetDailyNutrients(TEST_USER.id, {
+				startDate: '2026-02-10',
+				endDate: '2026-02-10'
+			});
+			expect(result).toEqual(mockDailyNutrients);
+		});
+	});
+
+	describe('handleListMealTypes', () => {
+		test('returns meal types', async () => {
+			mockMealTypes = [TEST_MEAL_TYPE];
+			const result = await handleListMealTypes(TEST_USER.id);
+			expect(result.mealTypes).toHaveLength(1);
+			expect(result.mealTypes[0].name).toBe('Pre-Workout');
+		});
+
+		test('returns empty array when no custom meal types', async () => {
+			mockMealTypes = [];
+			const result = await handleListMealTypes(TEST_USER.id);
+			expect(result.mealTypes).toEqual([]);
+		});
+	});
+
+	describe('handleGetSupplementHistory', () => {
+		test('returns supplement history for date range', async () => {
+			mockSupplementHistory = [
+				{ supplementId: TEST_SUPPLEMENT.id, date: '2026-02-10', takenAt: new Date() }
+			];
+			const result = await handleGetSupplementHistory(TEST_USER.id, {
+				from: '2026-02-01',
+				to: '2026-02-28'
+			});
+			expect(result.history).toHaveLength(1);
+		});
+
+		test('returns empty history when no logs in range', async () => {
+			mockSupplementHistory = [];
+			const result = await handleGetSupplementHistory(TEST_USER.id, {
+				from: '2026-01-01',
+				to: '2026-01-31'
+			});
+			expect(result.history).toEqual([]);
+		});
+	});
+
+	describe('handleGetDayProperties', () => {
+		test('returns day properties for date', async () => {
+			mockDayProperties = { isFastingDay: true };
+			const result = await handleGetDayProperties(TEST_USER.id, { date: '2026-02-10' });
+			expect(result.date).toBe('2026-02-10');
+			expect(result.properties).toEqual(mockDayProperties);
+		});
+
+		test('returns null properties when none set', async () => {
+			mockDayProperties = null;
+			const result = await handleGetDayProperties(TEST_USER.id, { date: '2026-02-10' });
+			expect(result.date).toBe('2026-02-10');
+			expect(result.properties).toBeNull();
+		});
+	});
+
+	describe('handleSetDayProperties', () => {
+		test('returns success and properties', async () => {
+			mockDayProperties = { isFastingDay: true };
+			const result = await handleSetDayProperties(TEST_USER.id, {
+				date: '2026-02-10',
+				isFastingDay: true
+			});
+			expect(result.success).toBe(true);
+			expect(result.properties).toEqual(mockDayProperties);
+		});
+	});
+
+	describe('handleDeleteDayProperties', () => {
+		test('returns success', async () => {
+			const result = await handleDeleteDayProperties(TEST_USER.id, { date: '2026-02-10' });
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('handleGetCalendarStats', () => {
+		test('returns calendar stats for month', async () => {
+			mockCalendarStats = { days: [], totalDays: 28 };
+			const result = await handleGetCalendarStats(TEST_USER.id, { month: '2026-02' });
+			expect(result).toEqual(mockCalendarStats);
+		});
+	});
+
+	describe('handleGetWeeklyStats (with date range)', () => {
+		test('uses computeAverages when startDate and endDate provided', async () => {
+			mockComputedAverages = { calories: 1900, protein: 145 };
+			mockDateRangeEntries = [TEST_ENTRY];
+			mockFastingDays = new Set(['2026-02-05']);
+			const result = await handleGetWeeklyStats(TEST_USER.id, '2026-02-01', '2026-02-07');
+			expect(result).toEqual(mockComputedAverages);
+		});
+
+		test('uses getWeeklyStats when no date range provided', async () => {
+			mockWeeklyStats = { calories: 2000, protein: 150 };
+			const result = await handleGetWeeklyStats(TEST_USER.id);
+			expect(result).toEqual(mockWeeklyStats);
+		});
+	});
+
+	describe('handleGetMonthlyStats (with date range)', () => {
+		test('uses computeAverages when startDate and endDate provided', async () => {
+			mockComputedAverages = { calories: 1850, protein: 140 };
+			mockDateRangeEntries = [TEST_ENTRY];
+			mockFastingDays = new Set();
+			const result = await handleGetMonthlyStats(TEST_USER.id, '2026-01-01', '2026-01-31');
+			expect(result).toEqual(mockComputedAverages);
+		});
+
+		test('uses getMonthlyStats when no date range provided', async () => {
+			mockMonthlyStats = { calories: 1800, protein: 140 };
+			const result = await handleGetMonthlyStats(TEST_USER.id);
+			expect(result).toEqual(mockMonthlyStats);
+		});
+	});
+
+	describe('handleSearchFoods (with limit and offset)', () => {
+		test('passes limit param through', async () => {
+			mockFoods = [TEST_FOOD];
+			mockRecentFoods = [];
+			const result = await handleSearchFoods(TEST_USER.id, 'Oats', 10);
+			expect(result.foods).toHaveLength(1);
+		});
+
+		test('passes offset param through', async () => {
+			mockFoods = [];
+			mockRecentFoods = [];
+			const result = await handleSearchFoods(TEST_USER.id, 'Oats', 10, 5);
+			expect(result.foods).toHaveLength(0);
 		});
 	});
 });

--- a/tests/server/mcp-handlers.test.ts
+++ b/tests/server/mcp-handlers.test.ts
@@ -640,7 +640,7 @@ describe('MCP handlers', () => {
 	describe('handleGetWeeklyStats', () => {
 		test('returns weekly stats', async () => {
 			mockWeeklyStats = { calories: 2000, protein: 150 };
-			const result = await handleGetWeeklyStats(TEST_USER.id);
+			const result = (await handleGetWeeklyStats(TEST_USER.id)) as any;
 			expect(result.calories).toBe(2000);
 		});
 	});
@@ -648,7 +648,7 @@ describe('MCP handlers', () => {
 	describe('handleGetMonthlyStats', () => {
 		test('returns monthly stats', async () => {
 			mockMonthlyStats = { calories: 1800, protein: 140 };
-			const result = await handleGetMonthlyStats(TEST_USER.id);
+			const result = (await handleGetMonthlyStats(TEST_USER.id)) as any;
 			expect(result.calories).toBe(1800);
 		});
 	});
@@ -991,10 +991,10 @@ describe('MCP handlers', () => {
 			mockDailyBreakdown = [
 				{ date: '2026-02-10', calories: 2000, protein: 150, carbs: 200, fat: 67, fiber: 30 }
 			];
-			const result = await handleGetDailyBreakdown(TEST_USER.id, {
+			const result = (await handleGetDailyBreakdown(TEST_USER.id, {
 				startDate: '2026-02-10',
 				endDate: '2026-02-10'
-			});
+			})) as any;
 			expect(result).toHaveLength(1);
 			expect(result[0].calories).toBe(2000);
 		});
@@ -1007,6 +1007,22 @@ describe('MCP handlers', () => {
 			});
 			expect(result).toEqual([]);
 		});
+
+		test('rejects date range exceeding 366 days', async () => {
+			const result = (await handleGetDailyBreakdown(TEST_USER.id, {
+				startDate: '2020-01-01',
+				endDate: '2026-02-07'
+			})) as any;
+			expect(result.error).toContain('exceeds maximum');
+		});
+
+		test('rejects inverted date range', async () => {
+			const result = (await handleGetDailyBreakdown(TEST_USER.id, {
+				startDate: '2026-02-07',
+				endDate: '2026-02-01'
+			})) as any;
+			expect(result.error).toContain('before');
+		});
 	});
 
 	describe('handleGetMealBreakdown', () => {
@@ -1014,10 +1030,10 @@ describe('MCP handlers', () => {
 			mockMealBreakdown = [
 				{ mealType: 'breakfast', calories: 500, protein: 30, carbs: 60, fat: 15, fiber: 8 }
 			];
-			const result = await handleGetMealBreakdown(TEST_USER.id, {
+			const result = (await handleGetMealBreakdown(TEST_USER.id, {
 				startDate: '2026-02-01',
 				endDate: '2026-02-07'
-			});
+			})) as any;
 			expect(result).toHaveLength(1);
 			expect(result[0].mealType).toBe('breakfast');
 		});
@@ -1319,19 +1335,19 @@ describe('MCP handlers', () => {
 			mockSupplementHistory = [
 				{ supplementId: TEST_SUPPLEMENT.id, date: '2026-02-10', takenAt: new Date() }
 			];
-			const result = await handleGetSupplementHistory(TEST_USER.id, {
+			const result = (await handleGetSupplementHistory(TEST_USER.id, {
 				from: '2026-02-01',
 				to: '2026-02-28'
-			});
+			})) as any;
 			expect(result.history).toHaveLength(1);
 		});
 
 		test('returns empty history when no logs in range', async () => {
 			mockSupplementHistory = [];
-			const result = await handleGetSupplementHistory(TEST_USER.id, {
+			const result = (await handleGetSupplementHistory(TEST_USER.id, {
 				from: '2026-01-01',
 				to: '2026-01-31'
-			});
+			})) as any;
 			expect(result.history).toEqual([]);
 		});
 	});

--- a/tests/utils/mcp-tools.test.ts
+++ b/tests/utils/mcp-tools.test.ts
@@ -23,7 +23,17 @@ const READ_ONLY_TOOLS = [
 	'get_supplement_status',
 	'list_supplements',
 	'search_openfoodfacts',
-	'get_sleep'
+	'get_sleep',
+	'get_food_diversity',
+	'get_meal_timing',
+	'get_sleep_food_correlation',
+	'get_weight_food_series',
+	'get_extended_nutrients',
+	'get_daily_nutrients',
+	'list_meal_types',
+	'get_supplement_history',
+	'get_day_properties',
+	'get_calendar_stats'
 ] as const;
 
 const WRITE_TOOLS = [
@@ -34,9 +44,7 @@ const WRITE_TOOLS = [
 	'log_weight',
 	'create_supplement',
 	'copy_entries',
-	'log_sleep',
-	'update_sleep',
-	'delete_sleep'
+	'log_sleep'
 ] as const;
 
 const UPDATE_TOOLS = [
@@ -45,7 +53,9 @@ const UPDATE_TOOLS = [
 	'update_entry',
 	'update_goals',
 	'update_supplement',
-	'update_weight'
+	'update_weight',
+	'update_sleep',
+	'set_day_properties'
 ] as const;
 
 const DESTRUCTIVE_TOOLS = [
@@ -54,7 +64,9 @@ const DESTRUCTIVE_TOOLS = [
 	'delete_entry',
 	'delete_supplement',
 	'delete_weight',
-	'unlog_supplement'
+	'unlog_supplement',
+	'delete_sleep',
+	'delete_day_properties'
 ] as const;
 
 describe('tool annotations', () => {
@@ -105,9 +117,9 @@ describe('tool annotations', () => {
 		}
 	});
 
-	test('all 43 tools are classified', () => {
+	test('all 55 tools are classified', () => {
 		const all = [...READ_ONLY_TOOLS, ...WRITE_TOOLS, ...UPDATE_TOOLS, ...DESTRUCTIVE_TOOLS];
-		expect(all).toHaveLength(43);
+		expect(all).toHaveLength(55);
 		for (const name of toolNames) {
 			expect(all, `${name} should be classified`).toContain(name);
 		}
@@ -159,11 +171,23 @@ describe('toolNames', () => {
 			'log_sleep',
 			'get_sleep',
 			'update_sleep',
-			'delete_sleep'
+			'delete_sleep',
+			'get_food_diversity',
+			'get_meal_timing',
+			'get_sleep_food_correlation',
+			'get_weight_food_series',
+			'get_extended_nutrients',
+			'get_daily_nutrients',
+			'list_meal_types',
+			'get_supplement_history',
+			'get_day_properties',
+			'set_day_properties',
+			'delete_day_properties',
+			'get_calendar_stats'
 		] as const;
 		for (const name of expected) {
 			expect(toolNames).toContain(name);
 		}
-		expect(toolNames).toHaveLength(43);
+		expect(toolNames).toHaveLength(55);
 	});
 });


### PR DESCRIPTION
## Summary

- Add 12 new MCP tools: 6 analytics (food diversity, meal timing, sleep-food correlation, weight-food series, extended/daily nutrients), meal types listing, supplement history, day properties CRUD, and calendar stats
- All tools include Zod schema validation, read-only/update/destructive annotations, and date range guards
- Comprehensive test coverage for all 55 tools (12 new + 43 existing)

## Changes

- `src/lib/server/mcp/server.ts` — register 12 new tools with schemas and annotations
- `src/lib/server/mcp/create-handlers.ts` — implement 12 new handler functions
- `src/lib/server/mcp/handlers.ts` — export new handler mappings
- `src/lib/server/mcp/tools.ts` — add tool names to registry (43 → 55)
- `tests/server/mcp-handlers.test.ts` — tests for all 12 new handlers
- `tests/utils/mcp-tools.test.ts` — tool classification tests updated for 55 tools

## Verification

- [x] `bun run check` — type checking passes
- [x] `bun run test` — 128 files, 1755 tests pass
- [x] `bun run security` — Semgrep, dependency audit, Trivy all clean

## Test plan

- [ ] Verify MCP tools respond correctly via Claude desktop/API
- [ ] Test analytics tools with date range parameters
- [ ] Test day properties CRUD operations
- [ ] Confirm backward compatibility with existing 43 tools