### PR TITLE
feat(crawler): catalog dataset crawler (OFF bulk-dump + Migros)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ vite.config.ts.timestamp-*
 
 # Worktrees
 .worktrees/
-.claude/worktrees/
+
+# Claude Code
+.claude/
 
 # Superpowers
 .superpowers/

--- a/crawler/README.md
+++ b/crawler/README.md
@@ -1,0 +1,67 @@
+# Bissbilanz Catalog Crawler
+
+Offline tool that builds **catalog datasets** (normalized JSONL) for the access-gated
+base food catalog. It is **not part of the SvelteKit app**, its build, or `bun run security`
+scope — nothing under `src/` imports it.
+
+## Legal posture
+
+- **Private use, no redistribution.** Crawler _code_ ships in this repo; crawled _data_ never
+  does. Datasets are written under `data/catalog/` which is git-ignored and rejected by a
+  pre-commit hook (`no-catalog-data`).
+- Output is imported only into this app's database and surfaced only to its authenticated,
+  individually access-granted users. It is not rehosted or redistributed.
+- Retailer images are referenced by source URL only — never rehosted.
+- Sources are accessed politely: fixed-delay throttling, on-disk response caching, descriptive
+  User-Agent, exponential-backoff retry.
+
+## Dataset format
+
+One JSONL file per dataset. Line 1 is a `{ "_dataset": { ... } }` header; lines 2..n are one
+product per line. The contract is the shared Zod schema
+`src/lib/server/catalog/dataset-schema.ts` — the crawler validates every emitted row against it,
+so a produced file always imports cleanly (`catalog:import` is fail-closed).
+
+## Usage
+
+```bash
+cd crawler
+bun install            # installs migros-api-wrapper (Migros source only)
+
+# Open Food Facts — from a downloaded ODbL bulk dump (.jsonl or .jsonl.gz):
+#   download once from https://world.openfoodfacts.org/data (openfoodfacts-products.jsonl.gz)
+bun run crawl off /path/to/openfoodfacts-products.jsonl.gz
+#   → writes data/catalog/off-ch-<date>.jsonl (Swiss products with full core macros)
+
+# Migros — live API (polite, throttled):
+bun run crawl migros
+#   → writes data/catalog/migros-<date>.jsonl
+```
+
+The OFF dump is large (tens of GB uncompressed); the crawler streams it (gunzip + line split),
+never loading it into memory. The Migros crawl is live and rate-limited — expect it to take a
+while; it checkpoints progress.
+
+## Importing on the server host
+
+The CLI that loads a dataset into Postgres runs **on the server host** (production Postgres is
+Docker-internal), not from the crawler:
+
+```bash
+scp data/catalog/migros-<date>.jsonl  server:/tmp/
+ssh server
+docker compose exec -T app bun run catalog:import /tmp/migros-<date>.jsonl
+docker compose exec -T app bun run catalog:grant <userEmail> migros
+```
+
+Re-importing the same dataset `key` fully replaces its rows and preserves access grants.
+
+## Testing
+
+```bash
+cd crawler && bun test
+```
+
+All tests are fixture-driven — no live network. Adapters split a pure, tested normalizer from
+thin live-fetch glue; the glue (`createMigrosClient`, dump download) is exercised only by the
+maintainer during a real crawl.

--- a/crawler/adapters/migros/client.test.ts
+++ b/crawler/adapters/migros/client.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { mapProductDetail, extractProductIds, pickDetail } from './client';
+
+test('mapProductDetail reduces a Migros API product-detail to MigrosProductDetail', async () => {
+	const raw = await Bun.file(
+		join(import.meta.dir, '../../fixtures/migros-product-detail.json')
+	).json();
+	const d = mapProductDetail(raw);
+	expect(d).not.toBeNull();
+	expect(d!.id).toBe('100001');
+	expect(d!.name).toBe('M-Classic Vollmilch UHT');
+	expect(d!.gtins).toEqual(['7610200000001']);
+	expect(d!.productUrl).toContain('100001');
+	expect(d!.nutrition.basis).toBe('100g');
+	expect(d!.nutrition.energyKcal).toBe(64);
+	expect(d!.nutrition.sugar).toBe(4.8);
+	expect(d!.nutrition.saturatedFat).toBe(2.1);
+	expect(d!.nutrition.salt).toBe(0.1);
+});
+
+test('mapProductDetail returns null when id or name is missing', () => {
+	expect(mapProductDetail({ name: 'no id' })).toBeNull();
+	expect(mapProductDetail({ productId: '1' })).toBeNull();
+});
+
+test('extractProductIds reads productIds or products[].id/uid', () => {
+	expect(extractProductIds({ productIds: ['a', 'b'] })).toEqual(['a', 'b']);
+	expect(extractProductIds({ products: [{ id: 'x' }, { uid: 'y' }] })).toEqual(['x', 'y']);
+	expect(extractProductIds({})).toEqual([]);
+	expect(extractProductIds(null)).toEqual([]);
+});
+
+test('pickDetail selects a single product from array/products/object shapes', () => {
+	expect(pickDetail([{ productId: '1' }])?.productId).toBe('1');
+	expect(pickDetail({ products: [{ productId: '2' }] })?.productId).toBe('2');
+	expect(pickDetail({ productId: '3' })?.productId).toBe('3');
+	expect(pickDetail(null)).toBeNull();
+});

--- a/crawler/adapters/migros/client.ts
+++ b/crawler/adapters/migros/client.ts
@@ -1,0 +1,138 @@
+import type { MigrosClient, MigrosProductDetail, MigrosNutrition } from './types';
+
+type RawNutrientValue = { code?: string; value?: number | string };
+type RawProductDetail = {
+	productId?: string;
+	name?: string;
+	brand?: string;
+	gtins?: string[];
+	productUrls?: Record<string, string>;
+	image?: { original?: string };
+	ingredients?: string;
+	nutrients?: { referenceValue?: string; values?: RawNutrientValue[] };
+};
+
+type MigrosNumericKey = Exclude<keyof MigrosNutrition, 'basis'>;
+
+const NUTRIENT_CODE: Record<string, MigrosNumericKey> = {
+	energy_kcal: 'energyKcal',
+	protein: 'protein',
+	carbohydrate: 'carbohydrate',
+	of_which_sugars: 'sugar',
+	fat: 'fat',
+	of_which_saturated: 'saturatedFat',
+	dietary_fiber: 'fiber',
+	salt: 'salt'
+};
+
+function num(v: number | string | undefined): number | null {
+	if (v == null) return null;
+	const n = typeof v === 'string' ? parseFloat(v) : v;
+	return Number.isNaN(n) ? null : n;
+}
+
+export function mapProductDetail(raw: RawProductDetail): MigrosProductDetail | null {
+	const id = raw.productId;
+	const name = raw.name;
+	if (!id || !name) return null;
+	const nutrition: MigrosNutrition = { basis: raw.nutrients?.referenceValue ?? '100g' };
+	for (const entry of raw.nutrients?.values ?? []) {
+		const key = entry.code ? NUTRIENT_CODE[entry.code] : undefined;
+		if (key) nutrition[key] = num(entry.value);
+	}
+	return {
+		id,
+		name,
+		brand: raw.brand ?? null,
+		gtins: (raw.gtins ?? []).filter((g) => !!g),
+		productUrl: raw.productUrls?.de ?? Object.values(raw.productUrls ?? {})[0] ?? null,
+		imageUrl: raw.image?.original ?? null,
+		ingredients: raw.ingredients ?? null,
+		nutrition
+	};
+}
+
+export type MigrosClientConfig = {
+	/** Food category search terms or category ids to page through (host-confirmed). */
+	categories: string[];
+	pageSize?: number;
+	maxPagesPerCategory?: number;
+};
+
+/** Best-effort extraction of product ids from a (loosely-typed) search response. */
+export function extractProductIds(res: unknown): string[] {
+	const r = res as { productIds?: string[]; products?: Array<{ id?: string; uid?: string }> };
+	if (Array.isArray(r?.productIds)) return r.productIds.filter((id): id is string => !!id);
+	if (Array.isArray(r?.products)) {
+		return r.products.map((p) => p.id ?? p.uid).filter((id): id is string => !!id);
+	}
+	return [];
+}
+
+/** Best-effort selection of the single product object from a product-detail response. */
+export function pickDetail(res: unknown): RawProductDetail | null {
+	if (!res) return null;
+	if (Array.isArray(res)) return (res[0] as RawProductDetail) ?? null;
+	const r = res as { products?: RawProductDetail[] };
+	if (Array.isArray(r.products)) return r.products[0] ?? null;
+	return res as RawProductDetail;
+}
+
+/**
+ * Live client backed by `migros-api-wrapper` (`MigrosAPI`: guest token → product search →
+ * product-detail). NOT unit-tested — no live network in CI (spec §12). The dependency is
+ * imported dynamically so the tested core type-checks/runs without loading axios/cheerio/pino.
+ *
+ * The wrapper's instance methods return `any` and some option types are inconsistent, so the
+ * call boundary is navigated through a narrow facade. The exact category ids/pagination params
+ * and the product-detail response field paths consumed by `mapProductDetail`/`extractProductIds`
+ * are verified against a live response on the server host during the first crawl (spec §13).
+ */
+export async function createMigrosClient(config: MigrosClientConfig): Promise<MigrosClient> {
+	const { MigrosAPI } = await import('migros-api-wrapper');
+	const api = new MigrosAPI();
+	// Guest token — public product data needs no login.
+	const token = (await api.account.oauth2.loginGuestToken()) as string;
+
+	const products = api.products as unknown as {
+		productSearch: {
+			searchProduct: (
+				body: { query: string; [k: string]: unknown },
+				options?: Record<string, unknown>,
+				token?: string
+			) => Promise<unknown>;
+		};
+		productDisplay: {
+			getProductDetails: (
+				options: { uids: string | string[]; [k: string]: unknown },
+				token?: string
+			) => Promise<unknown>;
+		};
+	};
+
+	const pageSize = config.pageSize ?? 24;
+	const maxPages = config.maxPagesPerCategory ?? 1000;
+
+	return {
+		async *listProductIds({ resume }) {
+			for (const category of config.categories) {
+				let page = resume && resume.category === category ? resume.page : 0;
+				for (; page < maxPages; page++) {
+					const res = await products.productSearch.searchProduct(
+						{ query: category },
+						{ from: page * pageSize, hitsPerPage: pageSize },
+						token
+					);
+					const ids = extractProductIds(res);
+					for (const id of ids) yield { id, cursor: { category, page } };
+					if (ids.length < pageSize) break;
+				}
+			}
+		},
+		async getProduct(id) {
+			const res = await products.productDisplay.getProductDetails({ uids: id }, token);
+			const raw = pickDetail(res);
+			return raw ? mapProductDetail(raw) : null;
+		}
+	};
+}

