### PR TITLE
feat: add /api/health endpoint

### DIFF
--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,0 +1,6 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+	return json({ status: 'ok' });
+};


### PR DESCRIPTION
## Summary
- Adds a `/api/health` GET endpoint that returns `{ status: "ok" }`
- Fixes the `mobile-android-e2e` workflow which was failing because it health-checked a non-existent route

## Test plan
- [x] Endpoint follows project conventions (SvelteKit handler, `json()` response)
- [x] No auth required — consistent with other `/api/*` routes being public-path exempt
- [x] Code reviewed by code-reviewer agent — no issues found