### PR TITLE
refactor: unify MCP tool schemas with shared REST validation (Phase 3)

### DIFF
--- a/src/lib/server/mcp/create-handlers.ts
+++ b/src/lib/server/mcp/create-handlers.ts
@@ -371,9 +371,12 @@ export function createHandlers(d: HandlerDeps) {
 		userId: string,
 		args: {
 			entryId: string;
+			foodId?: string;
+			recipeId?: string;
+			date?: string;
 			servings?: number;
 			mealType?: string;
-			notes?: string;
+			notes?: string | null;
 			eatenAt?: string;
 			quickName?: string | null;
 			quickCalories?: number | null;

--- a/src/lib/server/mcp/create-handlers.ts
+++ b/src/lib/server/mcp/create-handlers.ts
@@ -88,6 +88,7 @@ import type {
 	getFastingDays
 } from '$lib/server/day-properties';
 import type { getCalendarStats } from '$lib/server/stats';
+import { isZodError } from '$lib/server/errors';
 
 export type HandlerDeps = {
 	// Foods
@@ -174,6 +175,19 @@ export type HandlerDeps = {
 	searchProducts: typeof searchProducts;
 };
 
+function errorPayload(e: unknown): {
+	error: string;
+	issues?: Array<{ path: string; message: string }>;
+} {
+	if (isZodError(e)) {
+		return {
+			error: 'validation_failed',
+			issues: e.issues.map((i) => ({ path: i.path.join('.'), message: i.message }))
+		};
+	}
+	return { error: e instanceof Error ? e.message : 'Unexpected error' };
+}
+
 export function createHandlers(d: HandlerDeps) {
 	function wrapError(op: string, e: unknown): never {
 		throw new Error(`Failed to ${op}: ${e instanceof Error ? e.message : String(e)}`);
@@ -239,7 +253,7 @@ export function createHandlers(d: HandlerDeps) {
 	const handleCreateFood = async (userId: string, payload: unknown) => {
 		try {
 			const result = await d.createFood(userId, payload);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { foodId: result.data.id, success: true, food: result.data };
 		} catch (e) {
 			wrapError('create food', e);
@@ -249,7 +263,7 @@ export function createHandlers(d: HandlerDeps) {
 	const handleCreateRecipe = async (userId: string, payload: unknown) => {
 		try {
 			const result = await d.createRecipe(userId, payload);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { recipeId: result.data.id, success: true, recipe: result.data };
 		} catch (e) {
 			wrapError('create recipe', e);
@@ -259,7 +273,7 @@ export function createHandlers(d: HandlerDeps) {
 	const handleLogFood = async (userId: string, payload: unknown) => {
 		try {
 			const result = await d.createEntry(userId, payload);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			const date = result.data.date ?? d.today();
 			const dailyStatus = await getDailyStatusForDate(userId, date);
 			return { entryId: result.data.id, success: true, dailyStatus };
@@ -323,7 +337,7 @@ export function createHandlers(d: HandlerDeps) {
 
 			const result = await d.logSupplement(userId, id, targetDate);
 			if (!result.success) {
-				return { success: false, error: result.error.message };
+				return { success: false, ...errorPayload(result.error) };
 			}
 
 			const supplement = await d.getSupplementById(userId, id);
@@ -389,7 +403,7 @@ export function createHandlers(d: HandlerDeps) {
 		try {
 			const { entryId, ...rest } = args;
 			const result = await d.updateEntry(userId, entryId, rest);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			const date = result.data?.date ?? d.today();
 			const dailyStatus = await getDailyStatusForDate(userId, date);
 			return { success: true, entryId, dailyStatus };
@@ -421,7 +435,7 @@ export function createHandlers(d: HandlerDeps) {
 	const handleUpdateGoals = async (userId: string, payload: unknown) => {
 		try {
 			const result = await d.upsertGoals(userId, payload);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, goals: result.data };
 		} catch (e) {
 			wrapError('update goals', e);
@@ -480,7 +494,7 @@ export function createHandlers(d: HandlerDeps) {
 				entryDate: args.date,
 				notes: args.notes
 			});
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return {
 				success: true,
 				entryId: result.data.id,
@@ -587,7 +601,7 @@ export function createHandlers(d: HandlerDeps) {
 		try {
 			const { foodId, ...rest } = args;
 			const result = await d.updateFood(userId, foodId, rest);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, foodId };
 		} catch (e) {
 			wrapError('update food', e);
@@ -624,7 +638,7 @@ export function createHandlers(d: HandlerDeps) {
 		try {
 			const { recipeId, ...rest } = args;
 			const result = await d.updateRecipe(userId, recipeId, rest);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, recipeId };
 		} catch (e) {
 			wrapError('update recipe', e);
@@ -690,7 +704,7 @@ export function createHandlers(d: HandlerDeps) {
 						}
 					: args;
 			const result = await d.createSupplement(userId, normalized);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, supplementId: result.data.id };
 		} catch (e) {
 			wrapError('create supplement', e);
@@ -718,7 +732,7 @@ export function createHandlers(d: HandlerDeps) {
 					: {})
 			};
 			const result = await d.updateSupplement(userId, supplementId, normalized);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, supplementId };
 		} catch (e) {
 			wrapError('update supplement', e);
@@ -753,7 +767,7 @@ export function createHandlers(d: HandlerDeps) {
 		try {
 			const { weightId, ...rest } = args;
 			const result = await d.updateWeightEntry(userId, weightId, rest);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, weightId };
 		} catch (e) {
 			wrapError('update weight', e);
@@ -843,7 +857,7 @@ export function createHandlers(d: HandlerDeps) {
 				wakeUps: args.wakeUps ?? null,
 				notes: args.notes ?? null
 			});
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, entryId: result.data.id, entry: result.data };
 		} catch (e) {
 			wrapError('log sleep', e);
@@ -887,7 +901,7 @@ export function createHandlers(d: HandlerDeps) {
 		try {
 			const { id, ...rest } = args;
 			const result = await d.updateSleepEntry(userId, id, rest);
-			if (!result.success) return { error: result.error.message };
+			if (!result.success) return errorPayload(result.error);
 			return { success: true, entryId: id };
 		} catch (e) {
 			wrapError('update sleep', e);

--- a/src/lib/server/mcp/create-handlers.ts
+++ b/src/lib/server/mcp/create-handlers.ts
@@ -471,7 +471,7 @@ export function createHandlers(d: HandlerDeps) {
 
 	const handleLogWeight = async (
 		userId: string,
-		args: { weightKg: number; date?: string; notes?: string }
+		args: { weightKg: number; date?: string; notes?: string | null }
 	) => {
 		try {
 			const previous = await d.getLatestWeight(userId);
@@ -827,10 +827,10 @@ export function createHandlers(d: HandlerDeps) {
 			durationMinutes: number;
 			quality: number;
 			date?: string;
-			bedtime?: string;
-			wakeTime?: string;
-			wakeUps?: number;
-			notes?: string;
+			bedtime?: string | null;
+			wakeTime?: string | null;
+			wakeUps?: number | null;
+			notes?: string | null;
 		}
 	) => {
 		try {

--- a/src/lib/server/mcp/safe.ts
+++ b/src/lib/server/mcp/safe.ts
@@ -1,0 +1,40 @@
+import { ResultValidationError } from '$lib/server/errors';
+
+type McpResult = {
+	content: { type: 'text'; text: string }[];
+	isError?: true;
+};
+
+export const asText = (payload: unknown): McpResult => ({
+	content: [
+		{
+			type: 'text' as const,
+			text: JSON.stringify(payload, null, 2)
+		}
+	]
+});
+
+export const safe = <T extends unknown[], R>(fn: (...args: T) => Promise<R>) => {
+	return async (...args: T): Promise<McpResult> => {
+		try {
+			return asText(await fn(...args));
+		} catch (e) {
+			if (e instanceof ResultValidationError) {
+				return {
+					...asText({
+						error: 'validation_failed',
+						issues: e.zodError.issues.map((i) => ({
+							path: i.path.join('.'),
+							message: i.message
+						}))
+					}),
+					isError: true
+				};
+			}
+			return {
+				...asText({ error: e instanceof Error ? e.message : 'Unexpected error' }),
+				isError: true
+			};
+		}
+	};
+};

--- a/src/lib/server/mcp/schema-utils.ts
+++ b/src/lib/server/mcp/schema-utils.ts
@@ -1,0 +1,13 @@
+import type { z } from 'zod';
+
+export function describeShape<S extends z.ZodRawShape>(
+	shape: S,
+	docs: Partial<Record<keyof S & string, string>>
+): S {
+	const out: Record<string, z.ZodType> = {};
+	for (const [key, schema] of Object.entries(shape)) {
+		const doc = docs[key as keyof S & string];
+		out[key] = doc ? (schema as z.ZodType).describe(doc) : (schema as z.ZodType);
+	}
+	return out as unknown as S;
+}

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -9,6 +9,7 @@ import { goalsSchema } from '$lib/server/validation/goals';
 import { dayPropertiesSetSchema } from '$lib/server/validation/day-properties';
 import { weightCreateSchema, weightUpdateSchema } from '$lib/server/validation/weight';
 import { sleepCreateSchema, sleepUpdateSchema } from '$lib/server/validation/sleep';
+import { scheduleTypeValues } from '$lib/supplement-units';
 import {
 	handleCreateFood,
 	handleUpdateFood,
@@ -594,11 +595,9 @@ export function createMcpServer(userId: string): McpServer {
 				"Create a new supplement with schedule and ingredients. Each ingredient needs a backing food (kind='supplement') that carries its nutrient data. Pass `foodId` to reuse an existing backing food, or `food: { name, nutrients... }` to create one inline.",
 			inputSchema: {
 				name: z.string().describe('Supplement name'),
-				scheduleType: z
-					.enum(['daily', 'every_other_day', 'weekly', 'specific_days'])
-					.describe('Schedule type'),
+				scheduleType: z.enum(scheduleTypeValues).describe('Schedule type'),
 				scheduleDays: z
-					.array(z.number())
+					.array(z.number().int().min(0).max(6))
 					.optional()
 					.describe('Days of week (0=Sun..6=Sat) for weekly/specific_days'),
 				scheduleStartDate: z.string().optional().describe('Start date in YYYY-MM-DD format'),
@@ -609,6 +608,7 @@ export function createMcpServer(userId: string): McpServer {
 				ingredients: z
 					.array(supplementIngredientInputSchema)
 					.min(1)
+					.max(50)
 					.describe('At least one ingredient'),
 				isActive: z
 					.boolean()
@@ -642,11 +642,11 @@ export function createMcpServer(userId: string): McpServer {
 			inputSchema: {
 				supplementId: z.string().describe('The supplement ID to update'),
 				name: z.string().optional().describe('New name'),
-				scheduleType: z
-					.enum(['daily', 'every_other_day', 'weekly', 'specific_days'])
+				scheduleType: z.enum(scheduleTypeValues).optional().describe('New schedule type'),
+				scheduleDays: z
+					.array(z.number().int().min(0).max(6))
 					.optional()
-					.describe('New schedule type'),
-				scheduleDays: z.array(z.number()).optional().describe('New days of week'),
+					.describe('New days of week'),
 				scheduleStartDate: z.string().optional().describe('New start date'),
 				timeOfDay: z
 					.enum(['morning', 'noon', 'evening'])
@@ -657,6 +657,7 @@ export function createMcpServer(userId: string): McpServer {
 				ingredients: z
 					.array(supplementIngredientInputSchema)
 					.min(1)
+					.max(50)
 					.optional()
 					.describe('New ingredients (replaces all; must have at least one)')
 			},

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -7,6 +7,8 @@ import { entryBaseSchema, entryUpdateSchema } from '$lib/server/validation/entri
 import { recipeCreateSchema, recipeUpdateSchema } from '$lib/server/validation/recipes';
 import { goalsSchema } from '$lib/server/validation/goals';
 import { dayPropertiesSetSchema } from '$lib/server/validation/day-properties';
+import { weightCreateSchema, weightUpdateSchema } from '$lib/server/validation/weight';
+import { sleepCreateSchema, sleepUpdateSchema } from '$lib/server/validation/sleep';
 import {
 	handleCreateFood,
 	handleUpdateFood,
@@ -381,9 +383,11 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Log a body weight measurement.',
 			inputSchema: {
-				weightKg: z.number().describe('Weight in kilograms'),
-				date: z.string().optional().describe('Date in YYYY-MM-DD format. Defaults to today.'),
-				notes: z.string().optional().describe('Optional notes')
+				weightKg: weightCreateSchema.shape.weightKg.describe('Weight in kilograms'),
+				date: weightCreateSchema.shape.entryDate
+					.optional()
+					.describe('Date in YYYY-MM-DD format. Defaults to today.'),
+				notes: weightCreateSchema.shape.notes.describe('Optional notes')
 			},
 			annotations: WRITE
 		},
@@ -691,10 +695,12 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Update an existing weight entry.',
 			inputSchema: {
-				weightId: z.string().describe('The weight entry ID to update'),
-				weightKg: z.number().optional().describe('New weight in kilograms'),
-				entryDate: z.string().optional().describe('New date in YYYY-MM-DD format'),
-				notes: z.string().optional().nullable().describe('New notes')
+				weightId: z.string().uuid().describe('The weight entry ID to update'),
+				...describeShape(weightUpdateSchema.shape, {
+					weightKg: 'New weight in kilograms',
+					entryDate: 'New date in YYYY-MM-DD format',
+					notes: 'New notes'
+				})
 			},
 			annotations: UPDATE
 		},
@@ -718,32 +724,21 @@ export function createMcpServer(userId: string): McpServer {
 		{
 			description: 'Log a sleep entry. Records duration and quality for a given date.',
 			inputSchema: {
-				durationMinutes: z
-					.number()
-					.int()
-					.min(1)
-					.max(1440)
-					.describe('Total sleep duration in minutes'),
-				quality: z
-					.number()
-					.int()
-					.min(1)
-					.max(10)
-					.describe('Sleep quality rating from 1 (poor) to 10 (great)'),
-				date: z
-					.string()
-					.regex(/^\d{4}-\d{2}-\d{2}$/)
+				durationMinutes: sleepCreateSchema.shape.durationMinutes.describe(
+					'Total sleep duration in minutes'
+				),
+				quality: sleepCreateSchema.shape.quality.describe(
+					'Sleep quality rating from 1 (poor) to 10 (great)'
+				),
+				date: sleepCreateSchema.shape.entryDate
 					.optional()
 					.describe('Date in YYYY-MM-DD format. Defaults to today.'),
-				bedtime: z.string().optional().describe('Bedtime as ISO datetime string'),
-				wakeTime: z.string().optional().describe('Wake time as ISO datetime string'),
-				wakeUps: z
-					.number()
-					.int()
-					.min(0)
-					.optional()
-					.describe('Number of times woken up during the night'),
-				notes: z.string().optional().describe('Optional notes')
+				bedtime: sleepCreateSchema.shape.bedtime.describe('Bedtime as ISO datetime string'),
+				wakeTime: sleepCreateSchema.shape.wakeTime.describe('Wake time as ISO datetime string'),
+				wakeUps: sleepCreateSchema.shape.wakeUps.describe(
+					'Number of times woken up during the night'
+				),
+				notes: sleepCreateSchema.shape.notes.describe('Optional notes')
 			},
 			annotations: WRITE
 		},
@@ -784,17 +779,15 @@ export function createMcpServer(userId: string): McpServer {
 			description: 'Update an existing sleep entry.',
 			inputSchema: {
 				id: z.string().uuid().describe('Sleep entry ID to update'),
-				durationMinutes: z.number().int().min(1).max(1440).optional(),
-				quality: z.number().int().min(1).max(10).optional(),
-				entryDate: z
-					.string()
-					.regex(/^\d{4}-\d{2}-\d{2}$/)
-					.optional()
-					.describe('New date in YYYY-MM-DD format'),
-				bedtime: z.string().optional().nullable(),
-				wakeTime: z.string().optional().nullable(),
-				wakeUps: z.number().int().min(0).optional().nullable(),
-				notes: z.string().optional().nullable()
+				...describeShape(sleepUpdateSchema.shape, {
+					durationMinutes: 'New total sleep duration in minutes',
+					quality: 'New sleep quality rating from 1 (poor) to 10 (great)',
+					entryDate: 'New date in YYYY-MM-DD format',
+					bedtime: 'New bedtime as ISO datetime string (null to clear)',
+					wakeTime: 'New wake time as ISO datetime string (null to clear)',
+					wakeUps: 'New number of wake-ups (null to clear)',
+					notes: 'New notes (null to clear)'
+				})
 			},
 			annotations: UPDATE
 		},

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -4,6 +4,7 @@ import { safe } from './safe';
 import { describeShape } from './schema-utils';
 import { servingUnitValues } from '$lib/units';
 import { foodCreateSchema, foodUpdateSchema } from '$lib/server/validation/foods';
+import { entryBaseSchema, entryUpdateSchema } from '$lib/server/validation/entries';
 import {
 	handleCreateFood,
 	handleUpdateFood,
@@ -203,47 +204,33 @@ export function createMcpServer(userId: string): McpServer {
 		safe((args) => handleCreateRecipe(userId, args))
 	);
 
+	const ENTRY_FIELD_DOCS = {
+		foodId: 'Food ID to log',
+		recipeId: 'Recipe ID to log',
+		mealType:
+			'Meal type. Default values: "Breakfast", "Lunch", "Dinner", "Snacks". Custom meal types are also supported if configured by the user.',
+		servings: 'Number of servings',
+		notes: 'Optional notes for the entry',
+		date: 'Date in YYYY-MM-DD format. Defaults to today.',
+		quickName: 'Label for quick log entry (e.g., "Restaurant lunch")',
+		quickCalories: 'Calories for quick log (use instead of foodId/recipeId)',
+		quickProtein: 'Protein in grams for quick log',
+		quickCarbs: 'Carbs in grams for quick log',
+		quickFat: 'Fat in grams for quick log',
+		quickFiber: 'Fiber in grams for quick log',
+		eatenAt:
+			'When the food was eaten, as ISO 8601 datetime with timezone (e.g., "2025-01-15T12:30:00+01:00"). Defaults to current time if not provided.'
+	};
+
 	server.registerTool(
 		'log_food',
 		{
 			description:
 				"Log a food entry to the user's daily diary. Specify either a foodId, recipeId, or quickCalories for a quick log (e.g., eating out). If no date is provided, the entry is logged for today. Returns the updated daily nutrition status.",
-			inputSchema: {
-				foodId: z.string().optional().describe('Food ID to log'),
-				recipeId: z.string().optional().describe('Recipe ID to log'),
-				mealType: z
-					.string()
-					.describe(
-						'Meal type. Default values: "Breakfast", "Lunch", "Dinner", "Snacks". Custom meal types are also supported if configured by the user.'
-					),
-				servings: z.number().describe('Number of servings'),
-				notes: z.string().optional().describe('Optional notes for the entry'),
-				date: z.string().optional().describe('Date in YYYY-MM-DD format. Defaults to today.'),
-				quickName: z
-					.string()
-					.optional()
-					.describe('Label for quick log entry (e.g., "Restaurant lunch")'),
-				quickCalories: z
-					.number()
-					.nonnegative()
-					.optional()
-					.describe('Calories for quick log (use instead of foodId/recipeId)'),
-				quickProtein: z
-					.number()
-					.nonnegative()
-					.optional()
-					.describe('Protein in grams for quick log'),
-				quickCarbs: z.number().nonnegative().optional().describe('Carbs in grams for quick log'),
-				quickFat: z.number().nonnegative().optional().describe('Fat in grams for quick log'),
-				quickFiber: z.number().nonnegative().optional().describe('Fiber in grams for quick log'),
-				eatenAt: z
-					.string()
-					.datetime({ offset: true })
-					.optional()
-					.describe(
-						'When the food was eaten, as ISO 8601 datetime with timezone (e.g., "2025-01-15T12:30:00+01:00"). Defaults to current time if not provided.'
-					)
-			},
+			inputSchema: describeShape(
+				{ ...entryBaseSchema.shape, date: entryBaseSchema.shape.date.optional() },
+				ENTRY_FIELD_DOCS
+			),
 			annotations: WRITE
 		},
 		safe((args) => handleLogFood(userId, { ...args, date: args.date ?? today() }))
@@ -294,50 +281,10 @@ export function createMcpServer(userId: string): McpServer {
 		'update_entry',
 		{
 			description:
-				'Update an existing food entry. Can change servings, meal type, notes, or quick log fields.',
+				'Update an existing food entry. Can change servings, meal type, notes, date, food/recipe reference, or quick log fields.',
 			inputSchema: {
-				entryId: z.string().describe('ID of the entry to update'),
-				servings: z.number().optional().describe('New number of servings'),
-				mealType: z
-					.string()
-					.optional()
-					.describe(
-						'New meal type. Default values: "Breakfast", "Lunch", "Dinner", "Snacks". Custom meal types are also supported if configured by the user.'
-					),
-				notes: z.string().optional().describe('New notes'),
-				quickName: z.string().optional().nullable().describe('New label for quick log entry'),
-				quickCalories: z
-					.number()
-					.nonnegative()
-					.optional()
-					.nullable()
-					.describe('New calories for quick log'),
-				quickProtein: z
-					.number()
-					.nonnegative()
-					.optional()
-					.nullable()
-					.describe('New protein for quick log'),
-				quickCarbs: z
-					.number()
-					.nonnegative()
-					.optional()
-					.nullable()
-					.describe('New carbs for quick log'),
-				quickFat: z.number().nonnegative().optional().nullable().describe('New fat for quick log'),
-				quickFiber: z
-					.number()
-					.nonnegative()
-					.optional()
-					.nullable()
-					.describe('New fiber for quick log'),
-				eatenAt: z
-					.string()
-					.datetime({ offset: true })
-					.optional()
-					.describe(
-						'When the food was eaten, as ISO 8601 datetime with timezone. Omit to leave unchanged.'
-					)
+				entryId: z.string().uuid().describe('ID of the entry to update'),
+				...describeShape(entryUpdateSchema.shape, ENTRY_FIELD_DOCS)
 			},
 			annotations: UPDATE
 		},

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -2,9 +2,11 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { z } from 'zod';
 import { safe } from './safe';
 import { describeShape } from './schema-utils';
-import { servingUnitValues } from '$lib/units';
 import { foodCreateSchema, foodUpdateSchema } from '$lib/server/validation/foods';
 import { entryBaseSchema, entryUpdateSchema } from '$lib/server/validation/entries';
+import { recipeCreateSchema, recipeUpdateSchema } from '$lib/server/validation/recipes';
+import { goalsSchema } from '$lib/server/validation/goals';
+import { dayPropertiesSetSchema } from '$lib/server/validation/day-properties';
 import {
 	handleCreateFood,
 	handleUpdateFood,
@@ -175,30 +177,21 @@ export function createMcpServer(userId: string): McpServer {
 		safe((args) => handleCreateFood(userId, args))
 	);
 
+	const RECIPE_FIELD_DOCS = {
+		name: 'Recipe name',
+		totalServings: 'Number of servings the recipe makes',
+		ingredients:
+			'List of ingredients. Each needs foodId (from the database), quantity, and servingUnit.',
+		isFavorite: 'Mark as favorite',
+		imageUrl: 'Image URL or relative path (null to clear)'
+	};
+
 	server.registerTool(
 		'create_recipe',
 		{
 			description:
 				'Create a new recipe with multiple food ingredients. Each ingredient references a food ID from the database.',
-			inputSchema: {
-				name: z.string().describe('Recipe name'),
-				totalServings: z.number().describe('Number of servings the recipe makes'),
-				ingredients: z
-					.array(
-						z.object({
-							foodId: z.string().describe('Food ID from the database'),
-							quantity: z.number().describe('Quantity of the food'),
-							servingUnit: z.enum(servingUnitValues).describe('Unit for the quantity')
-						})
-					)
-					.describe('List of ingredients'),
-				isFavorite: z.boolean().optional().describe('Mark as favorite'),
-				imageUrl: z
-					.string()
-					.nullable()
-					.optional()
-					.describe('Image URL or relative path (null to clear)')
-			},
+			inputSchema: describeShape(recipeCreateSchema.shape, RECIPE_FIELD_DOCS),
 			annotations: WRITE
 		},
 		safe((args) => handleCreateRecipe(userId, args))
@@ -325,20 +318,15 @@ export function createMcpServer(userId: string): McpServer {
 		'update_goals',
 		{
 			description: 'Set or update daily nutrition goals.',
-			inputSchema: {
-				calorieGoal: z.number().positive().describe('Daily calorie goal'),
-				proteinGoal: z.number().nonnegative().describe('Daily protein goal in grams'),
-				carbGoal: z.number().nonnegative().describe('Daily carbohydrate goal in grams'),
-				fatGoal: z.number().nonnegative().describe('Daily fat goal in grams'),
-				fiberGoal: z.number().nonnegative().describe('Daily fiber goal in grams'),
-				sodiumGoal: z
-					.number()
-					.nonnegative()
-					.nullable()
-					.optional()
-					.describe('Daily sodium goal in mg'),
-				sugarGoal: z.number().nonnegative().nullable().optional().describe('Daily sugar goal in g')
-			},
+			inputSchema: describeShape(goalsSchema.shape, {
+				calorieGoal: 'Daily calorie goal',
+				proteinGoal: 'Daily protein goal in grams',
+				carbGoal: 'Daily carbohydrate goal in grams',
+				fatGoal: 'Daily fat goal in grams',
+				fiberGoal: 'Daily fiber goal in grams',
+				sodiumGoal: 'Daily sodium goal in mg (null to clear)',
+				sugarGoal: 'Daily sugar goal in grams (null to clear)'
+			}),
 			annotations: UPDATE
 		},
 		safe((args) => handleUpdateGoals(userId, args))
@@ -541,25 +529,8 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Update an existing recipe. Can change name, servings, or replace all ingredients.',
 			inputSchema: {
-				recipeId: z.string().describe('The recipe ID to update'),
-				name: z.string().optional().describe('New recipe name'),
-				totalServings: z.number().optional().describe('New number of servings'),
-				ingredients: z
-					.array(
-						z.object({
-							foodId: z.string().describe('Food ID from the database'),
-							quantity: z.number().describe('Quantity of the food'),
-							servingUnit: z.enum(servingUnitValues).describe('Unit for the quantity')
-						})
-					)
-					.optional()
-					.describe('New list of ingredients (replaces all existing)'),
-				isFavorite: z.boolean().optional().describe('Mark as favorite'),
-				imageUrl: z
-					.string()
-					.nullable()
-					.optional()
-					.describe('Image URL or relative path (null to clear)')
+				recipeId: z.string().uuid().describe('The recipe ID to update'),
+				...describeShape(recipeUpdateSchema.shape, RECIPE_FIELD_DOCS)
 			},
 			annotations: UPDATE
 		},
@@ -1025,10 +996,10 @@ export function createMcpServer(userId: string): McpServer {
 		'set_day_properties',
 		{
 			description: 'Set properties for a specific day, such as marking it as a fasting day.',
-			inputSchema: {
-				date: dateStr.describe('Date in YYYY-MM-DD format'),
-				isFastingDay: z.boolean().describe('Whether the day is a fasting day')
-			},
+			inputSchema: describeShape(dayPropertiesSetSchema.shape, {
+				date: 'Date in YYYY-MM-DD format',
+				isFastingDay: 'Whether the day is a fasting day'
+			}),
 			annotations: UPDATE
 		},
 		safe((args) => handleSetDayProperties(userId, args))

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -1,5 +1,7 @@
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { safe } from './safe';
+import { describeShape } from './schema-utils';
 import { servingUnitValues } from '$lib/units';
 import {
 	handleCreateFood,
@@ -81,26 +83,6 @@ export function createMcpServer(userId: string): McpServer {
 		name: MCP_SERVER_NAME,
 		version: MCP_SERVER_VERSION
 	});
-
-	const asText = (payload: unknown) => ({
-		content: [
-			{
-				type: 'text' as const,
-				text: JSON.stringify(payload, null, 2)
-			}
-		]
-	});
-
-	const safe = <T extends unknown[], R>(fn: (...args: T) => Promise<R>) => {
-		return async (...args: T) => {
-			try {
-				return asText(await fn(...args));
-			} catch (e) {
-				const message = e instanceof Error ? e.message : String(e);
-				return asText({ error: message });
-			}
-		};
-	};
 
 	server.registerTool(
 		'get_daily_status',

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { safe } from './safe';
 import { describeShape } from './schema-utils';
 import { servingUnitValues } from '$lib/units';
+import { foodCreateSchema, foodUpdateSchema } from '$lib/server/validation/foods';
 import {
 	handleCreateFood,
 	handleUpdateFood,
@@ -138,53 +139,36 @@ export function createMcpServer(userId: string): McpServer {
 			.describe(`${n.key} in ${n.unit} per serving`);
 	}
 
+	const NUTRIENT_DOCS = Object.fromEntries(
+		ALL_NUTRIENTS.map((n) => [n.key, `${n.key} in ${n.unit} per serving`])
+	);
+
+	const FOOD_FIELD_DOCS = {
+		name: 'Food name',
+		brand: 'Brand name',
+		servingSize: 'Serving size amount',
+		servingUnit: 'Serving unit (e.g., "g", "ml", "oz")',
+		calories: 'Calories per serving',
+		protein: 'Protein in grams per serving',
+		carbs: 'Carbohydrates in grams per serving',
+		fat: 'Fat in grams per serving',
+		fiber: 'Fiber in grams per serving',
+		barcode: 'Barcode number',
+		isFavorite: 'Mark as favorite',
+		nutriScore: 'Nutri-Score grade (null to clear)',
+		novaGroup: 'NOVA food processing group 1-4 (null to clear)',
+		additives: 'List of additives (null to clear)',
+		ingredientsText: 'Full ingredients text (null to clear)',
+		imageUrl: 'Image URL or relative path (null to clear)',
+		...NUTRIENT_DOCS
+	};
+
 	server.registerTool(
 		'create_food',
 		{
 			description:
 				"Create a new food item in the user's food database with nutritional information per serving. Supports extended nutrients (vitamins, minerals, etc.).",
-			inputSchema: {
-				name: z.string().describe('Food name'),
-				brand: z.string().optional().describe('Brand name'),
-				servingSize: z.number().describe('Serving size amount'),
-				servingUnit: z.enum(servingUnitValues).describe('Serving unit (e.g., "g", "ml", "oz")'),
-				calories: z.number().nonnegative().describe('Calories per serving'),
-				protein: z.number().nonnegative().describe('Protein in grams per serving'),
-				carbs: z.number().nonnegative().describe('Carbohydrates in grams per serving'),
-				fat: z.number().nonnegative().describe('Fat in grams per serving'),
-				fiber: z.number().nonnegative().describe('Fiber in grams per serving'),
-				barcode: z.string().optional().describe('Barcode number'),
-				isFavorite: z.boolean().optional().describe('Mark as favorite'),
-				nutriScore: z
-					.enum(['a', 'b', 'c', 'd', 'e'])
-					.nullable()
-					.optional()
-					.describe('Nutri-Score grade (null to clear)'),
-				novaGroup: z
-					.number()
-					.int()
-					.min(1)
-					.max(4)
-					.nullable()
-					.optional()
-					.describe('NOVA food processing group 1-4 (null to clear)'),
-				additives: z
-					.array(z.string())
-					.nullable()
-					.optional()
-					.describe('List of additives (null to clear)'),
-				ingredientsText: z
-					.string()
-					.nullable()
-					.optional()
-					.describe('Full ingredients text (null to clear)'),
-				imageUrl: z
-					.string()
-					.nullable()
-					.optional()
-					.describe('Image URL or relative path (null to clear)'),
-				...nutrientInputSchema
-			},
+			inputSchema: describeShape(foodCreateSchema.shape, FOOD_FIELD_DOCS),
 			annotations: WRITE
 		},
 		safe((args) => handleCreateFood(userId, args))
@@ -570,47 +554,8 @@ export function createMcpServer(userId: string): McpServer {
 			description:
 				'Update an existing food item in the database. Supports extended nutrients (vitamins, minerals, etc.).',
 			inputSchema: {
-				foodId: z.string().describe('The food ID to update'),
-				name: z.string().optional().describe('New name'),
-				servingSize: z.number().optional().describe('New serving size'),
-				servingUnit: z.enum(servingUnitValues).optional().describe('New serving unit'),
-				calories: z.number().nonnegative().optional().describe('New calories per serving'),
-				protein: z.number().nonnegative().optional().describe('New protein in grams per serving'),
-				carbs: z.number().nonnegative().optional().describe('New carbs in grams per serving'),
-				fat: z.number().nonnegative().optional().describe('New fat in grams per serving'),
-				fiber: z.number().nonnegative().optional().describe('New fiber in grams per serving'),
-				brand: z.string().optional().describe('New brand name'),
-				barcode: z.string().optional().describe('New barcode number'),
-				isFavorite: z.boolean().optional().describe('Mark as favorite'),
-				nutriScore: z
-					.enum(['a', 'b', 'c', 'd', 'e'])
-					.nullable()
-					.optional()
-					.describe('Nutri-Score grade (null to clear)'),
-				novaGroup: z
-					.number()
-					.int()
-					.min(1)
-					.max(4)
-					.nullable()
-					.optional()
-					.describe('NOVA food processing group 1-4 (null to clear)'),
-				additives: z
-					.array(z.string())
-					.nullable()
-					.optional()
-					.describe('List of additives (null to clear)'),
-				ingredientsText: z
-					.string()
-					.nullable()
-					.optional()
-					.describe('Full ingredients text (null to clear)'),
-				imageUrl: z
-					.string()
-					.nullable()
-					.optional()
-					.describe('Image URL or relative path (null to clear)'),
-				...nutrientInputSchema
+				foodId: z.string().uuid().describe('The food ID to update'),
+				...describeShape(foodUpdateSchema.shape, FOOD_FIELD_DOCS)
 			},
 			annotations: UPDATE
 		},

--- a/src/lib/server/validation/entries.ts
+++ b/src/lib/server/validation/entries.ts
@@ -2,7 +2,7 @@ import 'zod-openapi';
 import { z } from 'zod';
 import { normalizeMealType } from '$lib/utils/meals';
 
-const entryBaseSchema = z.object({
+export const entryBaseSchema = z.object({
 	foodId: z.string().uuid().optional(),
 	recipeId: z.string().uuid().optional(),
 	mealType: z.string().min(1).max(50).transform(normalizeMealType),

--- a/tests/server/mcp-handlers.test.ts
+++ b/tests/server/mcp-handlers.test.ts
@@ -9,6 +9,7 @@ import {
 	TEST_MEAL_TYPE
 } from '../helpers/fixtures';
 import { createHandlers, type HandlerDeps } from '../../src/lib/server/mcp/create-handlers';
+import { foodCreateSchema } from '../../src/lib/server/validation/foods';
 
 // Mock state
 let mockFoods: any[] = [];
@@ -48,6 +49,7 @@ let mockLogSupplementResult: any = null;
 let mockSupplementById: any = null;
 let mockCreateSupplementResult: any = null;
 let mockUpdateSupplementResult: any = null;
+let mockCreateFoodError: any = null;
 let mockOFFProduct: any = null;
 let mockOFFSearchResults: any[] = [];
 let mockCreateSleepResult: any = null;
@@ -74,7 +76,7 @@ const mockDeps = {
 	createFood: async () =>
 		mockCreateFoodResult
 			? { success: true, data: mockCreateFoodResult }
-			: { success: false, error: new Error('Validation failed') },
+			: { success: false, error: mockCreateFoodError ?? new Error('Validation failed') },
 	getFood: async () => mockFood,
 	findFoodByBarcode: async () => mockBarcodeFood,
 	updateFood: async () =>
@@ -260,6 +262,7 @@ describe('MCP handlers', () => {
 	beforeEach(() => {
 		mockFoods = [];
 		mockCreateFoodResult = null;
+		mockCreateFoodError = null;
 		mockUpdateFoodResult = null;
 		mockDeleteFoodResult = { blocked: false };
 		mockRecipes = [];
@@ -345,7 +348,7 @@ describe('MCP handlers', () => {
 	describe('handleCreateFood', () => {
 		test('returns foodId and food on success', async () => {
 			mockCreateFoodResult = { ...TEST_FOOD, id: 'new-food-id' };
-			const result = await handleCreateFood(TEST_USER.id, {
+			const result: any = await handleCreateFood(TEST_USER.id, {
 				name: 'Oats',
 				servingSize: 100,
 				servingUnit: 'g',
@@ -362,15 +365,26 @@ describe('MCP handlers', () => {
 
 		test('returns error on validation failure', async () => {
 			mockCreateFoodResult = null;
-			const result = await handleCreateFood(TEST_USER.id, {});
+			const result: any = await handleCreateFood(TEST_USER.id, {});
 			expect(result.error).toBeDefined();
+		});
+
+		test('create_food validation failure returns structured issues', async () => {
+			mockCreateFoodError = foodCreateSchema.safeParse({ name: '' }).error;
+			const result = await handleCreateFood(TEST_USER.id, { name: '' });
+			expect(result).toMatchObject({ error: 'validation_failed' });
+			expect(
+				(result as unknown as { issues: Array<{ path: string }> }).issues.some(
+					(i) => i.path === 'name'
+				)
+			).toBe(true);
 		});
 	});
 
 	describe('handleCreateRecipe', () => {
 		test('returns recipeId and recipe on success', async () => {
 			mockCreateRecipeResult = { ...TEST_RECIPE, id: 'new-recipe-id' };
-			const result = await handleCreateRecipe(TEST_USER.id, {
+			const result: any = await handleCreateRecipe(TEST_USER.id, {
 				name: 'Shake',
 				totalServings: 2,
 				ingredients: [{ foodId: TEST_FOOD.id, quantity: 1, servingUnit: 'cup' }]
@@ -382,7 +396,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockCreateRecipeResult = null;
-			const result = await handleCreateRecipe(TEST_USER.id, {});
+			const result: any = await handleCreateRecipe(TEST_USER.id, {});
 			expect(result.error).toBeDefined();
 		});
 	});
@@ -391,7 +405,7 @@ describe('MCP handlers', () => {
 		test('returns entryId and dailyStatus on success', async () => {
 			mockCreateEntryResult = { ...TEST_ENTRY, id: 'new-entry-id' };
 			mockGoals = TEST_GOALS;
-			const result = await handleLogFood(TEST_USER.id, {
+			const result: any = await handleLogFood(TEST_USER.id, {
 				foodId: TEST_FOOD.id,
 				mealType: 'breakfast',
 				servings: 1,
@@ -404,7 +418,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockCreateEntryResult = null;
-			const result = await handleLogFood(TEST_USER.id, {});
+			const result: any = await handleLogFood(TEST_USER.id, {});
 			expect(result.error).toBeDefined();
 		});
 	});
@@ -459,7 +473,7 @@ describe('MCP handlers', () => {
 	describe('handleUpdateEntry', () => {
 		test('returns success and dailyStatus on valid update', async () => {
 			mockUpdateEntryResult = { ...TEST_ENTRY, servings: 2 };
-			const result = await handleUpdateEntry(TEST_USER.id, {
+			const result: any = await handleUpdateEntry(TEST_USER.id, {
 				entryId: TEST_ENTRY.id,
 				servings: 2
 			});
@@ -470,7 +484,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockUpdateEntryResult = null;
-			const result = await handleUpdateEntry(TEST_USER.id, {
+			const result: any = await handleUpdateEntry(TEST_USER.id, {
 				entryId: 'nonexistent',
 				servings: 2
 			});
@@ -503,7 +517,7 @@ describe('MCP handlers', () => {
 	describe('handleUpdateGoals', () => {
 		test('returns success and goals on valid update', async () => {
 			mockUpsertGoalsResult = TEST_GOALS;
-			const result = await handleUpdateGoals(TEST_USER.id, {
+			const result: any = await handleUpdateGoals(TEST_USER.id, {
 				calorieGoal: 2000,
 				proteinGoal: 150,
 				carbGoal: 200,
@@ -516,7 +530,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockUpsertGoalsResult = null;
-			const result = await handleUpdateGoals(TEST_USER.id, {});
+			const result: any = await handleUpdateGoals(TEST_USER.id, {});
 			expect(result.error).toBeDefined();
 		});
 	});
@@ -577,7 +591,7 @@ describe('MCP handlers', () => {
 		test('returns success with weight details and structured change', async () => {
 			mockLatestWeight = { id: 'weight-0', weightKg: 76.0, entryDate: '2026-02-09' };
 			mockCreateWeightResult = { id: 'weight-1', weightKg: 75.5, entryDate: '2026-02-10' };
-			const result = await handleLogWeight(TEST_USER.id, { weightKg: 75.5 });
+			const result: any = await handleLogWeight(TEST_USER.id, { weightKg: 75.5 });
 			expect(result.success).toBe(true);
 			expect(result.entryId).toBe('weight-1');
 			expect(result.weightKg).toBe(75.5);
@@ -592,14 +606,14 @@ describe('MCP handlers', () => {
 		test('returns null change when no previous weight', async () => {
 			mockLatestWeight = null;
 			mockCreateWeightResult = { id: 'weight-1', weightKg: 75.5, entryDate: '2026-02-10' };
-			const result = await handleLogWeight(TEST_USER.id, { weightKg: 75.5 });
+			const result: any = await handleLogWeight(TEST_USER.id, { weightKg: 75.5 });
 			expect(result.success).toBe(true);
 			expect(result.change).toBeNull();
 		});
 
 		test('returns error on failure', async () => {
 			mockCreateWeightResult = null;
-			const result = await handleLogWeight(TEST_USER.id, { weightKg: -5 });
+			const result: any = await handleLogWeight(TEST_USER.id, { weightKg: -5 });
 			expect(result.error).toBeDefined();
 		});
 	});
@@ -772,7 +786,7 @@ describe('MCP handlers', () => {
 
 		test('returns error when name not found', async () => {
 			mockSupplements = [];
-			const result = await handleLogSupplement(TEST_USER.id, {
+			const result: any = await handleLogSupplement(TEST_USER.id, {
 				name: 'nonexistent'
 			});
 			expect(result.success).toBe(false);
@@ -780,7 +794,7 @@ describe('MCP handlers', () => {
 		});
 
 		test('returns error when neither name nor id provided', async () => {
-			const result = await handleLogSupplement(TEST_USER.id, {});
+			const result: any = await handleLogSupplement(TEST_USER.id, {});
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Provide either');
 		});
@@ -789,7 +803,7 @@ describe('MCP handlers', () => {
 	describe('handleUpdateFood', () => {
 		test('returns success on valid update', async () => {
 			mockUpdateFoodResult = { ...TEST_FOOD, name: 'Updated Oats' };
-			const result = await handleUpdateFood(TEST_USER.id, {
+			const result: any = await handleUpdateFood(TEST_USER.id, {
 				foodId: TEST_FOOD.id,
 				name: 'Updated Oats'
 			});
@@ -799,7 +813,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockUpdateFoodResult = null;
-			const result = await handleUpdateFood(TEST_USER.id, {
+			const result: any = await handleUpdateFood(TEST_USER.id, {
 				foodId: 'nonexistent'
 			});
 			expect(result.error).toBeDefined();
@@ -839,7 +853,7 @@ describe('MCP handlers', () => {
 	describe('handleUpdateRecipe', () => {
 		test('returns success on valid update', async () => {
 			mockUpdateRecipeResult = { ...TEST_RECIPE, name: 'Updated Bowl' };
-			const result = await handleUpdateRecipe(TEST_USER.id, {
+			const result: any = await handleUpdateRecipe(TEST_USER.id, {
 				recipeId: TEST_RECIPE.id,
 				name: 'Updated Bowl'
 			});
@@ -849,7 +863,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockUpdateRecipeResult = null;
-			const result = await handleUpdateRecipe(TEST_USER.id, {
+			const result: any = await handleUpdateRecipe(TEST_USER.id, {
 				recipeId: 'nonexistent'
 			});
 			expect(result.error).toBeDefined();
@@ -875,7 +889,7 @@ describe('MCP handlers', () => {
 	describe('handleCreateSupplement', () => {
 		test('returns supplementId on success', async () => {
 			mockCreateSupplementResult = { ...TEST_SUPPLEMENT, id: 'new-supp' };
-			const result = await handleCreateSupplement(TEST_USER.id, {
+			const result: any = await handleCreateSupplement(TEST_USER.id, {
 				name: 'Vitamin D3',
 				scheduleType: 'daily',
 				ingredients: [{ foodId: '10000000-0000-4000-8000-000000000099' }]
@@ -886,7 +900,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockCreateSupplementResult = null;
-			const result = await handleCreateSupplement(TEST_USER.id, {});
+			const result: any = await handleCreateSupplement(TEST_USER.id, {});
 			expect(result.error).toBeDefined();
 		});
 	});
@@ -908,7 +922,7 @@ describe('MCP handlers', () => {
 	describe('handleUpdateSupplement', () => {
 		test('returns success on valid update', async () => {
 			mockUpdateSupplementResult = { ...TEST_SUPPLEMENT, name: 'Updated D3' };
-			const result = await handleUpdateSupplement(TEST_USER.id, {
+			const result: any = await handleUpdateSupplement(TEST_USER.id, {
 				supplementId: TEST_SUPPLEMENT.id,
 				name: 'Updated D3'
 			});
@@ -918,7 +932,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockUpdateSupplementResult = null;
-			const result = await handleUpdateSupplement(TEST_USER.id, {
+			const result: any = await handleUpdateSupplement(TEST_USER.id, {
 				supplementId: 'nonexistent'
 			});
 			expect(result.error).toBeDefined();
@@ -954,7 +968,7 @@ describe('MCP handlers', () => {
 	describe('handleUpdateWeight', () => {
 		test('returns success on valid update', async () => {
 			mockUpdateWeightResult = { id: 'weight-1', weightKg: 76.0 };
-			const result = await handleUpdateWeight(TEST_USER.id, {
+			const result: any = await handleUpdateWeight(TEST_USER.id, {
 				weightId: 'weight-1',
 				weightKg: 76.0
 			});
@@ -964,7 +978,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockUpdateWeightResult = null;
-			const result = await handleUpdateWeight(TEST_USER.id, {
+			const result: any = await handleUpdateWeight(TEST_USER.id, {
 				weightId: 'nonexistent'
 			});
 			expect(result.error).toBeDefined();
@@ -1143,7 +1157,7 @@ describe('MCP handlers', () => {
 	describe('handleLogSleep', () => {
 		test('returns success with entryId and entry', async () => {
 			mockCreateSleepResult = { id: 'sleep-1', durationMinutes: 480, quality: 4 };
-			const result = await handleLogSleep(TEST_USER.id, {
+			const result: any = await handleLogSleep(TEST_USER.id, {
 				durationMinutes: 480,
 				quality: 4
 			});
@@ -1154,7 +1168,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on validation failure', async () => {
 			mockCreateSleepResult = null;
-			const result = await handleLogSleep(TEST_USER.id, {
+			const result: any = await handleLogSleep(TEST_USER.id, {
 				durationMinutes: 480,
 				quality: 4
 			});
@@ -1209,7 +1223,7 @@ describe('MCP handlers', () => {
 	describe('handleUpdateSleep', () => {
 		test('returns success on valid update', async () => {
 			mockUpdateSleepResult = { id: 'sleep-1', durationMinutes: 500, quality: 5 };
-			const result = await handleUpdateSleep(TEST_USER.id, {
+			const result: any = await handleUpdateSleep(TEST_USER.id, {
 				id: 'sleep-1',
 				durationMinutes: 500,
 				quality: 5
@@ -1220,7 +1234,7 @@ describe('MCP handlers', () => {
 
 		test('accepts entryDate param', async () => {
 			mockUpdateSleepResult = { id: 'sleep-1', durationMinutes: 480, quality: 4 };
-			const result = await handleUpdateSleep(TEST_USER.id, {
+			const result: any = await handleUpdateSleep(TEST_USER.id, {
 				id: 'sleep-1',
 				entryDate: '2026-02-09'
 			});
@@ -1229,7 +1243,7 @@ describe('MCP handlers', () => {
 
 		test('returns error on failure', async () => {
 			mockUpdateSleepResult = null;
-			const result = await handleUpdateSleep(TEST_USER.id, { id: 'nonexistent' });
+			const result: any = await handleUpdateSleep(TEST_USER.id, { id: 'nonexistent' });
 			expect(result.error).toBeDefined();
 		});
 	});

--- a/tests/utils/mcp-resources.test.ts
+++ b/tests/utils/mcp-resources.test.ts
@@ -5,7 +5,8 @@ vi.mock('$lib/nutrients', () => ({
 	ALL_NUTRIENTS: [
 		{ key: 'saturatedFat', unit: 'g' },
 		{ key: 'sodium', unit: 'mg' }
-	]
+	],
+	ALL_NUTRIENT_KEYS: ['saturatedFat', 'sodium']
 }));
 vi.mock('$lib/server/mcp/handlers', () => ({
 	handleCreateFood: vi.fn(),

--- a/tests/utils/mcp-safe.test.ts
+++ b/tests/utils/mcp-safe.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { safe } from '../../src/lib/server/mcp/safe';
+import { ResultValidationError } from '../../src/lib/server/errors';
+import { foodCreateSchema } from '../../src/lib/server/validation/foods';
+
+describe('safe', () => {
+	test('wraps successful results as text content without isError', async () => {
+		const wrapped = safe(async () => ({ ok: true }));
+		const result = await wrapped();
+		expect(result.isError).toBeUndefined();
+		expect(JSON.parse(result.content[0].text)).toEqual({ ok: true });
+	});
+
+	test('marks thrown errors with isError and keeps the message', async () => {
+		const wrapped = safe(async () => {
+			throw new Error('boom');
+		});
+		const result = await wrapped();
+		expect(result.isError).toBe(true);
+		expect(JSON.parse(result.content[0].text)).toEqual({ error: 'boom' });
+	});
+
+	test('does not leak non-Error thrown values', async () => {
+		const wrapped = safe(async () => {
+			throw { secret: 'internal state' };
+		});
+		const result = await wrapped();
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).not.toContain('internal state');
+	});
+
+	test('returns structured issues for ResultValidationError', async () => {
+		const zodError = foodCreateSchema.safeParse({ name: '' }).error!;
+		const wrapped = safe(async () => {
+			throw new ResultValidationError(zodError);
+		});
+		const result = await wrapped();
+		expect(result.isError).toBe(true);
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.error).toBe('validation_failed');
+		expect(payload.issues.some((i: { path: string }) => i.path === 'name')).toBe(true);
+	});
+});

--- a/tests/utils/mcp-schema-drift.test.ts
+++ b/tests/utils/mcp-schema-drift.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../../src/lib/server/mcp/server';
+import { foodCreateSchema } from '../../src/lib/server/validation/foods';
+import { recipeCreateSchema } from '../../src/lib/server/validation/recipes';
+import { goalsSchema } from '../../src/lib/server/validation/goals';
+import { dayPropertiesSetSchema } from '../../src/lib/server/validation/day-properties';
+
+const server = createMcpServer('test-user');
+const tools = (
+	server as unknown as {
+		_registeredTools: Record<string, { inputSchema?: z.ZodObject<z.ZodRawShape> }>;
+	}
+)._registeredTools;
+
+const FOOD_BASE = {
+	name: 'Oats',
+	servingSize: 100,
+	servingUnit: 'g',
+	calories: 389,
+	protein: 16.9,
+	carbs: 66,
+	fat: 6.9,
+	fiber: 10.6
+};
+
+const AGREEMENT_CASES: Array<{ tool: string; rest: z.ZodType; payloads: unknown[] }> = [
+	{
+		tool: 'create_food',
+		rest: foodCreateSchema,
+		payloads: [
+			FOOD_BASE,
+			{ ...FOOD_BASE, name: '' },
+			{ ...FOOD_BASE, servingSize: '100', calories: '389' },
+			{ ...FOOD_BASE, servingSize: 0 },
+			{ ...FOOD_BASE, imageUrl: 'javascript:alert(1)' },
+			{ ...FOOD_BASE, imageUrl: '/uploads/oats.jpg' }
+		]
+	},
+	{
+		tool: 'create_recipe',
+		rest: recipeCreateSchema,
+		payloads: [
+			{
+				name: 'Porridge',
+				totalServings: 2,
+				ingredients: [
+					{ foodId: '123e4567-e89b-12d3-a456-426614174000', quantity: 80, servingUnit: 'g' }
+				]
+			},
+			{ name: 'Porridge', totalServings: 2, ingredients: [] },
+			{ name: '', totalServings: 2, ingredients: [] },
+			{
+				name: 'Porridge',
+				totalServings: 0,
+				ingredients: [
+					{ foodId: '123e4567-e89b-12d3-a456-426614174000', quantity: 80, servingUnit: 'g' }
+				]
+			}
+		]
+	},
+	{
+		tool: 'update_goals',
+		rest: goalsSchema,
+		payloads: [
+			{ calorieGoal: 2200, proteinGoal: 150, carbGoal: 250, fatGoal: 70, fiberGoal: 30 },
+			{ calorieGoal: 0, proteinGoal: 150, carbGoal: 250, fatGoal: 70, fiberGoal: 30 },
+			{ calorieGoal: '2200', proteinGoal: '150', carbGoal: 250, fatGoal: 70, fiberGoal: 30 }
+		]
+	},
+	{
+		tool: 'set_day_properties',
+		rest: dayPropertiesSetSchema,
+		payloads: [
+			{ date: '2026-06-09', isFastingDay: true },
+			{ date: 'not-a-date', isFastingDay: true }
+		]
+	}
+];
+
+describe('MCP tool schemas agree with REST validation schemas', () => {
+	for (const { tool, rest, payloads } of AGREEMENT_CASES) {
+		test(tool, () => {
+			const registered = tools[tool]?.inputSchema;
+			expect(registered, `${tool} should have an inputSchema`).toBeDefined();
+			const mcpSchema =
+				typeof registered!.safeParse === 'function'
+					? registered!
+					: z.object(registered as unknown as z.ZodRawShape);
+			for (const payload of payloads) {
+				expect(
+					mcpSchema.safeParse(payload).success,
+					`${tool} disagrees with REST on ${JSON.stringify(payload)}`
+				).toBe(rest.safeParse(payload).success);
+			}
+		});
+	}
+});
+
+describe('tools/list serialization', () => {
+	test('derived schemas (coerce/transform) serialize to JSON Schema', async () => {
+		const srv = createMcpServer('test-user');
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: 'drift-test', version: '0.0.0' });
+		await Promise.all([client.connect(clientTransport), srv.connect(serverTransport)]);
+		const { tools: listed } = await client.listTools();
+
+		for (const name of ['create_food', 'log_food', 'update_entry', 'log_weight', 'log_sleep']) {
+			const tool = listed.find((t) => t.name === name);
+			expect(tool, `${name} missing from tools/list`).toBeDefined();
+			expect(Object.keys(tool!.inputSchema.properties ?? {}).length).toBeGreaterThan(0);
+		}
+
+		const createFood = listed.find((t) => t.name === 'create_food')!;
+		expect(createFood.inputSchema.properties).toHaveProperty('name');
+		expect(createFood.inputSchema.properties).toHaveProperty('servingSize');
+		await client.close();
+	});
+});

--- a/tests/utils/mcp-schema-utils.test.ts
+++ b/tests/utils/mcp-schema-utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
+import { describeShape } from '../../src/lib/server/mcp/schema-utils';
+
+describe('describeShape', () => {
+	const shape = { name: z.string().min(1), count: z.coerce.number().positive() };
+
+	test('attaches descriptions to documented fields', () => {
+		const described = describeShape(shape, { name: 'The name' });
+		expect(described.name.description).toBe('The name');
+		expect(described.count.description).toBeUndefined();
+	});
+
+	test('preserves validation constraints', () => {
+		const described = describeShape(shape, { name: 'The name', count: 'The count' });
+		expect(described.name.safeParse('').success).toBe(false);
+		expect(described.count.safeParse('5').success).toBe(true);
+		expect(described.count.safeParse(-1).success).toBe(false);
+	});
+});


### PR DESCRIPTION
Phase 3 of the 2026-06-09 architecture-review fixes. Independent PR off `main`.

## Problem
The 60+ MCP tools defined inline Zod input schemas that had drifted from `src/lib/server/validation/` — REST coerces, MCP didn't; REST had `min(1)`/`max()`/`uuid()`/URL refinements the MCP schemas lacked. So MCP accepted payloads the service layer would reject, failing with generic errors instead of schema errors.

## Strategy
Constraints now come from the shared validation schemas; MCP-specific descriptions stay local via a small `describeShape` helper. Each tool now rejects exactly what the service layer rejects, with a proper schema error.

- **Task 10** — extract `safe()` wrapper to `safe.ts` (now sets MCP `isError: true`, stops leaking non-Error throws, emits structured `validation_failed` issues) + `describeShape` helper in `schema-utils.ts`.
- **Tasks 11–14** — derive `create_food`/`update_food`, `log_food`/`update_entry`, `create_recipe`/`update_recipe`/`update_goals`/`set_day_properties`, and `log_weight`/`update_weight`/`log_sleep`/`update_sleep` input schemas from the shared validation schemas (field-level reuse where MCP `date` ↔ REST `entryDate`). Picks up `name` min(1), coercion, uuid checks, `imageUrl` URL refinement, positive/`max()` bounds.
- **Task 15** — tighten the (intentionally-different) supplement schema: shared schedule-type enum, `scheduleDays` int 0–6, `ingredients` max 50.
- **Task 16** — regression nets: an MCP↔REST schema-agreement test and a `tools/list` serialization test proving the derived `z.coerce`/`.transform()`/refine schemas still serialize to JSON Schema for clients.
- **Task 17** — MCP handlers return `{ error: 'validation_failed', issues: [{path, message}] }` for Zod failures (was a raw JSON blob via `.message`), via an `isZodError`-based `errorPayload`.

## Verification
- `svelte-check`: 0 errors · `prettier --check .`: clean · `bun run test`: 133 files, **1780 tests pass** (incl. new agreement + serialization nets)
- `bun run security`: **Semgrep (SAST) passed.** The SCA/Trivy failures are pre-existing baseline — Phase 3 changed only `.ts` files (no deps, no Dockerfile); SCA findings are transitive-dep vulns (picomatch/devalue, same family as the documented `minimatch` exception) and the Trivy HIGHs come from it scanning the gitignored `.claude/worktrees/.../node_modules/`. No new findings introduced; this PR tightens input validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)