--- a/crawler/adapters/migros/crawl-migros.test.ts
+++ b/crawler/adapters/migros/crawl-migros.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from 'bun:test';
+import { crawlMigros } from './crawl-migros';
+import { newStats } from '../../types';
+import type { MigrosClient, MigrosProductDetail } from './types';
+
+function makeClient(
+	products: Record<string, MigrosProductDetail | null>,
+	ids: string[]
+): MigrosClient {
+	return {
+		async *listProductIds() {
+			let page = 0;
+			for (const id of ids) yield { id, cursor: { category: 'all', page: page++ } };
+		},
+		async getProduct(id) {
+			return products[id] ?? null;
+		}
+	};
+}
+
+const base: MigrosProductDetail = {
+	id: '1',
+	name: 'A',
+	gtins: ['7610200000001'],
+	productUrl: 'https://m/1',
+	nutrition: { basis: '100g', energyKcal: 64, protein: 3.3, carbohydrate: 4.8, fat: 3.5, fiber: 0 }
+};
+
+test('emits normalized products and dedupes repeated ids and barcodes', async () => {
+	const client = makeClient(
+		{
+			'1': base,
+			'2': { ...base, id: '2', name: 'B', gtins: ['7610200000002'] },
+			'3': { ...base, id: '3', name: 'A-dup', gtins: ['7610200000001'] } // dup barcode
+		},
+		['1', '2', '2', '3'] // '2' listed twice
+	);
+	const stats = newStats();
+	const out = [];
+	for await (const p of crawlMigros(client, { stats, sleep: async () => {} })) out.push(p);
+	expect(out.map((p) => p.name).sort()).toEqual(['A', 'B']);
+	expect(stats.emitted).toBe(2);
+	expect(stats.dropReasons['dup']).toBe(2); // one dup id + one dup barcode
+});
+
+test('skips ids whose product detail is null', async () => {
+	const client = makeClient({ '1': base, '9': null }, ['1', '9']);
+	const out = [];
+	for await (const p of crawlMigros(client, { sleep: async () => {} })) out.push(p);
+	expect(out.length).toBe(1);
+});
+
+test('respects the limit option', async () => {
+	const client = makeClient({ '1': base, '2': { ...base, id: '2', gtins: ['7610200000002'] } }, [
+		'1',
+		'2'
+	]);
+	const out = [];
+	for await (const p of crawlMigros(client, { limit: 1, sleep: async () => {} })) out.push(p);
+	expect(out.length).toBe(1);
+});

--- a/crawler/adapters/migros/crawl-migros.test.ts
+++ b/crawler/adapters/migros/crawl-migros.test.ts
@@ -59,3 +59,20 @@ test('respects the limit option', async () => {
 	for await (const p of crawlMigros(client, { limit: 1, sleep: async () => {} })) out.push(p);
 	expect(out.length).toBe(1);
 });
+
+test('checkpoints only emitted products (after yield), not dropped ones', async () => {
+	const client = makeClient(
+		{ '1': base, '2': { ...base, id: '2', name: 'B', gtins: ['7610200000002'] }, '9': null },
+		['1', '9', '2']
+	);
+	const cursors: Array<{ category: string; page: number }> = [];
+	const out = [];
+	for await (const p of crawlMigros(client, {
+		sleep: async () => {},
+		onCheckpoint: (c) => void cursors.push(c)
+	}))
+		out.push(p);
+	// '9' has no detail (dropped) → not checkpointed; only the two emitted products are.
+	expect(out.length).toBe(2);
+	expect(cursors.length).toBe(2);
+});

--- a/crawler/adapters/migros/crawl-migros.ts
+++ b/crawler/adapters/migros/crawl-migros.ts
@@ -32,7 +32,6 @@ export async function* crawlMigros(
 			continue;
 		}
 		seenIds.add(id);
-		if (opts.onCheckpoint) await opts.onCheckpoint(cursor);
 
 		const detail = await client.getProduct(id);
 		if (throttleMs > 0) await sleep(throttleMs);
@@ -53,6 +52,7 @@ export async function* crawlMigros(
 		stats.emitted++;
 		if (opts.onProgress && stats.emitted % 500 === 0) opts.onProgress(stats);
 		yield r.product;
+		if (opts.onCheckpoint) await opts.onCheckpoint(cursor);
 		if (opts.limit && stats.emitted >= opts.limit) return;
 	}
 }

--- a/crawler/adapters/migros/crawl-migros.ts
+++ b/crawler/adapters/migros/crawl-migros.ts
@@ -1,0 +1,58 @@
+import type { DatasetProduct, CrawlStats } from '../../types';
+import { newStats, recordDrop } from '../../types';
+import { migrosToDataset } from './normalize-migros';
+import type { MigrosClient } from './types';
+
+export type MigrosCrawlOpts = {
+	limit?: number;
+	stats?: CrawlStats;
+	crawledAt?: string;
+	resume?: { category: string; page: number } | null;
+	sleep?: (ms: number) => Promise<void>;
+	throttleMs?: number;
+	onCheckpoint?: (cursor: { category: string; page: number }) => Promise<void> | void;
+	onProgress?: (stats: CrawlStats) => void;
+};
+
+export async function* crawlMigros(
+	client: MigrosClient,
+	opts: MigrosCrawlOpts = {}
+): AsyncIterable<DatasetProduct> {
+	const stats = opts.stats ?? newStats();
+	const crawledAt = opts.crawledAt ?? new Date().toISOString();
+	const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+	const throttleMs = opts.throttleMs ?? 0;
+	const seenIds = new Set<string>();
+	const seenBarcodes = new Set<string>();
+
+	for await (const { id, cursor } of client.listProductIds({ resume: opts.resume ?? null })) {
+		stats.seen++;
+		if (seenIds.has(id)) {
+			recordDrop(stats, 'dup:id');
+			continue;
+		}
+		seenIds.add(id);
+		if (opts.onCheckpoint) await opts.onCheckpoint(cursor);
+
+		const detail = await client.getProduct(id);
+		if (throttleMs > 0) await sleep(throttleMs);
+		if (!detail) {
+			recordDrop(stats, 'no-detail');
+			continue;
+		}
+		const r = migrosToDataset(detail, crawledAt);
+		if (!r.ok) {
+			recordDrop(stats, r.reason);
+			continue;
+		}
+		if (r.product.barcode && seenBarcodes.has(r.product.barcode)) {
+			recordDrop(stats, 'dup:barcode');
+			continue;
+		}
+		if (r.product.barcode) seenBarcodes.add(r.product.barcode);
+		stats.emitted++;
+		if (opts.onProgress && stats.emitted % 500 === 0) opts.onProgress(stats);
+		yield r.product;
+		if (opts.limit && stats.emitted >= opts.limit) return;
+	}
+}

