### PR TITLE
fix: stop reporting UnauthorizedException to Sentry

### DIFF
--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/SentryErrorReporter.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/SentryErrorReporter.kt
@@ -1,10 +1,12 @@
 package com.bissbilanz.android
 
 import com.bissbilanz.ErrorReporter
+import com.bissbilanz.api.UnauthorizedException
 import io.sentry.Sentry
 
 class SentryErrorReporter : ErrorReporter {
     override fun captureException(e: Throwable) {
+        if (e is UnauthorizedException) return
         Sentry.captureException(e)
     }
 }


### PR DESCRIPTION
## Summary

- Filter `UnauthorizedException` in `SentryErrorReporter` so expired-session errors are never reported as bugs
- Centralizes the filter at the reporter level instead of adding catch blocks to each of the 69 call sites

## Context

Sentry issues BISSBILANZ-1B (232 events) and BISSBILANZ-1C (3 events) were caused by `UnauthorizedException` being sent to Sentry from `RefreshManager`, widget workers, repositories, and ViewModels. When a token refresh fails, `AuthManager` already sets `SessionExpired` state to trigger the login screen — the exception is expected behavior, not a bug.

## Changes

- `SentryErrorReporter.kt` — return early for `UnauthorizedException` before calling `Sentry.captureException()`

## Test plan

- [ ] Verify Sentry no longer receives `UnauthorizedException` events after session expiry
- [ ] Verify real errors (network failures, server errors) are still reported to Sentry
- [ ] Verify the app still transitions to login screen when session expires