### PR TITLE
chore: remove debug console statements from src

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -55,10 +55,8 @@ export async function withDbRetry<T>(fn: () => Promise<T>): Promise<T> {
 export async function runMigrations(): Promise<void> {
 	const database = getDB();
 	const migrationsPath = join(process.cwd(), 'drizzle');
-	console.log(`Running database migrations from ${migrationsPath}...`);
 	try {
 		await migrate(database, { migrationsFolder: migrationsPath });
-		console.log('Migrations completed successfully');
 	} catch (error) {
 		console.error('Migration failed:', error);
 		throw error;


### PR DESCRIPTION
## Summary
- Remove two `console.log` calls in `runMigrations()` that logged migration start/success messages
- All `console.error` calls in server-side catch blocks are intentional and retained

## What was kept
- `console.error` in `hooks.server.ts` (startup/session-cleanup error reporting)
- `console.error` in `lib/server/db.ts` (migration failure — rethrows after logging)
- `console.error` in `lib/server/errors.ts` (unhandled error handler)
- `console.error` in `lib/stores/auth.svelte.ts` (client-side, only error reporting mechanism)
- `console.error` in MCP settings page server and OAuth consent server (catch blocks)

## What was removed
- `console.log` for migration progress messages (not errors, just noise)