--- a/crawler/adapters/migros/normalize-migros.test.ts
+++ b/crawler/adapters/migros/normalize-migros.test.ts
@@ -1,0 +1,70 @@
+import { test, expect } from 'bun:test';
+import { migrosToDataset } from './normalize-migros';
+import type { MigrosProductDetail } from './types';
+
+const detail: MigrosProductDetail = {
+	id: '100001',
+	name: 'M-Classic Vollmilch',
+	brand: 'M-Classic',
+	gtins: ['7610200000001'],
+	productUrl: 'https://www.migros.ch/de/product/100001',
+	imageUrl: 'https://image.migros.ch/100001.jpg',
+	nutrition: {
+		basis: '100g',
+		energyKcal: 64,
+		protein: 3.3,
+		carbohydrate: 4.8,
+		fat: 3.5,
+		fiber: 0,
+		sugar: 4.8,
+		saturatedFat: 2.1,
+		salt: 0.1
+	}
+};
+
+test('maps a Migros product-detail to a valid dataset product (de)', () => {
+	const r = migrosToDataset(detail);
+	expect(r.ok).toBe(true);
+	if (r.ok) {
+		expect(r.product.name).toBe('M-Classic Vollmilch');
+		expect(r.product.language).toBe('de');
+		expect(r.product.barcode).toBe('7610200000001');
+		expect(r.product.calories).toBe(64);
+		expect(r.product.sugar).toBe(4.8);
+		expect(r.product.saturatedFat).toBe(2.1);
+		expect(r.product.salt).toBe(0.1);
+		expect(r.product.sourceRef).toBe('100001');
+		expect(r.product.vitaminC).toBeNull();
+	}
+});
+
+test('rescales per-serving nutrition to per-100g when basis is grams', () => {
+	const r = migrosToDataset({
+		...detail,
+		nutrition: {
+			...detail.nutrition,
+			basis: '200g',
+			energyKcal: 128,
+			protein: 6.6,
+			carbohydrate: 9.6,
+			fat: 7,
+			fiber: 0
+		}
+	});
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.product.calories).toBe(64);
+});
+
+test('drops a product with no GTIN', () => {
+	const r = migrosToDataset({ ...detail, gtins: [] });
+	expect(r.ok).toBe(false);
+	if (!r.ok) expect(r.reason).toContain('no-barcode');
+});
+
+test('drops a product missing core macros', () => {
+	const r = migrosToDataset({
+		...detail,
+		nutrition: { basis: '100g', energyKcal: 64, protein: 3.3 }
+	});
+	expect(r.ok).toBe(false);
+});

--- a/crawler/adapters/migros/normalize-migros.test.ts
+++ b/crawler/adapters/migros/normalize-migros.test.ts
@@ -68,3 +68,15 @@ test('drops a product missing core macros', () => {
 	});
 	expect(r.ok).toBe(false);
 });
+
+test('uses ml serving unit and rescales for an ml-based product', () => {
+	const r = migrosToDataset({
+		...detail,
+		nutrition: { ...detail.nutrition, basis: '200ml', energyKcal: 128 }
+	});
+	expect(r.ok).toBe(true);
+	if (r.ok) {
+		expect(r.product.servingUnit).toBe('ml');
+		expect(r.product.calories).toBe(64);
+	}
+});

--- a/crawler/adapters/migros/normalize-migros.ts
+++ b/crawler/adapters/migros/normalize-migros.ts
@@ -20,6 +20,9 @@ export function migrosToDataset(d: MigrosProductDetail, crawledAt?: string): Bui
 
 	const basisG = gramsBasis(d.nutrition.basis);
 	if (basisG == null || basisG <= 0) return { ok: false, reason: 'bad-basis' };
+	const servingUnit: 'g' | 'ml' = d.nutrition.basis?.trim().toLowerCase().endsWith('ml')
+		? 'ml'
+		: 'g';
 	const f = 100 / basisG;
 	const scale = (v: number | null | undefined): number | null =>
 		v == null || Number.isNaN(v) ? null : Math.round(v * f * 100) / 100;
@@ -29,7 +32,7 @@ export function migrosToDataset(d: MigrosProductDetail, crawledAt?: string): Bui
 		brand: d.brand ?? null,
 		language: 'de',
 		servingSize: 100,
-		servingUnit: 'g',
+		servingUnit,
 		calories: scale(d.nutrition.energyKcal),
 		protein: scale(d.nutrition.protein),
 		carbs: scale(d.nutrition.carbohydrate),

--- a/crawler/adapters/migros/normalize-migros.ts
+++ b/crawler/adapters/migros/normalize-migros.ts
@@ -1,0 +1,50 @@
+import { buildDatasetProduct } from '../../lib/normalize';
+import type { BuildResult } from '../../types';
+import type { MigrosProductDetail } from './types';
+
+function gramsBasis(basis: string | undefined): number | null {
+	if (!basis) return 100; // assume per-100g when unspecified
+	const m = basis
+		.trim()
+		.toLowerCase()
+		.match(/^(\d+(?:\.\d+)?)\s*(g|ml)$/);
+	if (!m) return null;
+	return parseFloat(m[1]);
+}
+
+export function migrosToDataset(d: MigrosProductDetail, crawledAt?: string): BuildResult {
+	const barcode = (d.gtins ?? []).find((g) => g && g.trim().length > 0)?.trim();
+	if (!barcode) return { ok: false, reason: 'no-barcode' };
+	const name = (d.name ?? '').trim();
+	if (!name) return { ok: false, reason: 'no-name' };
+
+	const basisG = gramsBasis(d.nutrition.basis);
+	if (basisG == null || basisG <= 0) return { ok: false, reason: 'bad-basis' };
+	const f = 100 / basisG;
+	const scale = (v: number | null | undefined): number | null =>
+		v == null || Number.isNaN(v) ? null : Math.round(v * f * 100) / 100;
+
+	return buildDatasetProduct({
+		name: name.slice(0, 500),
+		brand: d.brand ?? null,
+		language: 'de',
+		servingSize: 100,
+		servingUnit: 'g',
+		calories: scale(d.nutrition.energyKcal),
+		protein: scale(d.nutrition.protein),
+		carbs: scale(d.nutrition.carbohydrate),
+		fat: scale(d.nutrition.fat),
+		fiber: scale(d.nutrition.fiber),
+		nutrients: {
+			sugar: scale(d.nutrition.sugar),
+			saturatedFat: scale(d.nutrition.saturatedFat),
+			salt: scale(d.nutrition.salt)
+		},
+		barcode: barcode.slice(0, 32),
+		ingredientsText: d.ingredients?.slice(0, 10000) ?? null,
+		imageUrl: d.imageUrl ?? null,
+		sourceUrl: d.productUrl ?? null,
+		sourceRef: d.id,
+		crawledAt: crawledAt ?? null
+	});
+}

--- a/crawler/adapters/migros/types.ts
+++ b/crawler/adapters/migros/types.ts
@@ -1,0 +1,32 @@
+export type MigrosNutrition = {
+	basis?: string; // e.g. "100g", "200g", "100ml"
+	energyKcal?: number | null;
+	protein?: number | null;
+	carbohydrate?: number | null;
+	fat?: number | null;
+	fiber?: number | null;
+	sugar?: number | null;
+	saturatedFat?: number | null;
+	salt?: number | null;
+};
+
+export type MigrosProductDetail = {
+	id: string;
+	name: string;
+	brand?: string | null;
+	gtins?: string[];
+	productUrl?: string | null;
+	imageUrl?: string | null;
+	ingredients?: string | null;
+	nutrition: MigrosNutrition;
+};
+
+export interface MigrosClient {
+	/** Yields product ids for the configured food categories, page by page. */
+	listProductIds(opts: { resume?: { category: string; page: number } | null }): AsyncIterable<{
+		id: string;
+		cursor: { category: string; page: number };
+	}>;
+	/** Fetches and normalizes one product detail; null if unavailable. */
+	getProduct(id: string): Promise<MigrosProductDetail | null>;
+}

--- a/crawler/adapters/off/crawl-off.test.ts
+++ b/crawler/adapters/off/crawl-off.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { readDumpLines } from '../../lib/jsonl-stream';
+import { crawlOffDump } from './crawl-off';
+import { newStats } from '../../types';
+
+const FIXTURE = join(import.meta.dir, '../../fixtures/off-sample.jsonl');
+
+test('crawlOffDump emits only valid Swiss products from the fixture dump', async () => {
+	const stats = newStats();
+	const names: string[] = [];
+	for await (const product of crawlOffDump(readDumpLines(FIXTURE), { stats }))
+		names.push(product.name);
+	expect(stats.seen).toBe(6);
+	expect(stats.emitted).toBe(2);
+	expect(stats.dropped).toBe(4);
+	expect(names).toContain('Zweifel Paprika Chips');
+	expect(stats.dropReasons['not-swiss']).toBe(1);
+	expect(stats.dropReasons['no-barcode']).toBe(1);
+	expect(stats.dropReasons['no-name']).toBe(1);
+	expect(stats.dropReasons['missing-core']).toBe(1);
+});
+
+test('crawlOffDump respects the limit option', async () => {
+	const out = [];
+	for await (const p of crawlOffDump(readDumpLines(FIXTURE), { limit: 1 })) out.push(p);
+	expect(out.length).toBe(1);
+});

--- a/crawler/adapters/off/crawl-off.ts
+++ b/crawler/adapters/off/crawl-off.ts
@@ -1,0 +1,38 @@
+import type { DatasetProduct, CrawlStats } from '../../types';
+import { newStats, recordDrop } from '../../types';
+import { offDumpToDataset } from './normalize-off';
+import type { OffDumpProduct } from './types';
+
+export type OffCrawlOpts = {
+	limit?: number;
+	stats?: CrawlStats;
+	crawledAt?: string;
+	onProgress?: (stats: CrawlStats) => void;
+};
+
+export async function* crawlOffDump(
+	lines: AsyncIterable<string>,
+	opts: OffCrawlOpts = {}
+): AsyncIterable<DatasetProduct> {
+	const stats = opts.stats ?? newStats();
+	const crawledAt = opts.crawledAt ?? new Date().toISOString();
+	for await (const line of lines) {
+		stats.seen++;
+		let raw: OffDumpProduct;
+		try {
+			raw = JSON.parse(line);
+		} catch {
+			recordDrop(stats, 'bad-json');
+			continue;
+		}
+		const r = offDumpToDataset(raw, crawledAt);
+		if (!r.ok) {
+			recordDrop(stats, r.reason);
+			continue;
+		}
+		stats.emitted++;
+		if (opts.onProgress && stats.seen % 10000 === 0) opts.onProgress(stats);
+		yield r.product;
+		if (opts.limit && stats.emitted >= opts.limit) return;
+	}
+}

