### PR TITLE
feat(ios): iOS feature parity — sleep tracking, HealthKit write-through, insights, polish

### DIFF
--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -322,6 +322,30 @@ final class BissbilanzAPI {
         try await get("/api/weight/stats")
     }
 
+    // MARK: - Sleep
+
+    func getSleepEntries(from: String? = nil, to: String? = nil) async throws -> [SleepEntry] {
+        var params: [String: String] = [:]
+        if let from { params["from"] = from }
+        if let to { params["to"] = to }
+        let response: SleepEntriesResponse = try await get("/api/sleep", params: params)
+        return response.entries
+    }
+
+    func createSleepEntry(_ entry: SleepCreate) async throws -> SleepEntry {
+        let response: SleepEntryResponse = try await post("/api/sleep", body: entry)
+        return response.entry
+    }
+
+    func updateSleepEntry(id: String, _ update: SleepUpdate) async throws -> SleepEntry {
+        let response: SleepEntryResponse = try await patch("/api/sleep/\(id)", body: update)
+        return response.entry
+    }
+
+    func deleteSleepEntry(id: String) async throws {
+        try await deleteRequest("/api/sleep/\(id)")
+    }
+
     // MARK: - Open Food Facts proxy
 
     func lookupBarcode(_ barcode: String) async throws -> Food? {

--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -346,6 +346,48 @@ final class BissbilanzAPI {
         try await deleteRequest("/api/sleep/\(id)")
     }
 
+    // MARK: - Analytics
+
+    func getFoodDiversity(startDate: String, endDate: String) async throws -> [FoodDiversityEntry] {
+        let r: FoodDiversityResponse = try await get("/api/analytics/food-diversity", params: [
+            "startDate": startDate,
+            "endDate": endDate,
+        ])
+        return r.data
+    }
+
+    func getMealTiming(startDate: String, endDate: String) async throws -> [MealTimingEntry] {
+        let r: MealTimingResponse = try await get("/api/analytics/meal-timing", params: [
+            "startDate": startDate,
+            "endDate": endDate,
+        ])
+        return r.data
+    }
+
+    func getWeightFood(startDate: String, endDate: String) async throws -> [DailyWeightFood] {
+        let r: DailyWeightFoodResponse = try await get("/api/analytics/weight-food", params: [
+            "startDate": startDate,
+            "endDate": endDate,
+        ])
+        return r.data
+    }
+
+    func getSleepFood(startDate: String, endDate: String) async throws -> [SleepFoodCorrelationEntry] {
+        let r: SleepFoodCorrelationResponse = try await get("/api/analytics/sleep-food", params: [
+            "startDate": startDate,
+            "endDate": endDate,
+        ])
+        return r.data
+    }
+
+    func getNutrientsExtended(startDate: String, endDate: String) async throws -> [ExtendedNutrientEntry] {
+        let r: ExtendedNutrientResponse = try await get("/api/analytics/nutrients-extended", params: [
+            "startDate": startDate,
+            "endDate": endDate,
+        ])
+        return r.data
+    }
+
     // MARK: - Open Food Facts proxy
 
     func lookupBarcode(_ barcode: String) async throws -> Food? {

--- a/mobile/iosApp/Bissbilanz/Models/Analytics.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Analytics.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+struct FoodDiversityEntry: Codable {
+    let date: String
+    let foodId: String?
+    let recipeId: String?
+    let foodName: String
+    let novaGroup: Int?
+}
+
+struct FoodDiversityResponse: Codable {
+    let data: [FoodDiversityEntry]
+}
+
+struct MealTimingEntry: Codable {
+    let date: String
+    let mealType: String
+    let eatenAt: String
+    let foodId: String?
+    let recipeId: String?
+    let calories: Double
+    let foodName: String
+}
+
+struct MealTimingResponse: Codable {
+    let data: [MealTimingEntry]
+}
+
+struct DailyWeightFood: Codable {
+    let date: String
+    let calories: Double?
+    let weightKg: Double?
+    let movingAvg: Double?
+}
+
+struct DailyWeightFoodResponse: Codable {
+    let data: [DailyWeightFood]
+}
+
+struct SleepFoodCorrelationEntry: Codable {
+    let date: String
+    let eveningCalories: Double?
+    let sleepDurationMinutes: Int
+    let sleepQuality: Int
+}
+
+struct SleepFoodCorrelationResponse: Codable {
+    let data: [SleepFoodCorrelationEntry]
+}
+
+struct ExtendedNutrientEntry: Codable {
+    let date: String
+    let mealType: String
+    let eatenAt: String
+    let foodId: String?
+    let recipeId: String?
+    let foodName: String
+    let calories: Double
+    let protein: Double
+    let carbs: Double
+    let fat: Double
+    let fiber: Double
+    let novaGroup: Int?
+    let omega3: Double?
+    let omega6: Double?
+    let sodium: Double?
+    let caffeine: Double?
+    let saturatedFat: Double?
+    let transFat: Double?
+    let vitaminC: Double?
+    let vitaminD: Double?
+    let vitaminE: Double?
+    let alcohol: Double?
+    let addedSugars: Double?
+}
+
+struct ExtendedNutrientResponse: Codable {
+    let data: [ExtendedNutrientEntry]
+}

--- a/mobile/iosApp/Bissbilanz/Models/Recipe.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Recipe.swift
@@ -50,11 +50,11 @@ struct RecipeIngredientInput: Codable {
 }
 
 struct RecipeUpdate: Codable {
-    var name: String?
-    var totalServings: Double?
-    var ingredients: [RecipeIngredientInput]?
-    var isFavorite: Bool?
-    var imageUrl: String?
+    var name: String? = nil
+    var totalServings: Double? = nil
+    var ingredients: [RecipeIngredientInput]? = nil
+    var isFavorite: Bool? = nil
+    var imageUrl: String? = nil
 }
 
 struct RecipesResponse: Codable {

--- a/mobile/iosApp/Bissbilanz/Models/Sleep.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Sleep.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct SleepEntry: Codable, Identifiable {
+    let id: String
+    let userId: String?
+    let entryDate: String
+    let durationMinutes: Int
+    let quality: Int
+    let bedtime: String?
+    let wakeTime: String?
+    let wakeUps: Int?
+    let notes: String?
+    let loggedAt: String?
+    let createdAt: String?
+    let updatedAt: String?
+}
+
+struct SleepCreate: Codable {
+    let entryDate: String
+    let durationMinutes: Int
+    let quality: Int
+    var bedtime: String?
+    var wakeTime: String?
+    var wakeUps: Int?
+    var notes: String?
+}
+
+struct SleepUpdate: Codable {
+    var entryDate: String?
+    var durationMinutes: Int?
+    var quality: Int?
+    var bedtime: String?
+    var wakeTime: String?
+    var wakeUps: Int?
+    var notes: String?
+}
+
+struct SleepEntriesResponse: Codable {
+    let entries: [SleepEntry]
+}
+
+struct SleepEntryResponse: Codable {
+    let entry: SleepEntry
+}

--- a/mobile/iosApp/Bissbilanz/Sheets/MealPickerSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/MealPickerSheet.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct MealPickerSheet: View {
+    @Environment(BissbilanzAPI.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let onPick: (String) -> Void
+
+    @State private var mealTypes: [MealType] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    LoadingView()
+                } else {
+                    List(mealTypes) { mealType in
+                        Button {
+                            onPick(mealType.name)
+                            dismiss()
+                        } label: {
+                            Text(L10n.mealName(mealType.name))
+                                .foregroundStyle(.primary)
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle(L10n.chooseMeal)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.cancel) { dismiss() }
+                }
+            }
+            .task { await loadMealTypes() }
+        }
+    }
+
+    private func loadMealTypes() async {
+        isLoading = true
+        do {
+            mealTypes = try await api.getMealTypes()
+        } catch {
+            mealTypes = []
+        }
+        isLoading = false
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Sheets/SleepEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/SleepEditSheet.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+
+struct SleepEditSheet: View {
+    @Environment(BissbilanzAPI.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let existingEntry: SleepEntry?
+    let onSaved: () -> Void
+
+    @State private var entryDate = Date()
+    @State private var durationHours = 7
+    @State private var durationMinutes = 30
+    @State private var quality = 7
+    @State private var hasBedtime = false
+    @State private var bedtime = Calendar.current.date(bySettingHour: 23, minute: 0, second: 0, of: Date()) ?? Date()
+    @State private var hasWakeTime = false
+    @State private var wakeTime = Calendar.current.date(bySettingHour: 7, minute: 0, second: 0, of: Date()) ?? Date()
+    @State private var hasWakeUps = false
+    @State private var wakeUps = 0
+    @State private var notes = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(existingEntry: SleepEntry? = nil, onSaved: @escaping () -> Void) {
+        self.existingEntry = existingEntry
+        self.onSaved = onSaved
+    }
+
+    private var isValid: Bool {
+        durationHours > 0 || durationMinutes > 0
+    }
+
+    private var totalDurationMinutes: Int {
+        durationHours * 60 + durationMinutes
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    DatePicker(L10n.today, selection: $entryDate, displayedComponents: .date)
+                }
+
+                Section(L10n.sleepDuration) {
+                    Stepper(value: $durationHours, in: 0 ... 23) {
+                        HStack {
+                            Text(L10n.sleepDuration)
+                            Spacer()
+                            Text("\(durationHours)h")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Stepper(value: $durationMinutes, in: 0 ... 59, step: 5) {
+                        HStack {
+                            Text(L10n.minutes)
+                            Spacer()
+                            Text("\(durationMinutes)m")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Section(L10n.sleepQuality) {
+                    Stepper(value: $quality, in: 1 ... 10) {
+                        HStack {
+                            Text(L10n.sleepQuality)
+                            Spacer()
+                            Text("\(quality) / 10")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Section(L10n.bedtime) {
+                    Toggle(L10n.bedtime, isOn: $hasBedtime)
+                    if hasBedtime {
+                        DatePicker(L10n.bedtime, selection: $bedtime, displayedComponents: .hourAndMinute)
+                            .labelsHidden()
+                    }
+                }
+
+                Section(L10n.wakeTime) {
+                    Toggle(L10n.wakeTime, isOn: $hasWakeTime)
+                    if hasWakeTime {
+                        DatePicker(L10n.wakeTime, selection: $wakeTime, displayedComponents: .hourAndMinute)
+                            .labelsHidden()
+                    }
+                }
+
+                Section(L10n.wakeUps) {
+                    Toggle(L10n.wakeUps, isOn: $hasWakeUps)
+                    if hasWakeUps {
+                        Stepper(value: $wakeUps, in: 0 ... 20) {
+                            HStack {
+                                Text(L10n.wakeUps)
+                                Spacer()
+                                Text("\(wakeUps)")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+
+                Section(L10n.notes) {
+                    TextField(L10n.notes, text: $notes, axis: .vertical)
+                        .lineLimit(3 ... 6)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                    }
+                }
+            }
+            .navigationTitle(existingEntry != nil ? L10n.editSleep : L10n.addSleep)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.cancel) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.save) {
+                        Task { await save() }
+                    }
+                    .disabled(!isValid || isSaving)
+                    .fontWeight(.semibold)
+                }
+            }
+            .onAppear { prefill() }
+        }
+    }
+
+    private func prefill() {
+        guard let entry = existingEntry else { return }
+        if let d = DateFormatting.date(from: entry.entryDate) {
+            entryDate = d
+        }
+        durationHours = entry.durationMinutes / 60
+        durationMinutes = entry.durationMinutes % 60
+        quality = entry.quality
+        notes = entry.notes ?? ""
+
+        if let bedtimeStr = entry.bedtime,
+           let parsed = parseISO(bedtimeStr)
+        {
+            hasBedtime = true
+            bedtime = parsed
+        }
+        if let wakeTimeStr = entry.wakeTime,
+           let parsed = parseISO(wakeTimeStr)
+        {
+            hasWakeTime = true
+            wakeTime = parsed
+        }
+        if let wu = entry.wakeUps {
+            hasWakeUps = true
+            wakeUps = wu
+        }
+    }
+
+    private func parseISO(_ string: String) -> Date? {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFractional.date(from: string) { return date }
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: string)
+    }
+
+    private func save() async {
+        guard isValid else { return }
+        isSaving = true
+        errorMessage = nil
+
+        let dateStr = DateFormatting.isoString(from: entryDate)
+        let iso = ISO8601DateFormatter()
+        let bedtimeStr = hasBedtime ? iso.string(from: bedtime) : nil
+        let wakeTimeStr = hasWakeTime ? iso.string(from: wakeTime) : nil
+
+        do {
+            if let existing = existingEntry {
+                let update = SleepUpdate(
+                    entryDate: dateStr,
+                    durationMinutes: totalDurationMinutes,
+                    quality: quality,
+                    bedtime: bedtimeStr,
+                    wakeTime: wakeTimeStr,
+                    wakeUps: hasWakeUps ? wakeUps : nil,
+                    notes: notes.isEmpty ? nil : notes
+                )
+                _ = try await api.updateSleepEntry(id: existing.id, update)
+            } else {
+                let create = SleepCreate(
+                    entryDate: dateStr,
+                    durationMinutes: totalDurationMinutes,
+                    quality: quality,
+                    bedtime: bedtimeStr,
+                    wakeTime: wakeTimeStr,
+                    wakeUps: hasWakeUps ? wakeUps : nil,
+                    notes: notes.isEmpty ? nil : notes
+                )
+                _ = try await api.createSleepEntry(create)
+            }
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            onSaved()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSaving = false
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -107,6 +107,7 @@ enum L10n {
     static var logFood: String { localized("log_food", en: "Log Food", de: "Essen eintragen") }
     static var servings: String { localized("servings", en: "Servings", de: "Portionen") }
     static var meal: String { localized("meal", en: "Meal", de: "Mahlzeit") }
+    static var chooseMeal: String { localized("choose_meal", en: "Choose Meal", de: "Mahlzeit wählen") }
     static var quickEntry: String { localized("quick_entry", en: "Quick Entry", de: "Schnelleintrag") }
     static var editEntry: String { localized("edit_entry", en: "Edit Entry", de: "Eintrag bearbeiten") }
     static var logRecipe: String { localized("log_recipe", en: "Log Recipe", de: "Rezept eintragen") }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -284,6 +284,22 @@ enum L10n {
     static var fatLabel: String { localized("fat_label", en: "Fat", de: "Fett") }
     static var muscleLabel: String { localized("muscle_label", en: "Muscle", de: "Muskel") }
 
+    // MARK: - Sleep
+
+    static var sleep: String { localized("sleep", en: "Sleep", de: "Schlaf") }
+    static var sleepDuration: String { localized("sleep_duration", en: "Duration", de: "Dauer") }
+    static var sleepQuality: String { localized("sleep_quality", en: "Quality", de: "Qualität") }
+    static var bedtime: String { localized("bedtime", en: "Bedtime", de: "Schlafenszeit") }
+    static var wakeTime: String { localized("wake_time", en: "Wake Time", de: "Aufwachzeit") }
+    static var wakeUps: String { localized("wake_ups", en: "Wake Ups", de: "Aufwachen") }
+    static var addSleep: String { localized("add_sleep", en: "Log Sleep", de: "Schlaf eintragen") }
+    static var editSleep: String { localized("edit_sleep", en: "Edit Sleep", de: "Schlaf bearbeiten") }
+    static var noSleepEntries: String { localized("no_sleep_entries", en: "No sleep entries yet.", de: "Noch keine Schlafeinträge.") }
+    static var nightsLogged: String { localized("nights_logged", en: "Nights", de: "Nächte") }
+    static var avgDuration: String { localized("avg_duration", en: "Avg Duration", de: "Ø Dauer") }
+    static var avgQuality: String { localized("avg_quality", en: "Avg Quality", de: "Ø Qualität") }
+    static var minutes: String { localized("minutes", en: "Minutes", de: "Minuten") }
+
     // MARK: - Supplement History (additional)
 
     static var taken: String { localized("taken", en: "Taken", de: "Eingenommen") }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -341,6 +341,35 @@ enum L10n {
         }
     }
 
+    // MARK: - Analytics
+
+    static var mealTiming: String { localized("meal_timing", en: "Meal Timing", de: "Mahlzeitenzeiten") }
+    static var foodDiversity: String { localized("food_diversity", en: "Food Diversity", de: "Lebensmittelvielfalt") }
+    static var uniqueFoods: String { localized("unique_foods", en: "Unique Foods", de: "Verschiedene Lebensmittel") }
+    static var totalLogged: String { localized("total_logged", en: "Total Logged", de: "Gesamt eingetragen") }
+    static var weightVsCalories: String { localized("weight_vs_calories", en: "Weight vs. Calories", de: "Gewicht vs. Kalorien") }
+    static var sleepVsCalories: String { localized("sleep_vs_calories", en: "Sleep vs. Evening Calories", de: "Schlaf vs. Abendkalorien") }
+    static var extendedNutrients: String { localized("extended_nutrients", en: "Extended Nutrients", de: "Erweiterte Nährstoffe") }
+    static var avgPerDay: String { localized("avg_per_day", en: "Avg per day", de: "Ø pro Tag") }
+    static var busiestHour: String { localized("busiest_hour", en: "Busiest hour", de: "Aktivste Stunde") }
+    static var novaDistribution: String { localized("nova_distribution", en: "NOVA Distribution", de: "NOVA-Verteilung") }
+    static var noAnalyticsData: String { localized("no_analytics_data", en: "No data for this period", de: "Keine Daten für diesen Zeitraum") }
+    static var hourLabel: String { localized("hour_label", en: "h", de: "Uhr") }
+    static var hoursLabel: String { localized("hours_label", en: "hrs", de: "Std") }
+    static var eveningCalories: String { localized("evening_calories", en: "Evening Calories", de: "Abendkalorien") }
+    static var sleepHours: String { localized("sleep_hours", en: "Sleep (hrs)", de: "Schlaf (Std)") }
+    static var unknown: String { localized("unknown", en: "Unknown", de: "Unbekannt") }
+    static var omega3Label: String { localized("omega3_label", en: "Omega-3", de: "Omega-3") }
+    static var omega6Label: String { localized("omega6_label", en: "Omega-6", de: "Omega-6") }
+    static var sodiumLabel: String { localized("sodium_label", en: "Sodium", de: "Natrium") }
+    static var caffeineLabel: String { localized("caffeine_label", en: "Caffeine", de: "Koffein") }
+    static var saturatedFatLabel: String { localized("saturated_fat_label", en: "Saturated Fat", de: "Gesättigte Fettsäuren") }
+    static var transFatLabel: String { localized("trans_fat_label", en: "Trans Fat", de: "Transfett") }
+    static var vitaminCLabel: String { localized("vitamin_c_label", en: "Vitamin C", de: "Vitamin C") }
+    static var vitaminDLabel: String { localized("vitamin_d_label", en: "Vitamin D", de: "Vitamin D") }
+    static var vitaminELabel: String { localized("vitamin_e_label", en: "Vitamin E", de: "Vitamin E") }
+    static var addedSugarsLabel: String { localized("added_sugars_label", en: "Added Sugars", de: "Zugesetzter Zucker") }
+
     // MARK: - Weekday Abbreviations
 
     static var weekdayHeaders: [String] {

--- a/mobile/iosApp/Bissbilanz/Views/ContentView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/ContentView.swift
@@ -4,6 +4,7 @@ enum NavigableTab: String, CaseIterable, Identifiable {
     case foods
     case favorites
     case insights
+    case sleep
     case weight
     case supplements
 
@@ -14,6 +15,7 @@ enum NavigableTab: String, CaseIterable, Identifiable {
         case .foods: return L10n.foods
         case .favorites: return L10n.favorites
         case .insights: return L10n.insights
+        case .sleep: return L10n.sleep
         case .weight: return L10n.weight
         case .supplements: return L10n.supplements
         }
@@ -24,6 +26,7 @@ enum NavigableTab: String, CaseIterable, Identifiable {
         case .foods: return "fork.knife"
         case .favorites: return "star"
         case .insights: return "chart.bar"
+        case .sleep: return "moon.zzz"
         case .weight: return "scalemass"
         case .supplements: return "pills"
         }
@@ -35,6 +38,7 @@ enum NavigableTab: String, CaseIterable, Identifiable {
         case .foods: FoodSearchView()
         case .favorites: FavoritesView()
         case .insights: InsightsView()
+        case .sleep: SleepView()
         case .weight: WeightView()
         case .supplements: SupplementsView()
         }

--- a/mobile/iosApp/Bissbilanz/Views/FavoritesView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FavoritesView.swift
@@ -10,6 +10,10 @@ struct FavoritesView: View {
     @State private var selectedFood: Food?
     @State private var selectedRecipe: Recipe?
     @State private var toastMessage: String?
+    @State private var preferences: Preferences = .defaults
+    @State private var pendingFood: Food?
+    @State private var pendingRecipe: Recipe?
+    @State private var showMealPicker = false
 
     private let columns = [
         GridItem(.flexible(), spacing: 12),
@@ -41,17 +45,29 @@ struct FavoritesView: View {
                 }
             }
             .navigationTitle(L10n.favorites)
-            .refreshable { await loadFavorites() }
+            .refreshable { await loadAll() }
             .toast(message: $toastMessage)
             .sheet(item: $selectedFood) { food in
                 LogFoodSheet(food: food, date: DateFormatting.today)
             }
             .sheet(item: $selectedRecipe) { recipe in
                 LogRecipeSheet(recipe: recipe) {
-                    Task { await loadFavorites() }
+                    Task { await loadAll() }
                 }
             }
-            .task { await loadFavorites() }
+            .task { await loadAll() }
+            .sheet(isPresented: $showMealPicker, onDismiss: {
+                pendingFood = nil
+                pendingRecipe = nil
+            }) {
+                MealPickerSheet { mealName in
+                    if let food = pendingFood {
+                        Task { await quickLogFood(food, meal: mealName) }
+                    } else if let recipe = pendingRecipe {
+                        Task { await quickLogRecipe(recipe, meal: mealName) }
+                    }
+                }
+            }
         }
     }
 
@@ -76,7 +92,7 @@ struct FavoritesView: View {
                                     selectedFood = food
                                 },
                                 onQuickLog: {
-                                    Task { await quickLogFood(food) }
+                                    quickLog(food: food)
                                 }
                             )
                         }
@@ -108,7 +124,7 @@ struct FavoritesView: View {
                                     selectedRecipe = recipe
                                 },
                                 onQuickLog: {
-                                    Task { await quickLogRecipe(recipe) }
+                                    quickLog(recipe: recipe)
                                 }
                             )
                         }
@@ -129,8 +145,25 @@ struct FavoritesView: View {
         }
     }
 
-    private func quickLogFood(_ food: Food) async {
-        let meal = mealForCurrentTime()
+    private func quickLog(food: Food) {
+        if preferences.favoriteMealAssignmentMode == "ask_meal" {
+            pendingFood = food
+            showMealPicker = true
+        } else {
+            Task { await quickLogFood(food, meal: mealForCurrentTime()) }
+        }
+    }
+
+    private func quickLog(recipe: Recipe) {
+        if preferences.favoriteMealAssignmentMode == "ask_meal" {
+            pendingRecipe = recipe
+            showMealPicker = true
+        } else {
+            Task { await quickLogRecipe(recipe, meal: mealForCurrentTime()) }
+        }
+    }
+
+    private func quickLogFood(_ food: Food, meal: String) async {
         let entry = EntryCreate(
             foodId: food.id,
             mealType: meal,
@@ -147,8 +180,7 @@ struct FavoritesView: View {
         }
     }
 
-    private func quickLogRecipe(_ recipe: Recipe) async {
-        let meal = mealForCurrentTime()
+    private func quickLogRecipe(_ recipe: Recipe, meal: String) async {
         let entry = EntryCreate(
             recipeId: recipe.id,
             mealType: meal,
@@ -165,16 +197,19 @@ struct FavoritesView: View {
         }
     }
 
-    private func loadFavorites() async {
+    private func loadAll() async {
         isLoading = true
+        async let favs = api.getFavorites()
+        async let prefs = api.getPreferences()
         do {
-            let response = try await api.getFavorites()
+            let response = try await favs
             favoriteFoods = response.foods
             favoriteRecipes = response.recipes ?? []
         } catch {
             favoriteFoods = []
             favoriteRecipes = []
         }
+        if let p = try? await prefs { preferences = p }
         isLoading = false
     }
 }

--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -12,6 +12,11 @@ struct InsightsView: View {
     @State private var mealBreakdown: [MealBreakdownEntry] = []
     @State private var calendarDays: [CalendarDay] = []
     @State private var goals: Goals?
+    @State private var mealTimingEntries: [MealTimingEntry] = []
+    @State private var foodDiversityEntries: [FoodDiversityEntry] = []
+    @State private var weightFoodEntries: [DailyWeightFood] = []
+    @State private var sleepFoodEntries: [SleepFoodCorrelationEntry] = []
+    @State private var extendedNutrientEntries: [ExtendedNutrientEntry] = []
     @State private var selectedRange = 7
     @State private var isLoading = true
     @State private var calendarMonth = Date()
@@ -33,6 +38,11 @@ struct InsightsView: View {
                         calendarHeatmapCard
                         comparisonCard
                         topFoodsCard
+                        mealTimingCard
+                        foodDiversityCard
+                        weightVsCaloriesCard
+                        sleepVsCaloriesCard
+                        extendedNutrientsCard
                     }
                 }
                 .padding()
@@ -476,6 +486,343 @@ struct InsightsView: View {
         }
     }
 
+    // MARK: - Meal Timing
+
+    @ViewBuilder
+    private var mealTimingCard: some View {
+        if !mealTimingEntries.isEmpty {
+            CardView {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(L10n.mealTiming, systemImage: "clock")
+                        .font(.headline)
+
+                    let hourlyCalories = mealTimingHourlyCalories()
+                    if hourlyCalories.isEmpty {
+                        Text(L10n.noAnalyticsData)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Chart(hourlyCalories, id: \.0) { item in
+                            BarMark(
+                                x: .value("Hour", "\(item.0)\(L10n.hourLabel)"),
+                                y: .value(L10n.calories, item.1)
+                            )
+                            .foregroundStyle(MacroColors.calories)
+                        }
+                        .frame(height: 150)
+                        .chartXAxis {
+                            AxisMarks(values: .stride(by: 4)) { value in
+                                AxisValueLabel()
+                            }
+                        }
+
+                        if let busiest = hourlyCalories.max(by: { $0.1 < $1.1 }) {
+                            Text("\(L10n.busiestHour): \(busiest.0):00 (\(Int(busiest.1)) kcal)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func mealTimingHourlyCalories() -> [(Int, Double)] {
+        var buckets = [Int: Double]()
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let fmt2 = ISO8601DateFormatter()
+        fmt2.formatOptions = [.withInternetDateTime]
+        for entry in mealTimingEntries {
+            let date = fmt.date(from: entry.eatenAt) ?? fmt2.date(from: entry.eatenAt)
+            guard let date else { continue }
+            let hour = Calendar.current.component(.hour, from: date)
+            buckets[hour, default: 0] += entry.calories
+        }
+        return buckets.sorted { $0.key < $1.key }.map { ($0.key, $0.value) }
+    }
+
+    // MARK: - Food Diversity
+
+    @ViewBuilder
+    private var foodDiversityCard: some View {
+        if !foodDiversityEntries.isEmpty {
+            CardView {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(L10n.foodDiversity, systemImage: "square.grid.2x2")
+                        .font(.headline)
+
+                    let uniqueCount = Set(foodDiversityEntries.map { $0.foodId ?? $0.recipeId ?? $0.foodName }).count
+                    let totalCount = foodDiversityEntries.count
+
+                    HStack(spacing: 24) {
+                        VStack {
+                            Text("\(uniqueCount)")
+                                .font(.system(size: 28, weight: .bold))
+                                .foregroundStyle(MacroColors.fiber)
+                            Text(L10n.uniqueFoods)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        VStack {
+                            Text("\(totalCount)")
+                                .font(.system(size: 28, weight: .bold))
+                                .foregroundStyle(MacroColors.calories)
+                            Text(L10n.totalLogged)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Text(L10n.novaDistribution)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .padding(.top, 4)
+
+                    let novaCounts = novaDiversityDistribution()
+                    HStack(spacing: 12) {
+                        ForEach([1, 2, 3, 4], id: \.self) { group in
+                            VStack(spacing: 2) {
+                                Text("\(novaCounts[group] ?? 0)")
+                                    .font(.caption)
+                                    .fontWeight(.bold)
+                                    .foregroundStyle(novaColor(group))
+                                Text("G\(group)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        let unknownCount = novaCounts[0] ?? 0
+                        if unknownCount > 0 {
+                            VStack(spacing: 2) {
+                                Text("\(unknownCount)")
+                                    .font(.caption)
+                                    .fontWeight(.bold)
+                                    .foregroundStyle(.secondary)
+                                Text(L10n.unknown)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func novaDiversityDistribution() -> [Int: Int] {
+        var counts = [Int: Int]()
+        for entry in foodDiversityEntries {
+            let group = entry.novaGroup ?? 0
+            counts[group, default: 0] += 1
+        }
+        return counts
+    }
+
+    private func novaColor(_ group: Int) -> Color {
+        switch group {
+        case 1: return .green
+        case 2: return .yellow
+        case 3: return .orange
+        case 4: return .red
+        default: return .gray
+        }
+    }
+
+    // MARK: - Weight vs Calories
+
+    @ViewBuilder
+    private var weightVsCaloriesCard: some View {
+        if !weightFoodEntries.isEmpty {
+            let weightPoints = weightFoodEntries.compactMap { entry -> (String, Double)? in
+                let w = entry.weightKg ?? entry.movingAvg
+                guard let w else { return nil }
+                return (entry.date, w)
+            }
+            let calPoints = weightFoodEntries.compactMap { entry -> (String, Double)? in
+                guard let c = entry.calories else { return nil }
+                return (entry.date, c)
+            }
+
+            if !weightPoints.isEmpty || !calPoints.isEmpty {
+                CardView {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(L10n.weightVsCalories, systemImage: "scalemass")
+                            .font(.headline)
+
+                        Chart {
+                            ForEach(calPoints, id: \.0) { item in
+                                LineMark(
+                                    x: .value("Date", DateFormatting.date(from: item.0) ?? Date()),
+                                    y: .value(L10n.calories, item.1),
+                                    series: .value("Series", "cal")
+                                )
+                                .foregroundStyle(MacroColors.calories)
+                                .interpolationMethod(.catmullRom)
+                            }
+                            ForEach(weightPoints, id: \.0) { item in
+                                LineMark(
+                                    x: .value("Date", DateFormatting.date(from: item.0) ?? Date()),
+                                    y: .value(L10n.weight, item.1),
+                                    series: .value("Series", "weight")
+                                )
+                                .foregroundStyle(MacroColors.protein)
+                                .interpolationMethod(.catmullRom)
+                            }
+                        }
+                        .frame(height: 180)
+                        .chartYAxis {
+                            AxisMarks(position: .leading)
+                        }
+
+                        HStack(spacing: 16) {
+                            legendItem(color: MacroColors.calories, label: L10n.calories)
+                            legendItem(color: MacroColors.protein, label: L10n.weight)
+                        }
+                        .font(.caption2)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Sleep vs Evening Calories
+
+    @ViewBuilder
+    private var sleepVsCaloriesCard: some View {
+        if !sleepFoodEntries.isEmpty {
+            CardView {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(L10n.sleepVsCalories, systemImage: "moon.zzz")
+                        .font(.headline)
+
+                    let sleepPoints = sleepFoodEntries.map { (DateFormatting.date(from: $0.date) ?? Date(), Double($0.sleepDurationMinutes) / 60.0) }
+                    let calPoints = sleepFoodEntries.compactMap { entry -> (Date, Double)? in
+                        guard let c = entry.eveningCalories else { return nil }
+                        return (DateFormatting.date(from: entry.date) ?? Date(), c)
+                    }
+
+                    Chart {
+                        ForEach(Array(sleepPoints.enumerated()), id: \.offset) { _, item in
+                            LineMark(
+                                x: .value("Date", item.0),
+                                y: .value(L10n.sleepHours, item.1),
+                                series: .value("Series", "sleep")
+                            )
+                            .foregroundStyle(MacroColors.carbs)
+                            .interpolationMethod(.catmullRom)
+                        }
+                        ForEach(Array(calPoints.enumerated()), id: \.offset) { _, item in
+                            LineMark(
+                                x: .value("Date", item.0),
+                                y: .value(L10n.eveningCalories, item.1),
+                                series: .value("Series", "cal")
+                            )
+                            .foregroundStyle(MacroColors.calories)
+                            .interpolationMethod(.catmullRom)
+                        }
+                    }
+                    .frame(height: 160)
+                    .chartYAxis {
+                        AxisMarks(position: .leading)
+                    }
+
+                    HStack(spacing: 16) {
+                        legendItem(color: MacroColors.carbs, label: L10n.sleepHours)
+                        legendItem(color: MacroColors.calories, label: L10n.eveningCalories)
+                    }
+                    .font(.caption2)
+
+                    let avgSleep = sleepFoodEntries.isEmpty ? 0.0 : sleepFoodEntries.map { Double($0.sleepDurationMinutes) / 60.0 }.reduce(0, +) / Double(sleepFoodEntries.count)
+                    let calEntries = sleepFoodEntries.compactMap(\.eveningCalories)
+                    let avgCal = calEntries.isEmpty ? 0.0 : calEntries.reduce(0, +) / Double(calEntries.count)
+
+                    HStack(spacing: 24) {
+                        VStack {
+                            Text(String(format: "%.1f \(L10n.hoursLabel)", avgSleep))
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(MacroColors.carbs)
+                            Text(L10n.avgDuration)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if !calEntries.isEmpty {
+                            VStack {
+                                Text("\(Int(avgCal)) kcal")
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundStyle(MacroColors.calories)
+                                Text(L10n.eveningCalories)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Extended Nutrients
+
+    @ViewBuilder
+    private var extendedNutrientsCard: some View {
+        if !extendedNutrientEntries.isEmpty {
+            let rows = extendedNutrientAverages()
+            if !rows.isEmpty {
+                CardView {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(L10n.extendedNutrients, systemImage: "list.bullet")
+                            .font(.headline)
+
+                        Text(L10n.avgPerDay)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+
+                        ForEach(rows, id: \.0) { name, value, unit in
+                            HStack {
+                                Text(name)
+                                    .font(.caption)
+                                Spacer()
+                                Text(String(format: "%.1f \(unit)", value))
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func extendedNutrientAverages() -> [(String, Double, String)] {
+        guard !extendedNutrientEntries.isEmpty else { return [] }
+        let distinctDates = Set(extendedNutrientEntries.map(\.date))
+        let n = Double(distinctDates.count)
+        guard n > 0 else { return [] }
+
+        func avg(_ values: [Double?]) -> Double {
+            values.reduce(0.0) { $0 + ($1 ?? 0) } / n
+        }
+
+        let e = extendedNutrientEntries
+        let candidates: [(String, Double, String)] = [
+            (L10n.omega3Label, avg(e.map(\.omega3)), "g"),
+            (L10n.omega6Label, avg(e.map(\.omega6)), "g"),
+            (L10n.sodiumLabel, avg(e.map(\.sodium)), "mg"),
+            (L10n.caffeineLabel, avg(e.map(\.caffeine)), "mg"),
+            (L10n.saturatedFatLabel, avg(e.map(\.saturatedFat)), "g"),
+            (L10n.transFatLabel, avg(e.map(\.transFat)), "g"),
+            (L10n.vitaminCLabel, avg(e.map(\.vitaminC)), "mg"),
+            (L10n.vitaminDLabel, avg(e.map(\.vitaminD)), "μg"),
+            (L10n.vitaminELabel, avg(e.map(\.vitaminE)), "mg"),
+            (L10n.addedSugarsLabel, avg(e.map(\.addedSugars)), "g"),
+        ]
+        return candidates.filter { $0.1 > 0 }
+    }
+
     // MARK: - Helpers
 
     private func mealColor(_ mealType: String) -> Color {
@@ -513,19 +860,28 @@ struct InsightsView: View {
     private func loadChartData() async {
         let endDate = Date()
         let startDate = endDate.adding(days: -selectedRange)
+        let startStr = DateFormatting.isoString(from: startDate)
+        let endStr = DateFormatting.isoString(from: endDate)
 
-        async let daily = try? api.getDailyStats(
-            startDate: DateFormatting.isoString(from: startDate),
-            endDate: DateFormatting.isoString(from: endDate)
-        )
+        async let daily = try? api.getDailyStats(startDate: startStr, endDate: endStr)
         async let meals = try? api.getMealBreakdown(days: selectedRange)
         async let foods = try? api.getTopFoods(days: selectedRange)
+        async let timing = try? api.getMealTiming(startDate: startStr, endDate: endStr)
+        async let diversity = try? api.getFoodDiversity(startDate: startStr, endDate: endStr)
+        async let weightFood = try? api.getWeightFood(startDate: startStr, endDate: endStr)
+        async let sleepFood = try? api.getSleepFood(startDate: startStr, endDate: endStr)
+        async let nutrients = try? api.getNutrientsExtended(startDate: startStr, endDate: endStr)
 
         if let response = await daily {
             dailyStats = response.data
         }
         mealBreakdown = await meals ?? []
         topFoods = await foods ?? []
+        mealTimingEntries = await timing ?? []
+        foodDiversityEntries = await diversity ?? []
+        weightFoodEntries = await weightFood ?? []
+        sleepFoodEntries = await sleepFood ?? []
+        extendedNutrientEntries = await nutrients ?? []
     }
 
     private func loadCalendar() async {

--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -709,7 +709,7 @@ struct InsightsView: View {
                                 y: .value(L10n.sleepHours, item.1),
                                 series: .value("Series", "sleep")
                             )
-                            .foregroundStyle(MacroColors.carbs)
+                            .foregroundStyle(Color.indigo)
                             .interpolationMethod(.catmullRom)
                         }
                         ForEach(Array(calPoints.enumerated()), id: \.offset) { _, item in
@@ -728,7 +728,7 @@ struct InsightsView: View {
                     }
 
                     HStack(spacing: 16) {
-                        legendItem(color: MacroColors.carbs, label: L10n.sleepHours)
+                        legendItem(color: Color.indigo, label: L10n.sleepHours)
                         legendItem(color: MacroColors.calories, label: L10n.eveningCalories)
                     }
                     .font(.caption2)
@@ -843,13 +843,11 @@ struct InsightsView: View {
         async let w = try? api.getWeeklyStats()
         async let m = try? api.getMonthlyStats()
         async let s = try? api.getStreaks()
-        async let t = try? api.getTopFoods(days: selectedRange)
         async let g = try? api.getGoals()
 
         weeklyStats = await w
         monthlyStats = await m
         streaks = await s
-        topFoods = await t ?? []
         goals = await g
 
         await loadChartData()

--- a/mobile/iosApp/Bissbilanz/Views/RecipeDetailView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/RecipeDetailView.swift
@@ -12,6 +12,7 @@ struct RecipeDetailView: View {
     @State private var showEditSheet = false
     @State private var showDeleteConfirmation = false
     @State private var showLogSheet = false
+    @State private var isTogglingFavorite = false
     @State private var errorMessage: String?
 
     var body: some View {
@@ -39,8 +40,16 @@ struct RecipeDetailView: View {
         .navigationTitle(recipe?.name ?? L10n.recipes)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if recipe != nil {
-                ToolbarItem(placement: .primaryAction) {
+            if let recipe {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button {
+                        Task { await toggleFavorite() }
+                    } label: {
+                        Image(systemName: recipe.isFavorite ? "star.fill" : "star")
+                            .foregroundStyle(recipe.isFavorite ? .yellow : .secondary)
+                    }
+                    .disabled(isTogglingFavorite)
+
                     Menu {
                         Button {
                             showEditSheet = true
@@ -161,6 +170,17 @@ struct RecipeDetailView: View {
     }
 
     // MARK: - Actions
+
+    private func toggleFavorite() async {
+        guard let recipe else { return }
+        isTogglingFavorite = true
+        do {
+            self.recipe = try await api.updateRecipe(id: recipe.id, RecipeUpdate(isFavorite: !recipe.isFavorite))
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isTogglingFavorite = false
+    }
 
     private func loadRecipe() async {
         isLoading = true

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -69,6 +69,9 @@ struct SettingsView: View {
 
                 // Navigation section
                 Section {
+                    NavigationLink { SleepView() } label: {
+                        Label(L10n.sleep, systemImage: "moon.zzz")
+                    }
                     NavigationLink { WeightView() } label: {
                         Label(L10n.weight, systemImage: "scalemass")
                     }

--- a/mobile/iosApp/Bissbilanz/Views/SleepView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SleepView.swift
@@ -1,0 +1,288 @@
+import Charts
+import SwiftUI
+
+struct SleepView: View {
+    @Environment(BissbilanzAPI.self) private var api
+
+    @State private var entries: [SleepEntry] = []
+    @State private var isLoading = true
+    @State private var showAddSheet = false
+    @State private var editingEntry: SleepEntry?
+    @State private var selectedRange = 30
+    @State private var errorMessage: String?
+
+    private enum RangeOption: Int, CaseIterable, Identifiable {
+        case week = 7
+        case month = 30
+        case quarter = 90
+        case all = 0
+
+        var id: Int {
+            rawValue
+        }
+
+        var label: String {
+            switch self {
+            case .week: "7d"
+            case .month: "30d"
+            case .quarter: "90d"
+            case .all: L10n.history
+            }
+        }
+    }
+
+    private var chartEntries: [SleepEntry] {
+        let sorted = entries.sorted { entryA, entryB in
+            guard let dateA = DateFormatting.date(from: entryA.entryDate),
+                  let dateB = DateFormatting.date(from: entryB.entryDate)
+            else { return false }
+            return dateA < dateB
+        }
+        guard selectedRange > 0 else { return sorted }
+        let cutoff = Date().adding(days: -selectedRange)
+        return sorted.filter { entry in
+            guard let date = DateFormatting.date(from: entry.entryDate) else { return false }
+            return date >= cutoff
+        }
+    }
+
+    private var avgDurationMinutes: Double {
+        guard !entries.isEmpty else { return 0 }
+        return Double(entries.map(\.durationMinutes).reduce(0, +)) / Double(entries.count)
+    }
+
+    private var avgQuality: Double {
+        guard !entries.isEmpty else { return 0 }
+        return Double(entries.map(\.quality).reduce(0, +)) / Double(entries.count)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    LoadingView()
+                } else if entries.isEmpty {
+                    ContentUnavailableView(
+                        L10n.sleep,
+                        systemImage: "moon.zzz",
+                        description: Text(L10n.noSleepEntries)
+                    )
+                } else {
+                    List {
+                        statsChipsSection
+                        if chartEntries.count >= 2 { chartSection }
+                        historySection
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle(L10n.sleep)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showAddSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAddSheet) {
+                SleepEditSheet {
+                    Task { await loadEntries() }
+                }
+            }
+            .sheet(item: $editingEntry) { entry in
+                SleepEditSheet(existingEntry: entry) {
+                    Task { await loadEntries() }
+                }
+            }
+            .refreshable { await loadEntries() }
+            .task { await loadEntries() }
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
+                Button(L10n.ok, role: .cancel) {}
+            } message: {
+                if let errorMessage { Text(errorMessage) }
+            }
+        }
+    }
+
+    // MARK: - Stats Chips
+
+    private var statsChipsSection: some View {
+        Section {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    statChip(L10n.nightsLogged, value: "\(entries.count)", color: .indigo)
+
+                    if !entries.isEmpty {
+                        let hours = Int(avgDurationMinutes) / 60
+                        let minutes = Int(avgDurationMinutes) % 60
+                        statChip(L10n.avgDuration, value: "\(hours)h \(minutes)m", color: .blue)
+                        statChip(L10n.avgQuality, value: String(format: "%.1f / 10", avgQuality), color: .purple)
+                    }
+                }
+                .padding(.horizontal, 4)
+            }
+            .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+        }
+    }
+
+    private func statChip(_ label: String, value: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(color.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Chart Section
+
+    private var chartSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(L10n.trend)
+                    .font(.headline)
+
+                Picker("Range", selection: $selectedRange) {
+                    ForEach(RangeOption.allCases) { option in
+                        Text(option.label).tag(option.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Chart {
+                    ForEach(chartEntries) { entry in
+                        if let date = DateFormatting.date(from: entry.entryDate) {
+                            let hours = Double(entry.durationMinutes) / 60.0
+                            BarMark(
+                                x: .value("Date", date, unit: .day),
+                                y: .value(L10n.sleepDuration, hours)
+                            )
+                            .foregroundStyle(.indigo.opacity(0.8))
+
+                            PointMark(
+                                x: .value("Date", date, unit: .day),
+                                y: .value(L10n.sleepQuality, Double(entry.quality) * hours / 10.0)
+                            )
+                            .foregroundStyle(.purple)
+                            .symbolSize(30)
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        AxisValueLabel {
+                            if let h = value.as(Double.self) {
+                                Text("\(h, specifier: "%.1f")h")
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine()
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+                        AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        AxisGridLine()
+                    }
+                }
+                .frame(height: 200)
+
+                // Legend
+                HStack(spacing: 16) {
+                    HStack(spacing: 4) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(.indigo.opacity(0.8))
+                            .frame(width: 12, height: 12)
+                        Text(L10n.sleepDuration).font(.caption2).foregroundStyle(.secondary)
+                    }
+                    HStack(spacing: 4) {
+                        Circle().fill(.purple).frame(width: 8, height: 8)
+                        Text(L10n.sleepQuality).font(.caption2).foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - History Section
+
+    private var historySection: some View {
+        Section(L10n.history) {
+            ForEach(entries) { entry in
+                Button {
+                    editingEntry = entry
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            if let date = DateFormatting.date(from: entry.entryDate) {
+                                Text(DateFormatting.displayString(from: date))
+                                    .font(.body)
+                                    .foregroundStyle(.primary)
+                            } else {
+                                Text(entry.entryDate)
+                                    .font(.body)
+                                    .foregroundStyle(.primary)
+                            }
+                            if let notes = entry.notes, !notes.isEmpty {
+                                Text(notes)
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(1)
+                            }
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing, spacing: 2) {
+                            let hours = entry.durationMinutes / 60
+                            let minutes = entry.durationMinutes % 60
+                            Text("\(hours)h \(minutes)m")
+                                .foregroundStyle(.secondary)
+                            Text("Q \(entry.quality)/10")
+                                .font(.caption2)
+                                .foregroundStyle(.purple)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .swipeActions(edge: .trailing) {
+                    Button(role: .destructive) {
+                        Task { await deleteEntry(entry) }
+                    } label: {
+                        Label(L10n.delete, systemImage: "trash")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadEntries() async {
+        isLoading = true
+        entries = await (try? api.getSleepEntries()) ?? []
+        isLoading = false
+    }
+
+    private func deleteEntry(_ entry: SleepEntry) async {
+        do {
+            try await api.deleteSleepEntry(id: entry.id)
+            entries.removeAll { $0.id == entry.id }
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -406,6 +406,7 @@ struct AddWeightSheet: View {
     @State private var notes = ""
     @State private var isSaving = false
     @State private var errorMessage: String?
+    @State private var healthKitService = HealthKitService()
 
     init(existingEntry: WeightEntry? = nil, onSaved: @escaping () -> Void) {
         self.existingEntry = existingEntry
@@ -484,6 +485,14 @@ struct AddWeightSheet: View {
                     notes: notes.isEmpty ? nil : notes
                 )
                 _ = try await api.createWeightEntry(entry)
+            }
+            if UserDefaults.standard.bool(forKey: "healthkit_sync_enabled"),
+               healthKitService.isAvailable,
+               healthKitService.isAuthorized
+            {
+                let capturedKg = kg
+                let capturedDate = date
+                Task { try? await healthKitService.saveWeight(capturedKg, date: capturedDate) }
             }
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             onSaved()


### PR DESCRIPTION
## Summary

Brings the Swift-native iOS app substantially closer to feature parity with the Jetpack Compose Android app. The iOS app keeps its existing architecture (own `BissbilanzAPI` URLSession client, hand-written Codable `Models/`, `@Observable`/`@Environment`, `NavigationStack`/`TabView`, `L10n` en/de) — this is **not** a shared-KMP re-architecture.

Closes concrete Android↔iOS gaps:

- **Sleep tracking (new vertical)** — `Models/Sleep.swift`, sleep CRUD in `BissbilanzAPI`, `SleepView` (range selector, duration/quality chart, stats, history with edit/delete), `SleepEditSheet`, reachable via Settings + as a selectable tab. Quality range is **1–10** (matches backend validation).
- **HealthKit weight write-through** — on weight create/update success, weight is written to HealthKit, triple-gated by the existing `healthkit_sync_enabled` toggle + availability + authorization, fire-and-forget (mirrors Android → Health Connect).
- **Insights/analytics parity** — 5 new cards in `InsightsView` from the `/api/analytics/*` endpoints: meal-timing histogram, food diversity + NOVA distribution, weight↔calories, sleep↔evening-calories, average extended-nutrient intake. Client-side aggregation only (counting/bucketing/averaging) — deliberately **no bespoke health "scores"** (DII/TEF/plateau/adaptive-TDEE) since those need exact unverifiable formulas.
- **Polish** — recipe favorite toggle in `RecipeDetailView`; ask-meal-type meal picker for favorites when `favoriteMealAssignmentMode == "ask_meal"` (new `MealPickerSheet`); barcode→create-food prefill verified already wired; `RecipeUpdate` given explicit `nil` field defaults.

All new user-facing strings are localized (en/de). Changes are 100% confined to `mobile/iosApp/`.

## Verification

⚠️ **Swift was not compiled in the dev environment** (Linux/WSL2, no Xcode). **iOS CI (macOS + Xcode 16.2) is the authoritative compile gate for this PR** — please rely on it + review.

What was done instead, given that constraint:
- Every API method/model validated against the **verified backend contract** (SvelteKit route handlers + Zod schemas read directly), not assumptions — this caught and fixed a wrong sleep-correlation endpoint and a 1–5-vs-1–10 quality bug pre-merge.
- Independent multi-agent spec-compliance review per task + a full whole-branch code-quality review (no Critical issues; correctness-by-inspection of types/SwiftUI/Codable/concurrency).
- New views/sheets/cards mirror existing iOS patterns (`WeightView`, existing sheets, `InsightsView` cards); existing screens/behaviors preserved (time-based favorites path and weight-save path unchanged).
- No web/shared/Android files changed, so those test suites are unaffected (`main` was green prior).

## Out of scope / follow-ups

- Offline cache/sync-queue on iOS (large architectural change; iOS is online-only by design), push notifications/supplement reminders, data export, widgets.
- Bespoke insight "scores" requiring Android's exact formulas.
- Minor nicety from review: mark `HealthKitService.saveWeight/saveNutrition` `nonisolated` (benign at current scale; deferred to avoid an unverifiable concurrency change to a pre-existing service).
- Unrelated: dependabot layerchart bump (#237) was separately closed (breaking prerelease API); the 7 other dependency PRs were merged to `main`.

## Test plan

- [ ] iOS CI (macOS/Xcode) builds the app green
- [ ] Sleep: add/edit/delete entry, chart + history render, quality accepts 1–10
- [ ] HealthKit: with toggle on + authorized, logging weight writes to Apple Health; with toggle off, it does not; weight save never blocked by HealthKit
- [ ] Insights: 5 new cards load, render, and are empty-safe on sparse data; existing cards unchanged
- [ ] Recipe favorite toggle persists; favorites ask-meal picker appears only in `ask_meal` mode, time-based path unchanged
- [ ] de/en localization for all new strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)