### PR TITLE
perf: project columns in food-duplicates query

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5937,11 +5937,46 @@
 					"foods": {
 						"type": "array",
 						"items": {
-							"$ref": "#/components/schemas/Food"
+							"$ref": "#/components/schemas/FoodDuplicateFood"
 						}
 					}
 				},
 				"required": ["reason", "key", "foods"],
+				"additionalProperties": false
+			},
+			"FoodDuplicateFood": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string",
+						"format": "uuid",
+						"pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+					},
+					"name": {
+						"type": "string"
+					},
+					"brand": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"barcode": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "null"
+							}
+						]
+					}
+				},
+				"required": ["id", "name", "brand", "barcode"],
 				"additionalProperties": false
 			},
 			"ConflictErrorResponse": {

--- a/src/lib/api/generated/schema.d.ts
+++ b/src/lib/api/generated/schema.d.ts
@@ -1297,7 +1297,14 @@ export interface components {
 			/** @enum {string} */
 			reason: 'barcode' | 'name_brand';
 			key: string;
-			foods: components['schemas']['Food'][];
+			foods: components['schemas']['FoodDuplicateFood'][];
+		};
+		FoodDuplicateFood: {
+			/** Format: uuid */
+			id: string;
+			name: string;
+			brand: string | null;
+			barcode: string | null;
 		};
 		ConflictErrorResponse: {
 			error: string;

--- a/src/lib/server/food-duplicates.ts
+++ b/src/lib/server/food-duplicates.ts
@@ -1,9 +1,18 @@
 import { getDB } from '$lib/server/db';
 import { foods } from '$lib/server/schema';
 import { and, eq } from 'drizzle-orm';
-import { roundNutrition } from '$lib/utils/round-nutrition';
 
-type Food = typeof foods.$inferSelect;
+/**
+ * Narrow projection returned for duplicate detection. We only need the fields
+ * used to compute group membership (name, brand, barcode) plus the id so the
+ * client can resolve the full food locally from its cached list.
+ */
+export type DuplicateFood = {
+	id: string;
+	name: string;
+	brand: string | null;
+	barcode: string | null;
+};
 
 export type DuplicateReason = 'barcode' | 'name_brand';
 
@@ -11,7 +20,7 @@ export type DuplicateGroup = {
 	reason: DuplicateReason;
 	/** Stable key per group: barcode value or normalized "name|brand" */
 	key: string;
-	foods: Food[];
+	foods: DuplicateFood[];
 };
 
 /**
@@ -65,7 +74,7 @@ const NAME_SIMILARITY_THRESHOLD = 0.4;
  *
  * For pairs (n=2) this collapses to a single similarity check.
  */
-function barcodeGroupNamesAreSimilar(groupFoods: Food[]): boolean {
+function barcodeGroupNamesAreSimilar(groupFoods: DuplicateFood[]): boolean {
 	if (groupFoods.length < 2) return false;
 	for (const a of groupFoods) {
 		const hasSimilarPeer = groupFoods.some(
@@ -92,12 +101,17 @@ function barcodeGroupNamesAreSimilar(groupFoods: Food[]): boolean {
 export async function findDuplicateGroups(userId: string): Promise<DuplicateGroup[]> {
 	const db = getDB();
 	const all = await db
-		.select()
+		.select({
+			id: foods.id,
+			name: foods.name,
+			brand: foods.brand,
+			barcode: foods.barcode
+		})
 		.from(foods)
 		.where(and(eq(foods.userId, userId), eq(foods.kind, 'food')));
 
-	const byBarcode = new Map<string, Food[]>();
-	const byNameBrand = new Map<string, Food[]>();
+	const byBarcode = new Map<string, DuplicateFood[]>();
+	const byNameBrand = new Map<string, DuplicateFood[]>();
 
 	for (const food of all) {
 		if (food.barcode) {
@@ -122,7 +136,7 @@ export async function findDuplicateGroups(userId: string): Promise<DuplicateGrou
 		groups.push({
 			reason: 'barcode',
 			key,
-			foods: items.map((f) => roundNutrition(f))
+			foods: items
 		});
 	}
 
@@ -131,7 +145,7 @@ export async function findDuplicateGroups(userId: string): Promise<DuplicateGrou
 		groups.push({
 			reason: 'name_brand',
 			key,
-			foods: items.map((f) => roundNutrition(f))
+			foods: items
 		});
 	}
 

--- a/src/lib/server/validation/responses/foods.ts
+++ b/src/lib/server/validation/responses/foods.ts
@@ -72,11 +72,20 @@ export const foodsRecentResponseSchema = z
 	})
 	.meta({ id: 'FoodsRecentResponse' });
 
+export const foodDuplicateFoodSchema = z
+	.object({
+		id: z.string().uuid(),
+		name: z.string(),
+		brand: z.string().nullable(),
+		barcode: z.string().nullable()
+	})
+	.meta({ id: 'FoodDuplicateFood' });
+
 export const foodDuplicateGroupSchema = z
 	.object({
 		reason: z.enum(['barcode', 'name_brand']),
 		key: z.string(),
-		foods: z.array(foodSchema)
+		foods: z.array(foodDuplicateFoodSchema)
 	})
 	.meta({ id: 'FoodDuplicateGroup' });
 

--- a/src/routes/(app)/foods/+page.svelte
+++ b/src/routes/(app)/foods/+page.svelte
@@ -62,7 +62,11 @@
 	};
 
 	const openMergeFromGroup = (group: components['schemas']['FoodDuplicateGroup']) => {
-		mergeCandidates = group.foods;
+		const pool = (allFoodsQuery.value as unknown as components['schemas']['Food'][]) ?? [];
+		const byId = new Map(pool.map((f) => [f.id, f]));
+		mergeCandidates = group.foods
+			.map((f) => byId.get(f.id))
+			.filter((f): f is components['schemas']['Food'] => f !== undefined);
 		mergeOpen = true;
 	};
 

--- a/src/routes/(app)/foods/duplicates/+page.svelte
+++ b/src/routes/(app)/foods/duplicates/+page.svelte
@@ -25,6 +25,7 @@
 
 	const allFoodsQuery = useLiveQuery(() => foodService.allFoods(), []);
 	const allFoods = $derived(allFoodsQuery.value as unknown as Food[]);
+	const foodById = $derived(new Map(allFoods.map((f) => [f.id, f])));
 
 	async function refresh() {
 		loading = true;
@@ -41,7 +42,9 @@
 	});
 
 	function resolve(group: DuplicateGroup) {
-		mergeCandidates = group.foods;
+		mergeCandidates = group.foods
+			.map((f) => foodById.get(f.id))
+			.filter((f): f is Food => f !== undefined);
 		mergeOpen = true;
 	}
 </script>
@@ -85,6 +88,7 @@
 					</Card.Header>
 					<Card.Content class="space-y-2 pb-4">
 						{#each group.foods as food (food.id)}
+							{@const full = foodById.get(food.id)}
 							<div
 								class="flex items-center justify-between gap-3 rounded-md border bg-background p-2.5"
 							>
@@ -101,9 +105,11 @@
 										<p class="truncate text-xs text-muted-foreground">{food.brand}</p>
 									{/if}
 								</div>
-								<div class="shrink-0 text-right text-xs tabular-nums text-muted-foreground">
-									{Math.round(food.calories)} kcal
-								</div>
+								{#if full}
+									<div class="shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+										{Math.round(full.calories)} kcal
+									</div>
+								{/if}
 							</div>
 						{/each}
 					</Card.Content>


### PR DESCRIPTION
## Summary

- `findDuplicateGroups` was pulling every row from `foods` (~60 nutrition columns) just to Levenshtein over `name` / `brand` / `barcode`. Project only the four columns the grouping logic actually reads (`id`, `name`, `brand`, `barcode`).
- Narrow the returned type (`DuplicateFood`) and the OpenAPI `FoodDuplicateGroup` schema to match.
- Update `/foods` and `/foods/duplicates` so the merge dialog resolves the full `Food` from the client-side `foodService` cache by id; the duplicates page reads `calories` for display from the same cache.

Does not introduce `pg_trgm` — that's left for a separate change.

Closes #194

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun run test tests/server/food-duplicates.test.ts` — 11/11 pass
- [ ] Manual: open `/foods/duplicates`, confirm groups render with calories, merge dialog opens with full nutrient data for diff rows