--- a/crawler/adapters/off/normalize-off.test.ts
+++ b/crawler/adapters/off/normalize-off.test.ts
@@ -1,0 +1,73 @@
+import { test, expect } from 'bun:test';
+import { offDumpToDataset } from './normalize-off';
+
+const swissFull = {
+	code: '7610095131003',
+	product_name: 'Zweifel Paprika Chips',
+	brands: 'Zweifel',
+	lang: 'de',
+	countries_tags: ['en:switzerland'],
+	nutriscore_grade: 'd',
+	nova_group: 4,
+	nutriments: {
+		'energy-kcal_100g': 515,
+		proteins_100g: 5.8,
+		carbohydrates_100g: 53,
+		fat_100g: 30,
+		fiber_100g: 5.6,
+		'saturated-fat_100g': 1.8,
+		salt_100g: 1.3
+	}
+};
+
+test('maps a full Swiss product to a valid dataset product', () => {
+	const r = offDumpToDataset(swissFull);
+	expect(r.ok).toBe(true);
+	if (r.ok) {
+		expect(r.product.name).toBe('Zweifel Paprika Chips');
+		expect(r.product.barcode).toBe('7610095131003');
+		expect(r.product.calories).toBe(515);
+		expect(r.product.saturatedFat).toBe(1.8);
+		expect(r.product.salt).toBe(1.3);
+		expect(r.product.nutriScore).toBe('d');
+		expect(r.product.sourceUrl).toContain('7610095131003');
+	}
+});
+
+test('rejects a non-Swiss product', () => {
+	const r = offDumpToDataset({ ...swissFull, countries_tags: ['en:france'] });
+	expect(r.ok).toBe(false);
+	if (!r.ok) expect(r.reason).toContain('not-swiss');
+});
+
+test('rejects a product with no barcode or no name', () => {
+	expect(offDumpToDataset({ ...swissFull, code: '' }).ok).toBe(false);
+	expect(offDumpToDataset({ ...swissFull, product_name: '' }).ok).toBe(false);
+});
+
+test('drops a product missing a core macro', () => {
+	const n = { ...swissFull.nutriments } as Record<string, number>;
+	delete n['fiber_100g'];
+	const r = offDumpToDataset({ ...swissFull, nutriments: n });
+	expect(r.ok).toBe(false);
+	if (!r.ok) expect(r.reason).toContain('fiber');
+});
+
+test('derives kcal from kJ when energy-kcal is absent', () => {
+	const n = { ...swissFull.nutriments } as Record<string, number>;
+	delete n['energy-kcal_100g'];
+	n['energy-kj_100g'] = 2155; // ~515 kcal
+	const r = offDumpToDataset({ ...swissFull, nutriments: n });
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(Math.round(r.product.calories)).toBe(515);
+});
+
+test('prefers product_name_de when present', () => {
+	const r = offDumpToDataset({
+		...swissFull,
+		product_name: 'Paprika Chips',
+		product_name_de: 'Paprika Chips DE'
+	});
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.product.name).toBe('Paprika Chips DE');
+});

--- a/crawler/adapters/off/normalize-off.ts
+++ b/crawler/adapters/off/normalize-off.ts
@@ -1,0 +1,57 @@
+import { extractAllNutrients } from '$lib/server/nutrient-extract';
+import { buildDatasetProduct } from '../../lib/normalize';
+import type { BuildResult } from '../../types';
+import type { OffDumpProduct } from './types';
+
+const KJ_PER_KCAL = 4.184;
+const NUTRISCORE = new Set(['a', 'b', 'c', 'd', 'e']);
+
+function num(v: number | string | undefined): number | null {
+	if (v == null) return null;
+	const n = typeof v === 'string' ? parseFloat(v) : v;
+	return Number.isNaN(n) ? null : n;
+}
+
+export function offDumpToDataset(p: OffDumpProduct, crawledAt?: string): BuildResult {
+	const code = (p.code ?? '').trim();
+	if (!code) return { ok: false, reason: 'no-barcode' };
+	const name = (p.product_name_de || p.product_name || '').trim();
+	if (!name) return { ok: false, reason: 'no-name' };
+	if (!(p.countries_tags ?? []).includes('en:switzerland'))
+		return { ok: false, reason: 'not-swiss' };
+
+	const n = (p.nutriments ?? {}) as Record<string, number | string | undefined>;
+	let calories = num(n['energy-kcal_100g']);
+	if (calories == null) {
+		const kj = num(n['energy-kj_100g']);
+		if (kj != null) calories = Math.round((kj / KJ_PER_KCAL) * 100) / 100;
+	}
+
+	const grade = (p.nutriscore_grade ?? '').toLowerCase();
+	const nova = num(p.nova_group);
+	const additives = (p.additives_tags ?? []).slice(0, 200);
+	const ingredients = (p.ingredients_text_de || p.ingredients_text || '').slice(0, 10000);
+
+	return buildDatasetProduct({
+		name: name.slice(0, 500),
+		brand: (p.brands ?? '').split(',')[0]?.trim() || null,
+		language: 'de',
+		servingSize: 100,
+		servingUnit: 'g',
+		calories,
+		protein: num(n['proteins_100g']),
+		carbs: num(n['carbohydrates_100g']),
+		fat: num(n['fat_100g']),
+		fiber: num(n['fiber_100g']),
+		nutrients: extractAllNutrients(n),
+		barcode: code.slice(0, 32),
+		nutriScore: NUTRISCORE.has(grade) ? (grade as 'a' | 'b' | 'c' | 'd' | 'e') : null,
+		novaGroup: nova != null && nova >= 1 && nova <= 4 ? Math.round(nova) : null,
+		additives: additives.length > 0 ? additives : null,
+		ingredientsText: ingredients.length > 0 ? ingredients : null,
+		imageUrl: p.image_front_url || p.image_url || null,
+		sourceUrl: `https://world.openfoodfacts.org/product/${code}`,
+		sourceRef: code,
+		crawledAt: crawledAt ?? null
+	});
+}

--- a/crawler/adapters/off/types.ts
+++ b/crawler/adapters/off/types.ts
@@ -1,0 +1,17 @@
+export type OffDumpProduct = {
+	code?: string;
+	product_name?: string;
+	product_name_de?: string;
+	brands?: string;
+	lang?: string;
+	lc?: string;
+	countries_tags?: string[];
+	nutriscore_grade?: string;
+	nova_group?: number | string;
+	additives_tags?: string[];
+	ingredients_text?: string;
+	ingredients_text_de?: string;
+	image_url?: string;
+	image_front_url?: string;
+	nutriments?: Record<string, number | string | undefined>;
+};

--- a/crawler/bun.lock
+++ b/crawler/bun.lock
@@ -1,0 +1,211 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@bissbilanz/crawler",
+      "dependencies": {
+        "migros-api-wrapper": "1.1.37",
+      },
+    },
+  },
+  "packages": {
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
+
+    "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "help-me": ["help-me@4.2.0", "", { "dependencies": { "glob": "^8.0.0", "readable-stream": "^3.6.0" } }, "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "migros-api-wrapper": ["migros-api-wrapper@1.1.37", "", { "dependencies": { "axios": "^1.8.4", "cheerio": "^1.0.0-rc.12", "deepmerge": "^4.3.1", "dotenv": "^16.4.5", "pino": "^8.6.1", "pino-pretty": "^9.1.1" } }, "sha512-D69K7y2BFc2sU+jums4nFIihSU9BiczIeHir5TSeRP9K/e1W6IXCHRLIeB1Of5RKG0wEH8pz8Bxv6S8Fv21tgg=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
+    "pino": ["pino@8.21.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^1.2.0", "pino-std-serializers": "^6.0.0", "process-warning": "^3.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^3.7.0", "thread-stream": "^2.6.0" }, "bin": { "pino": "bin.js" } }, "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@1.2.0", "", { "dependencies": { "readable-stream": "^4.0.0", "split2": "^4.0.0" } }, "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q=="],
+
+    "pino-pretty": ["pino-pretty@9.4.1", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^3.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^4.0.1", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^1.0.0", "pump": "^3.0.0", "readable-stream": "^4.0.0", "secure-json-parse": "^2.4.0", "sonic-boom": "^3.0.0", "strip-json-comments": "^3.1.1" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-loWr5SNawVycvY//hamIzyz3Fh5OSpvkcO13MwdDW+eKIGylobPLqnVGTDwDXkdmpJd1BhEG+qhDw09h6SqJiQ=="],
+
+    "pino-std-serializers": ["pino-std-serializers@6.2.2", "", {}, "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-warning": ["process-warning@3.0.0", "", {}, "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="],
+
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
+
+    "sonic-boom": ["sonic-boom@3.8.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "thread-stream": ["thread-stream@2.7.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw=="],
+
+    "undici": ["undici@7.26.0", "", {}, "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "help-me/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+  }
+}

--- a/crawler/fixtures/migros-product-detail.json
+++ b/crawler/fixtures/migros-product-detail.json
@@ -1,0 +1,21 @@
+{
+	"productId": "100001",
+	"name": "M-Classic Vollmilch UHT",
+	"brand": "M-Classic",
+	"gtins": ["7610200000001"],
+	"productUrls": { "de": "https://www.migros.ch/de/product/100001" },
+	"image": { "original": "https://image.migros.ch/100001.jpg" },
+	"nutrients": {
+		"referenceValue": "100g",
+		"values": [
+			{ "code": "energy_kcal", "value": 64 },
+			{ "code": "protein", "value": 3.3 },
+			{ "code": "carbohydrate", "value": 4.8 },
+			{ "code": "of_which_sugars", "value": 4.8 },
+			{ "code": "fat", "value": 3.5 },
+			{ "code": "of_which_saturated", "value": 2.1 },
+			{ "code": "dietary_fiber", "value": 0 },
+			{ "code": "salt", "value": 0.1 }
+		]
+	}
+}

--- a/crawler/fixtures/off-sample.jsonl
+++ b/crawler/fixtures/off-sample.jsonl
@@ -1,0 +1,6 @@
+{"code":"7610095131003","product_name":"Zweifel Paprika Chips","brands":"Zweifel","lang":"de","countries_tags":["en:switzerland"],"nutriscore_grade":"d","nova_group":4,"nutriments":{"energy-kcal_100g":515,"proteins_100g":5.8,"carbohydrates_100g":53,"fat_100g":30,"fiber_100g":5.6,"saturated-fat_100g":1.8,"salt_100g":1.3}}
+{"code":"7610095999999","product_name":"Bio Apfelsaft","brands":"Coop","lang":"de","countries_tags":["en:switzerland","en:france"],"nutriments":{"energy-kj_100g":192,"proteins_100g":0.2,"carbohydrates_100g":11,"fat_100g":0.1,"fiber_100g":0.2}}
+{"code":"3017620422003","product_name":"Nutella","brands":"Ferrero","lang":"fr","countries_tags":["en:france"],"nutriments":{"energy-kcal_100g":539,"proteins_100g":6.3,"carbohydrates_100g":57,"fat_100g":30.9,"fiber_100g":0}}
+{"code":"7610095000001","product_name":"Mystery Item","countries_tags":["en:switzerland"],"nutriments":{"energy-kcal_100g":100,"proteins_100g":1,"carbohydrates_100g":1,"fat_100g":1}}
+{"code":"","product_name":"No Barcode","countries_tags":["en:switzerland"],"nutriments":{"energy-kcal_100g":100,"proteins_100g":1,"carbohydrates_100g":1,"fat_100g":1,"fiber_100g":1}}
+{"code":"7610095000002","product_name":"","countries_tags":["en:switzerland"],"nutriments":{"energy-kcal_100g":100,"proteins_100g":1,"carbohydrates_100g":1,"fat_100g":1,"fiber_100g":1}}

--- a/crawler/index.test.ts
+++ b/crawler/index.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runOff } from './index';
+import { datasetHeaderSchema, datasetProductSchema } from '$lib/server/catalog/dataset-schema';
+
+test('runOff produces a schema-valid dataset file from the fixture dump', async () => {
+	const dump = join(import.meta.dir, 'fixtures/off-sample.jsonl');
+	const out = join(tmpdir(), `crawler-e2e-${process.pid}.jsonl`);
+	const stats = await runOff({ dumpPath: dump, outPath: out });
+	expect(stats.emitted).toBe(2);
+
+	const lines = (await Bun.file(out).text()).trim().split('\n');
+	expect(lines.length).toBe(3); // header + 2 products
+	expect(datasetHeaderSchema.safeParse(JSON.parse(lines[0])).success).toBe(true);
+	for (const l of lines.slice(1)) {
+		expect(datasetProductSchema.safeParse(JSON.parse(l)).success).toBe(true);
+	}
+});

--- a/crawler/index.ts
+++ b/crawler/index.ts
@@ -1,12 +1,15 @@
+import { rmSync } from 'node:fs';
 import { readDumpLines } from './lib/jsonl-stream';
 import { crawlOffDump } from './adapters/off/crawl-off';
 import { crawlMigros } from './adapters/migros/crawl-migros';
 import { createMigrosClient } from './adapters/migros/client';
 import { DatasetWriter } from './lib/jsonl-writer';
+import { readCheckpoint, writeCheckpoint } from './lib/checkpoint';
 import { newStats, type CrawlStats } from './types';
 
 // Root "food" category id(s) in the Migros taxonomy; refine on the host during a real crawl.
 const MIGROS_FOOD_CATEGORIES = ['7494731'];
+const MIGROS_CHECKPOINT = 'data/catalog/.migros-checkpoint.json';
 
 export async function runOff(opts: { dumpPath: string; outPath: string }): Promise<CrawlStats> {
 	const stats = newStats();
@@ -17,21 +20,32 @@ export async function runOff(opts: { dumpPath: string; outPath: string }): Promi
 		priority: 20
 	});
 	await writer.open();
-	for await (const product of crawlOffDump(readDumpLines(opts.dumpPath), {
-		stats,
-		onProgress: (s) =>
-			console.error(`[off] seen=${s.seen} emitted=${s.emitted} dropped=${s.dropped}`)
-	})) {
-		await writer.write(product);
+	try {
+		for await (const product of crawlOffDump(readDumpLines(opts.dumpPath), {
+			stats,
+			onProgress: (s) =>
+				console.error(`[off] seen=${s.seen} emitted=${s.emitted} dropped=${s.dropped}`)
+		})) {
+			await writer.write(product);
+		}
+	} finally {
+		await writer.close();
 	}
-	const count = await writer.close();
-	console.error(`[off] done: ${count} products → ${opts.outPath}`);
+	console.error(`[off] done: ${stats.emitted} products → ${opts.outPath}`);
 	console.error(`[off] drop reasons: ${JSON.stringify(stats.dropReasons)}`);
 	return stats;
 }
 
-export async function runMigros(opts: { outPath: string }): Promise<CrawlStats> {
+export async function runMigros(opts: {
+	outPath: string;
+	checkpointPath?: string;
+}): Promise<CrawlStats> {
 	const stats = newStats();
+	const checkpointPath = opts.checkpointPath ?? MIGROS_CHECKPOINT;
+	const resume = await readCheckpoint<{ category: string; page: number }>(checkpointPath);
+	if (resume)
+		console.error(`[migros] resuming from category ${resume.category} page ${resume.page}`);
+
 	const client = await createMigrosClient({ categories: MIGROS_FOOD_CATEGORIES });
 	const writer = new DatasetWriter(opts.outPath, {
 		key: 'migros',
@@ -40,16 +54,23 @@ export async function runMigros(opts: { outPath: string }): Promise<CrawlStats> 
 		priority: 10
 	});
 	await writer.open();
-	for await (const product of crawlMigros(client, {
-		stats,
-		throttleMs: 600,
-		onProgress: (s) =>
-			console.error(`[migros] seen=${s.seen} emitted=${s.emitted} dropped=${s.dropped}`)
-	})) {
-		await writer.write(product);
+	try {
+		for await (const product of crawlMigros(client, {
+			stats,
+			throttleMs: 600,
+			resume,
+			onCheckpoint: (cursor) => writeCheckpoint(checkpointPath, cursor),
+			onProgress: (s) =>
+				console.error(`[migros] seen=${s.seen} emitted=${s.emitted} dropped=${s.dropped}`)
+		})) {
+			await writer.write(product);
+		}
+	} finally {
+		await writer.close();
 	}
-	const count = await writer.close();
-	console.error(`[migros] done: ${count} products → ${opts.outPath}`);
+	// Completed cleanly → drop the checkpoint so the next run starts fresh.
+	rmSync(checkpointPath, { force: true });
+	console.error(`[migros] done: ${stats.emitted} products → ${opts.outPath}`);
 	console.error(`[migros] drop reasons: ${JSON.stringify(stats.dropReasons)}`);
 	return stats;
 }

--- a/crawler/index.ts
+++ b/crawler/index.ts
@@ -1,0 +1,79 @@
+import { readDumpLines } from './lib/jsonl-stream';
+import { crawlOffDump } from './adapters/off/crawl-off';
+import { crawlMigros } from './adapters/migros/crawl-migros';
+import { createMigrosClient } from './adapters/migros/client';
+import { DatasetWriter } from './lib/jsonl-writer';
+import { newStats, type CrawlStats } from './types';
+
+// Root "food" category id(s) in the Migros taxonomy; refine on the host during a real crawl.
+const MIGROS_FOOD_CATEGORIES = ['7494731'];
+
+export async function runOff(opts: { dumpPath: string; outPath: string }): Promise<CrawlStats> {
+	const stats = newStats();
+	const writer = new DatasetWriter(opts.outPath, {
+		key: 'off-ch',
+		name: 'Open Food Facts (Switzerland)',
+		source: 'off',
+		priority: 20
+	});
+	await writer.open();
+	for await (const product of crawlOffDump(readDumpLines(opts.dumpPath), {
+		stats,
+		onProgress: (s) =>
+			console.error(`[off] seen=${s.seen} emitted=${s.emitted} dropped=${s.dropped}`)
+	})) {
+		await writer.write(product);
+	}
+	const count = await writer.close();
+	console.error(`[off] done: ${count} products → ${opts.outPath}`);
+	console.error(`[off] drop reasons: ${JSON.stringify(stats.dropReasons)}`);
+	return stats;
+}
+
+export async function runMigros(opts: { outPath: string }): Promise<CrawlStats> {
+	const stats = newStats();
+	const client = await createMigrosClient({ categories: MIGROS_FOOD_CATEGORIES });
+	const writer = new DatasetWriter(opts.outPath, {
+		key: 'migros',
+		name: 'Migros (Switzerland)',
+		source: 'migros',
+		priority: 10
+	});
+	await writer.open();
+	for await (const product of crawlMigros(client, {
+		stats,
+		throttleMs: 600,
+		onProgress: (s) =>
+			console.error(`[migros] seen=${s.seen} emitted=${s.emitted} dropped=${s.dropped}`)
+	})) {
+		await writer.write(product);
+	}
+	const count = await writer.close();
+	console.error(`[migros] done: ${count} products → ${opts.outPath}`);
+	console.error(`[migros] drop reasons: ${JSON.stringify(stats.dropReasons)}`);
+	return stats;
+}
+
+function dateStamp(): string {
+	return new Date().toISOString().slice(0, 10);
+}
+
+async function main() {
+	const [cmd, ...args] = process.argv.slice(2);
+	if (cmd === 'off') {
+		const dumpPath = args[0];
+		if (!dumpPath) throw new Error('Usage: crawl off <dumpPath.jsonl[.gz]> [outPath]');
+		await runOff({ dumpPath, outPath: args[1] ?? `data/catalog/off-ch-${dateStamp()}.jsonl` });
+	} else if (cmd === 'migros') {
+		await runMigros({ outPath: args[0] ?? `data/catalog/migros-${dateStamp()}.jsonl` });
+	} else {
+		throw new Error(`Unknown command: ${cmd ?? '(none)'}. Expected: off | migros`);
+	}
+}
+
+if (import.meta.main) {
+	main().catch((e) => {
+		console.error(e instanceof Error ? e.message : String(e));
+		process.exit(1);
+	});
+}

--- a/crawler/lib/checkpoint.test.ts
+++ b/crawler/lib/checkpoint.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { readCheckpoint, writeCheckpoint } from './checkpoint';
+
+type Cursor = { category: string; page: number };
+
+test('round-trips a checkpoint and returns null when absent', async () => {
+	const path = join(tmpdir(), `crawler-cp-${process.pid}.json`);
+	rmSync(path, { force: true });
+	expect(await readCheckpoint<Cursor>(path)).toBeNull();
+	await writeCheckpoint(path, { category: 'snacks', page: 3 });
+	expect(await readCheckpoint<Cursor>(path)).toEqual({ category: 'snacks', page: 3 });
+});

--- a/crawler/lib/checkpoint.ts
+++ b/crawler/lib/checkpoint.ts
@@ -1,0 +1,13 @@
+export async function readCheckpoint<T = unknown>(path: string): Promise<T | null> {
+	const f = Bun.file(path);
+	if (!(await f.exists())) return null;
+	try {
+		return JSON.parse(await f.text()) as T;
+	} catch {
+		return null;
+	}
+}
+
+export async function writeCheckpoint(path: string, value: unknown): Promise<void> {
+	await Bun.write(path, JSON.stringify(value));
+}

--- a/crawler/lib/http.test.ts
+++ b/crawler/lib/http.test.ts
@@ -56,3 +56,21 @@ test('caches responses by url when a cache is provided', async () => {
 	expect(a).toEqual(b);
 	expect(calls).toBe(1);
 });
+
+test('cache key varies by request headers', async () => {
+	let calls = 0;
+	const store = new Map<string, string>();
+	const client = createPoliteClient({
+		minDelayMs: 0,
+		maxRetries: 1,
+		sleep: async () => {},
+		cache: { get: async (k) => store.get(k) ?? null, set: async (k, v) => void store.set(k, v) },
+		fetchImpl: async () => {
+			calls++;
+			return new Response(JSON.stringify({ n: calls }), { status: 200 });
+		}
+	});
+	await client.getJson('https://x.test/c', { Authorization: 'Bearer a' });
+	await client.getJson('https://x.test/c', { Authorization: 'Bearer b' });
+	expect(calls).toBe(2); // different headers → different cache entries
+});

--- a/crawler/lib/http.test.ts
+++ b/crawler/lib/http.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from 'bun:test';
+import { createPoliteClient } from './http';
+
+test('retries on failure then succeeds, applying backoff via injected sleep', async () => {
+	let calls = 0;
+	const sleeps: number[] = [];
+	const client = createPoliteClient({
+		minDelayMs: 50,
+		maxRetries: 3,
+		now: () => 0,
+		sleep: async (ms) => {
+			sleeps.push(ms);
+		},
+		fetchImpl: async () => {
+			calls++;
+			if (calls < 3) throw new Error('boom');
+			return new Response(JSON.stringify({ ok: true }), { status: 200 });
+		}
+	});
+	const res = await client.getJson<{ ok: boolean }>('https://x.test/a');
+	expect(res?.ok).toBe(true);
+	expect(calls).toBe(3);
+	expect(sleeps.filter((s) => s > 0).length).toBeGreaterThanOrEqual(2); // two backoff sleeps
+});
+
+test('returns null on a 404 without retrying', async () => {
+	let calls = 0;
+	const client = createPoliteClient({
+		minDelayMs: 0,
+		maxRetries: 3,
+		sleep: async () => {},
+		fetchImpl: async () => {
+			calls++;
+			return new Response('nope', { status: 404 });
+		}
+	});
+	expect(await client.getJson('https://x.test/missing')).toBeNull();
+	expect(calls).toBe(1);
+});
+
+test('caches responses by url when a cache is provided', async () => {
+	let calls = 0;
+	const store = new Map<string, string>();
+	const client = createPoliteClient({
+		minDelayMs: 0,
+		maxRetries: 1,
+		sleep: async () => {},
+		cache: { get: async (k) => store.get(k) ?? null, set: async (k, v) => void store.set(k, v) },
+		fetchImpl: async () => {
+			calls++;
+			return new Response(JSON.stringify({ n: calls }), { status: 200 });
+		}
+	});
+	const a = await client.getJson<{ n: number }>('https://x.test/c');
+	const b = await client.getJson<{ n: number }>('https://x.test/c');
+	expect(a).toEqual(b);
+	expect(calls).toBe(1);
+});

--- a/crawler/lib/http.ts
+++ b/crawler/lib/http.ts
@@ -31,8 +31,9 @@ export function createPoliteClient(opts: PoliteClientOpts = {}) {
 	}
 
 	async function getJson<T>(url: string, headers: Record<string, string> = {}): Promise<T | null> {
+		const cacheKey = Object.keys(headers).length > 0 ? `${url}|${JSON.stringify(headers)}` : url;
 		if (opts.cache) {
-			const hit = await opts.cache.get(url);
+			const hit = await opts.cache.get(cacheKey);
 			if (hit != null) return JSON.parse(hit) as T;
 		}
 		let attempt = 0;
@@ -43,7 +44,7 @@ export function createPoliteClient(opts: PoliteClientOpts = {}) {
 				if (res.status === 404 || res.status === 410) return null;
 				if (!res.ok) throw new Error(`HTTP ${res.status}`);
 				const text = await res.text();
-				if (opts.cache) await opts.cache.set(url, text);
+				if (opts.cache) await opts.cache.set(cacheKey, text);
 				return JSON.parse(text) as T;
 			} catch (err) {
 				attempt++;

--- a/crawler/lib/http.ts
+++ b/crawler/lib/http.ts
@@ -1,0 +1,57 @@
+export type CacheLike = {
+	get: (key: string) => Promise<string | null>;
+	set: (key: string, value: string) => Promise<void>;
+};
+
+export type PoliteClientOpts = {
+	minDelayMs?: number;
+	maxRetries?: number;
+	userAgent?: string;
+	sleep?: (ms: number) => Promise<void>;
+	fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>;
+	cache?: CacheLike;
+	now?: () => number;
+};
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function createPoliteClient(opts: PoliteClientOpts = {}) {
+	const minDelayMs = opts.minDelayMs ?? 500;
+	const maxRetries = opts.maxRetries ?? 4;
+	const sleep = opts.sleep ?? defaultSleep;
+	const doFetch = opts.fetchImpl ?? fetch;
+	const now = opts.now ?? Date.now;
+	const ua = opts.userAgent ?? 'Bissbilanz-Catalog-Crawler/1.0 (+private use; non-redistribution)';
+	let lastAt = 0;
+
+	async function throttle() {
+		const wait = Math.max(0, lastAt + minDelayMs - now());
+		if (wait > 0) await sleep(wait);
+		lastAt = now();
+	}
+
+	async function getJson<T>(url: string, headers: Record<string, string> = {}): Promise<T | null> {
+		if (opts.cache) {
+			const hit = await opts.cache.get(url);
+			if (hit != null) return JSON.parse(hit) as T;
+		}
+		let attempt = 0;
+		for (;;) {
+			await throttle();
+			try {
+				const res = await doFetch(url, { headers: { 'User-Agent': ua, ...headers } });
+				if (res.status === 404 || res.status === 410) return null;
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				const text = await res.text();
+				if (opts.cache) await opts.cache.set(url, text);
+				return JSON.parse(text) as T;
+			} catch (err) {
+				attempt++;
+				if (attempt >= maxRetries) throw err;
+				await sleep(minDelayMs * 2 ** attempt);
+			}
+		}
+	}
+
+	return { getJson };
+}

--- a/crawler/lib/jsonl-stream.test.ts
+++ b/crawler/lib/jsonl-stream.test.ts
@@ -11,3 +11,15 @@ test('splits a byte stream into lines across chunk boundaries, skipping blanks',
 		out.push(line);
 	expect(out).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
 });
+
+test('decodes a multi-byte UTF-8 char split across chunk boundaries', async () => {
+	// "ü" (U+00FC) encodes to bytes 0xC3 0xBC; split the stream between those two bytes.
+	const bytes = new TextEncoder().encode('{"n":"Grün"}\n');
+	async function* src() {
+		yield bytes.slice(0, 9); // ends on the first byte of "ü"
+		yield bytes.slice(9);
+	}
+	const out: string[] = [];
+	for await (const line of splitJsonlLines(src())) out.push(line);
+	expect(out).toEqual(['{"n":"Grün"}']);
+});

--- a/crawler/lib/jsonl-stream.test.ts
+++ b/crawler/lib/jsonl-stream.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from 'bun:test';
+import { splitJsonlLines } from './jsonl-stream';
+
+async function* chunks(parts: string[]) {
+	for (const p of parts) yield new TextEncoder().encode(p);
+}
+
+test('splits a byte stream into lines across chunk boundaries, skipping blanks', async () => {
+	const out: string[] = [];
+	for await (const line of splitJsonlLines(chunks(['{"a":1}\n{"b":', '2}\n\n{"c":3}'])))
+		out.push(line);
+	expect(out).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
+});

--- a/crawler/lib/jsonl-stream.ts
+++ b/crawler/lib/jsonl-stream.ts
@@ -1,0 +1,26 @@
+export async function* splitJsonlLines(source: AsyncIterable<Uint8Array>): AsyncIterable<string> {
+	const decoder = new TextDecoder();
+	let buf = '';
+	for await (const chunk of source) {
+		buf += decoder.decode(chunk, { stream: true });
+		let nl: number;
+		while ((nl = buf.indexOf('\n')) >= 0) {
+			const line = buf.slice(0, nl).trim();
+			buf = buf.slice(nl + 1);
+			if (line.length > 0) yield line;
+		}
+	}
+	const last = buf.trim();
+	if (last.length > 0) yield last;
+}
+
+export async function* readDumpLines(path: string): AsyncIterable<string> {
+	const file = Bun.file(path);
+	let stream: ReadableStream<Uint8Array> = file.stream();
+	if (path.endsWith('.gz')) {
+		stream = stream.pipeThrough(
+			new DecompressionStream('gzip') as unknown as ReadableWritablePair<Uint8Array, Uint8Array>
+		);
+	}
+	yield* splitJsonlLines(stream as unknown as AsyncIterable<Uint8Array>);
+}

--- a/crawler/lib/jsonl-stream.ts
+++ b/crawler/lib/jsonl-stream.ts
@@ -10,6 +10,7 @@ export async function* splitJsonlLines(source: AsyncIterable<Uint8Array>): Async
 			if (line.length > 0) yield line;
 		}
 	}
+	buf += decoder.decode(); // flush any buffered bytes from an incomplete trailing sequence
 	const last = buf.trim();
 	if (last.length > 0) yield last;
 }

--- a/crawler/lib/jsonl-writer.test.ts
+++ b/crawler/lib/jsonl-writer.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatasetWriter } from './jsonl-writer';
+import { datasetHeaderSchema, datasetProductSchema } from '$lib/server/catalog/dataset-schema';
+
+function tmpFile(name: string) {
+	return join(tmpdir(), `crawler-test-${name}-${process.pid}.jsonl`);
+}
+
+test('writes a header line then product lines, all schema-valid, with a correct count', async () => {
+	const path = tmpFile('write');
+	const w = new DatasetWriter(path, {
+		key: 'off-ch',
+		name: 'OFF (CH)',
+		source: 'off',
+		priority: 20
+	});
+	await w.open();
+	await w.write({
+		name: 'A',
+		servingSize: 100,
+		servingUnit: 'g',
+		calories: 1,
+		protein: 1,
+		carbs: 1,
+		fat: 1,
+		fiber: 1
+	});
+	await w.write({
+		name: 'B',
+		servingSize: 100,
+		servingUnit: 'g',
+		calories: 2,
+		protein: 2,
+		carbs: 2,
+		fat: 2,
+		fiber: 2
+	});
+	const count = await w.close();
+	expect(count).toBe(2);
+
+	const lines = (await Bun.file(path).text()).trim().split('\n');
+	expect(lines.length).toBe(3);
+	expect(datasetHeaderSchema.safeParse(JSON.parse(lines[0])).success).toBe(true);
+	expect(datasetProductSchema.safeParse(JSON.parse(lines[1])).success).toBe(true);
+	expect(JSON.parse(lines[0])._dataset.source).toBe('off');
+});

--- a/crawler/lib/jsonl-writer.ts
+++ b/crawler/lib/jsonl-writer.ts
@@ -1,0 +1,53 @@
+import { datasetProductSchema, type DatasetProduct } from '$lib/server/catalog/dataset-schema';
+
+export type DatasetHeaderInput = {
+	key: string;
+	name: string;
+	source: 'migros' | 'off' | 'coop';
+	priority: number;
+	version?: string;
+};
+
+export class DatasetWriter {
+	#path: string;
+	#header: DatasetHeaderInput;
+	#snapshotAt: string;
+	#sink: Bun.FileSink | null = null;
+	#count = 0;
+
+	constructor(path: string, header: DatasetHeaderInput, snapshotAt = new Date().toISOString()) {
+		this.#path = path;
+		this.#header = header;
+		this.#snapshotAt = snapshotAt;
+	}
+
+	async open(): Promise<void> {
+		this.#sink = Bun.file(this.#path).writer();
+		const headerLine = JSON.stringify({
+			_dataset: {
+				key: this.#header.key,
+				name: this.#header.name,
+				source: this.#header.source,
+				priority: this.#header.priority,
+				version: this.#header.version ?? null,
+				snapshotAt: this.#snapshotAt
+			}
+		});
+		this.#sink.write(headerLine + '\n');
+	}
+
+	async write(product: DatasetProduct): Promise<void> {
+		if (!this.#sink) throw new Error('DatasetWriter.open() not called');
+		// fail-closed: never write a line the importer would reject
+		const parsed = datasetProductSchema.safeParse(product);
+		if (!parsed.success) throw new Error(`invalid product: ${parsed.error.issues[0]?.message}`);
+		this.#sink.write(JSON.stringify(product) + '\n');
+		this.#count++;
+	}
+
+	async close(): Promise<number> {
+		if (this.#sink) await this.#sink.end();
+		this.#sink = null;
+		return this.#count;
+	}
+}

--- a/crawler/lib/normalize.test.ts
+++ b/crawler/lib/normalize.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from 'bun:test';
+import { buildDatasetProduct } from './normalize';
+
+const core = { calories: 515, protein: 5.8, carbs: 53, fat: 30, fiber: 5.6 };
+const meta = { name: 'Zweifel Paprika Chips', servingSize: 100, servingUnit: 'g' as const };
+
+test('builds a valid product from core macros + nutrients', () => {
+	const r = buildDatasetProduct({ ...meta, ...core, nutrients: { saturatedFat: 1.8, salt: 1.3 } });
+	expect(r.ok).toBe(true);
+	if (r.ok) {
+		expect(r.product.name).toBe('Zweifel Paprika Chips');
+		expect(r.product.saturatedFat).toBe(1.8);
+		expect(r.product.fiber).toBe(5.6);
+	}
+});
+
+test('drops a product missing a core macro with reason', () => {
+	const r = buildDatasetProduct({
+		...meta,
+		calories: 1,
+		protein: 1,
+		carbs: 1,
+		fat: 1,
+		fiber: null
+	});
+	expect(r.ok).toBe(false);
+	if (!r.ok) expect(r.reason).toContain('fiber');
+});
+
+test('drops a product with a negative macro', () => {
+	const r = buildDatasetProduct({ ...meta, ...core, calories: -1 });
+	expect(r.ok).toBe(false);
+});
+
+test('passes through optional quality fields', () => {
+	const r = buildDatasetProduct({
+		...meta,
+		...core,
+		barcode: '7610095131003',
+		nutriScore: 'd',
+		novaGroup: 4,
+		additives: ['en:e330'],
+		sourceUrl: 'https://example.com/p/1',
+		sourceRef: '1'
+	});
+	expect(r.ok).toBe(true);
+	if (r.ok) {
+		expect(r.product.barcode).toBe('7610095131003');
+		expect(r.product.nutriScore).toBe('d');
+	}
+});

--- a/crawler/lib/normalize.ts
+++ b/crawler/lib/normalize.ts
@@ -1,0 +1,71 @@
+import { datasetProductSchema } from '$lib/server/catalog/dataset-schema';
+import { ALL_NUTRIENT_KEYS } from '$lib/nutrients';
+import type { ServingUnit } from '$lib/units';
+import type { BuildResult } from '../types';
+
+export type NormalizerInput = {
+	name: string;
+	brand?: string | null;
+	language?: 'de' | 'fr' | 'it' | 'en' | null;
+	servingSize: number;
+	servingUnit: ServingUnit;
+	calories: number | null;
+	protein: number | null;
+	carbs: number | null;
+	fat: number | null;
+	fiber: number | null;
+	nutrients?: Record<string, number | null | undefined>;
+	barcode?: string | null;
+	nutriScore?: 'a' | 'b' | 'c' | 'd' | 'e' | null;
+	novaGroup?: number | null;
+	additives?: string[] | null;
+	ingredientsText?: string | null;
+	imageUrl?: string | null;
+	sourceUrl?: string | null;
+	sourceRef?: string | null;
+	crawledAt?: string | null;
+};
+
+const CORE = ['calories', 'protein', 'carbs', 'fat', 'fiber'] as const;
+
+export function buildDatasetProduct(input: NormalizerInput): BuildResult {
+	for (const k of CORE) {
+		const v = input[k];
+		if (v == null || Number.isNaN(v)) return { ok: false, reason: `missing-core:${k}` };
+	}
+
+	const nutrients: Record<string, number | null> = {};
+	for (const key of ALL_NUTRIENT_KEYS) {
+		const v = input.nutrients?.[key];
+		nutrients[key] = v == null || Number.isNaN(v) ? null : v;
+	}
+
+	const candidate = {
+		name: input.name,
+		brand: input.brand ?? null,
+		language: input.language ?? null,
+		servingSize: input.servingSize,
+		servingUnit: input.servingUnit,
+		calories: input.calories,
+		protein: input.protein,
+		carbs: input.carbs,
+		fat: input.fat,
+		fiber: input.fiber,
+		...nutrients,
+		barcode: input.barcode ?? null,
+		nutriScore: input.nutriScore ?? null,
+		novaGroup: input.novaGroup ?? null,
+		additives: input.additives ?? null,
+		ingredientsText: input.ingredientsText ?? null,
+		imageUrl: input.imageUrl ?? null,
+		sourceUrl: input.sourceUrl ?? null,
+		sourceRef: input.sourceRef ?? null,
+		crawledAt: input.crawledAt ?? null
+	};
+
+	const parsed = datasetProductSchema.safeParse(candidate);
+	if (!parsed.success) {
+		return { ok: false, reason: `schema:${parsed.error.issues[0]?.path.join('.') || 'invalid'}` };
+	}
+	return { ok: true, product: parsed.data };
+}

--- a/crawler/lib/smoke.test.ts
+++ b/crawler/lib/smoke.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from 'bun:test';
+import { ALL_NUTRIENT_KEYS } from '$lib/nutrients';
+import { extractAllNutrients } from '$lib/server/nutrient-extract';
+import { datasetProductSchema } from '$lib/server/catalog/dataset-schema';
+
+test('shared $lib modules resolve and work from the crawler package', () => {
+	expect(ALL_NUTRIENT_KEYS.length).toBe(43);
+	const out = extractAllNutrients({ 'saturated-fat_100g': 1.8, sodium_100g: 0.5 });
+	expect(out.saturatedFat).toBe(1.8);
+	expect(out.sodium).toBe(500); // g→mg conversion
+	const r = datasetProductSchema.safeParse({
+		name: 'X',
+		servingSize: 100,
+		servingUnit: 'g',
+		calories: 1,
+		protein: 1,
+		carbs: 1,
+		fat: 1,
+		fiber: 1
+	});
+	expect(r.success).toBe(true);
+});

--- a/crawler/package.json
+++ b/crawler/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@bissbilanz/crawler",
+	"private": true,
+	"type": "module",
+	"description": "Offline crawler that builds Bissbilanz catalog datasets (not part of the app build).",
+	"scripts": {
+		"test": "bun test",
+		"check": "tsc --noEmit",
+		"crawl": "bun run index.ts"
+	},
+	"dependencies": {
+		"migros-api-wrapper": "1.1.37"
+	}
+}

--- a/crawler/tsconfig.json
+++ b/crawler/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"types": ["bun-types"],
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": false,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"paths": {
+			"$lib": ["../src/lib"],
+			"$lib/*": ["../src/lib/*"]
+		}
+	},
+	"include": ["**/*.ts"]
+}

--- a/crawler/types.test.ts
+++ b/crawler/types.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from 'bun:test';
+import { NUTRIENT_KEYS, recordDrop, newStats } from './types';
+import { ALL_NUTRIENT_KEYS } from '$lib/nutrients';
+
+test('NUTRIENT_KEYS matches the app ALL_NUTRIENT_KEYS exactly (drift guard)', () => {
+	expect(([...NUTRIENT_KEYS] as string[]).sort()).toEqual([...ALL_NUTRIENT_KEYS].sort());
+});
+
+test('recordDrop buckets reasons by prefix before the colon', () => {
+	const s = newStats();
+	recordDrop(s, 'dup:id');
+	recordDrop(s, 'dup:barcode');
+	recordDrop(s, 'not-swiss');
+	expect(s.dropped).toBe(3);
+	expect(s.dropReasons).toEqual({ dup: 2, 'not-swiss': 1 });
+});

--- a/crawler/types.ts
+++ b/crawler/types.ts
@@ -1,0 +1,77 @@
+import type { DatasetProduct as SchemaDatasetProduct } from '$lib/server/catalog/dataset-schema';
+
+/**
+ * The 43 extended-nutrient keys. `DatasetProduct` from the shared Zod schema loses these
+ * (its `z.infer` is built via `Object.fromEntries`, so the keys vanish from the static type).
+ * We re-attach them here for typed nutrient access in the crawler. `types.test.ts` guards this
+ * list against `ALL_NUTRIENT_KEYS` (the app's single source of truth) so it can never drift.
+ */
+export const NUTRIENT_KEYS = [
+	'saturatedFat',
+	'monounsaturatedFat',
+	'polyunsaturatedFat',
+	'transFat',
+	'cholesterol',
+	'omega3',
+	'omega6',
+	'sugar',
+	'addedSugars',
+	'sugarAlcohols',
+	'starch',
+	'sodium',
+	'potassium',
+	'calcium',
+	'iron',
+	'magnesium',
+	'phosphorus',
+	'zinc',
+	'copper',
+	'manganese',
+	'selenium',
+	'iodine',
+	'fluoride',
+	'chromium',
+	'molybdenum',
+	'chloride',
+	'vitaminA',
+	'vitaminC',
+	'vitaminD',
+	'vitaminE',
+	'vitaminK',
+	'vitaminB1',
+	'vitaminB2',
+	'vitaminB3',
+	'vitaminB5',
+	'vitaminB6',
+	'vitaminB7',
+	'vitaminB9',
+	'vitaminB12',
+	'caffeine',
+	'alcohol',
+	'water',
+	'salt'
+] as const;
+
+export type NutrientKey = (typeof NUTRIENT_KEYS)[number];
+
+/** Dataset product with the extended-nutrient keys typed (see NUTRIENT_KEYS). */
+export type DatasetProduct = SchemaDatasetProduct & Partial<Record<NutrientKey, number | null>>;
+
+export type BuildResult = { ok: true; product: DatasetProduct } | { ok: false; reason: string };
+
+export type CrawlStats = {
+	seen: number;
+	emitted: number;
+	dropped: number;
+	dropReasons: Record<string, number>;
+};
+
+export function newStats(): CrawlStats {
+	return { seen: 0, emitted: 0, dropped: 0, dropReasons: {} };
+}
+
+export function recordDrop(stats: CrawlStats, reason: string): void {
+	stats.dropped++;
+	const key = reason.split(':')[0];
+	stats.dropReasons[key] = (stats.dropReasons[key] ?? 0) + 1;
+}


### PR DESCRIPTION
## Summary

Adds the **catalog crawler** — an offline Bun tool that builds normalized JSONL datasets for the access-gated base food catalog. Stacked on and targeting `feat/base-food-catalog` (not `main`).

It is **not part of the SvelteKit app**, its build, or `bun run security` scope — nothing under `src/` imports it. Crawled *data* is never committed: datasets are written to git-ignored `data/catalog/` and rejected by the `no-catalog-data` pre-commit hook.

## Sources

- **Open Food Facts** — streams a downloaded ODbL bulk dump (`.jsonl` / `.jsonl.gz`), filters to Swiss products with full core macros, never loading the (tens-of-GB) dump into memory.
- **Migros** — live API via `migros-api-wrapper`, accessed politely (fixed-delay throttle, on-disk response cache, descriptive User-Agent, exponential-backoff retry); checkpoints progress.

## Design

- Each adapter splits a **pure, tested normalizer** from thin live-fetch glue, so the suite is fully fixture-driven (no live network).
- Every emitted row is validated against the shared Zod schema `src/lib/server/catalog/dataset-schema.ts`, so a produced file always imports fail-closed via `catalog:import`.
- Shared lib covers streaming JSONL read/write, throttled+cached HTTP, checkpointing, and normalization helpers.
- Retailer images are referenced by source URL only — never rehosted.

## Commits

- `feat(crawler)`: scaffold Bun package + shared lib (normalize, jsonl, http, checkpoint)
- `feat(crawler)`: OFF bulk-dump adapter (Swiss/food filter + streaming crawl)
- `feat(crawler)`: Migros adapter (normalizer, crawl loop, migros-api-wrapper client)
- `feat(crawler)`: CLI entrypoint (`off` | `migros`) + end-to-end test
- `fix(crawler)`: address review — writer try/finally, checkpoint-after-yield, ml serving unit, stream flush + header-keyed cache
- `chore`: ignore entire `.claude` directory

## Testing

`cd crawler && bun test` → **37 pass / 0 fail** (111 assertions, 13 files), all fixture-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
