### PR TITLE
feat: local-first mobile with anonymous Local mode, offline sync, and weight page redesign

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,12 @@ Bissbilanz is a food tracking application that allows users to:
 - Log daily food entries organized by meals
 - Set and track daily macro goals
 - Scan barcodes to quickly add foods
+- Track body weight, sleep, and supplements
+- Calculate maintenance calories from weight trend + food log
 - Use AI agents via MCP to assist with logging
 - Access the app offline via PWA
 
-**Authentication:** Required via Infomaniak OIDC (no guest access)
+**Authentication:** Infomaniak OIDC required on web (no guest access). The mobile apps additionally support an anonymous local-only mode; its data is migrated to the account on first sign-in.
 
 ## Tech Stack
 
@@ -43,12 +45,13 @@ Bissbilanz is a food tracking application that allows users to:
 - **Charts:** layerchart
 - **Date Handling:** @internationalized/date
 - **Food Data:** Open Food Facts API
+- **Offline Storage:** Dexie (IndexedDB)
 
 ### Development
 
-- **Type Checking:** TypeScript 5.x
+- **Type Checking:** TypeScript (strict) via svelte-check
 - **Package Manager:** Bun
-- **Code Quality:** svelte-check
+- **Formatting:** Prettier (runs in pre-commit hook and as part of `bun run check`)
 
 ## Development Commands
 
@@ -67,9 +70,15 @@ bun run db:generate    # Generate migrations from schema
 bun run db:migrate     # Run migrations (applied automatically on dev server start too)
 # NOTE: Do NOT use db:push — see "Migration Safety" in Database section
 
-# Testing (vitest)
-bun run test                    # Run all tests
+# Testing
+bun run test                    # Unit tests (vitest)
 bun run test:watch              # Watch mode
+bun run test:integration-db     # DB integration tests (Testcontainers, requires Docker)
+bun run test:mobile             # Playwright e2e tests
+
+# API codegen (OpenAPI spec + TS/Kotlin clients)
+bun run api:generate            # Regenerate after changing API routes or validation schemas
+bun run api:check               # Verify generated output is current (enforced in CI)
 ```
 
 ## Code Conventions
@@ -109,6 +118,7 @@ bun run test:watch              # Watch mode
 - Return consistent error format: `{ error: string }`
 - Always check user authentication/authorization
 - Use HTTP status codes correctly (200, 201, 400, 401, 404, 500)
+- The OpenAPI spec (`docs/openapi.json`) and TS/Kotlin clients are generated from the Zod schemas via `bun run api:generate` — rerun and commit the output after changing API routes or validation schemas (CI fails otherwise via `api:check`)
 
 ### Styling
 
@@ -146,7 +156,7 @@ To also scan the Docker image:
 
 ## Mobile Development
 
-The `mobile/` directory contains a Kotlin Multiplatform project with an Android app (Jetpack Compose) and an iOS app (SwiftUI skeleton).
+The `mobile/` directory contains a Kotlin Multiplatform project with an Android app (Jetpack Compose) and an iOS app (SwiftUI).
 
 ### Build Commands
 
@@ -162,7 +172,7 @@ cd mobile && ./gradlew :shared:ktlintCheck :androidApp:ktlintCheck
 
 - **Shared module** (`mobile/shared/`): KMP code shared between Android and iOS — models, API client, repositories, auth, DI
 - **Android app** (`mobile/androidApp/`): Jetpack Compose UI with Material 3
-- **iOS app** (`mobile/iosApp/`): SwiftUI (skeleton, requires macOS with Xcode to build)
+- **iOS app** (`mobile/iosApp/`): SwiftUI, project generated with XcodeGen (`project.yml`)
 - Use `expect`/`actual` for platform-specific implementations (HTTP engine, secure storage, SHA-256)
 - Use Koin for dependency injection
 - Use Ktor for HTTP client, kotlinx.serialization for JSON
@@ -173,6 +183,8 @@ cd mobile && ./gradlew :shared:ktlintCheck :androidApp:ktlintCheck
 ### iOS Builds
 
 iOS builds require macOS with Xcode installed. The shared KMP framework is compiled to a static framework for iOS targets (x64, arm64, simulator arm64).
+
+If using XcodeBuildMCP, use the installed XcodeBuildMCP skill before calling XcodeBuildMCP tools.
 
 ## Git Workflow
 
@@ -232,5 +244,3 @@ Premium, polished, reliable. Three words: **refined, purposeful, trustworthy**. 
 3. **Consistent visual language** — macro colors, card patterns, and spacing should be predictable across all pages
 4. **Quiet hierarchy** — important information stands out through contrast and position, not size or color intensity
 5. **Touch-first confidence** — interactive elements should feel substantial and responsive on mobile
-
-- If using XcodeBuildMCP, use the installed XcodeBuildMCP skill before calling XcodeBuildMCP tools.

--- a/mobile/androidApp/src/androidMain/AndroidManifest.xml
+++ b/mobile/androidApp/src/androidMain/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <application
         android:name=".BissbilanzApplication"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="Bissbilanz"

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -22,8 +22,10 @@ import com.bissbilanz.auth.SecureStorage
 import com.bissbilanz.cache.DatabaseDriverFactory
 import com.bissbilanz.di.sharedModule
 import com.bissbilanz.health.HealthConnectService
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.repository.*
 import com.bissbilanz.repository.FoodRepository
+import com.bissbilanz.storage.PlainStorage
 import com.bissbilanz.sync.ConnectivityProvider
 import com.bissbilanz.sync.SyncManager
 import io.sentry.android.core.SentryAndroid
@@ -52,6 +54,7 @@ class BissbilanzApplication : Application() {
             module {
                 single(named("baseUrl")) { BuildConfig.BASE_URL }
                 single { SecureStorage(androidContext()) }
+                single { PlainStorage(androidContext()) }
                 single { DatabaseDriverFactory(androidContext()) }
                 single<HealthSyncService> { HealthConnectService(androidContext()) }
                 single { ConnectivityProvider(androidContext()) }
@@ -84,6 +87,11 @@ class BissbilanzApplication : Application() {
         val koin =
             org.koin.java.KoinJavaComponent
                 .getKoin()
+
+        // Load the persisted app mode before any sync can start, so Local mode is
+        // respected from the first connectivity event onwards.
+        koin.get<AppModeManager>().initialize()
+
         koin.get<EntryRepository>().onEntryChanged = {
             MacroWidget.updateAllWidgets(this@BissbilanzApplication)
         }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -12,6 +12,7 @@ import com.bissbilanz.android.ui.viewmodels.DayLogViewModel
 import com.bissbilanz.android.ui.viewmodels.FavoritesViewModel
 import com.bissbilanz.android.ui.viewmodels.FoodSearchViewModel
 import com.bissbilanz.android.ui.viewmodels.InsightsViewModel
+import com.bissbilanz.android.ui.viewmodels.MigrationViewModel
 import com.bissbilanz.android.ui.viewmodels.SettingsViewModel
 import com.bissbilanz.android.ui.viewmodels.WeightViewModel
 import com.bissbilanz.android.widget.FavoritesWidgetWorker
@@ -69,6 +70,7 @@ class BissbilanzApplication : Application() {
                 viewModelOf(::WeightViewModel)
                 viewModelOf(::SettingsViewModel)
                 viewModelOf(::AddFoodViewModel)
+                viewModelOf(::MigrationViewModel)
             }
 
         startKoin {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/BissbilanzApp.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/BissbilanzApp.kt
@@ -12,18 +12,53 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bissbilanz.android.navigation.AppNavigation
 import com.bissbilanz.android.ui.screens.LoginScreen
+import com.bissbilanz.android.ui.screens.MigrationScreen
 import com.bissbilanz.android.ui.theme.BissbilanzTheme
 import com.bissbilanz.auth.AuthManager
 import com.bissbilanz.auth.AuthState
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
 import io.sentry.Sentry
 import io.sentry.protocol.User
 import org.json.JSONObject
 import org.koin.compose.koinInject
 
+/** Top-level destination shown at the app root, resolved from auth state and app mode. */
+enum class RootDestination { Loading, Login, App, Migration }
+
+/**
+ * Pure routing decision: which root destination to show for the given [authState] and [mode].
+ *
+ * - Local mode is fully anonymous, so an unauthenticated user still sees the app.
+ * - A successful login while in Local mode means the local data must be migrated to the
+ *   account first, so the migration screen is shown.
+ * - A `null` mode means "not chosen yet" and is treated as sync-allowed (existing
+ *   installs and fresh logins).
+ */
+fun resolveRootDestination(
+    authState: AuthState,
+    mode: AppMode?,
+): RootDestination =
+    when (authState) {
+        is AuthState.Loading -> {
+            RootDestination.Loading
+        }
+
+        is AuthState.Authenticated, is AuthState.Refreshing -> {
+            if (mode == AppMode.LOCAL) RootDestination.Migration else RootDestination.App
+        }
+
+        is AuthState.Unauthenticated, is AuthState.SessionExpired -> {
+            if (mode == AppMode.LOCAL) RootDestination.App else RootDestination.Login
+        }
+    }
+
 @Composable
 fun BissbilanzApp() {
     val authManager: AuthManager = koinInject()
+    val appModeManager: AppModeManager = koinInject()
     val authState by authManager.authState.collectAsStateWithLifecycle()
+    val mode by appModeManager.mode.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         authManager.initialize()
@@ -41,9 +76,18 @@ fun BissbilanzApp() {
         }
     }
 
+    // Existing installs and fresh logins that never chose a mode default to Synced.
+    LaunchedEffect(authState, mode) {
+        if ((authState is AuthState.Authenticated || authState is AuthState.Refreshing) && mode == null) {
+            appModeManager.setMode(AppMode.SYNCED)
+        }
+    }
+
+    val destination = resolveRootDestination(authState, mode)
+
     BissbilanzTheme {
-        when (authState) {
-            is AuthState.Loading -> {
+        when (destination) {
+            RootDestination.Loading -> {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
@@ -51,16 +95,32 @@ fun BissbilanzApp() {
                     CircularProgressIndicator()
                 }
             }
-            is AuthState.SessionExpired -> {
-                val context = LocalContext.current
-                LaunchedEffect(Unit) {
-                    Toast.makeText(context, "Session expired, please sign in again", Toast.LENGTH_LONG).show()
-                    authManager.clearSessionExpired()
+
+            RootDestination.Login -> {
+                if (authState is AuthState.SessionExpired) {
+                    val context = LocalContext.current
+                    LaunchedEffect(Unit) {
+                        Toast.makeText(context, "Session expired, please sign in again", Toast.LENGTH_LONG).show()
+                        authManager.clearSessionExpired()
+                    }
                 }
-                LoginScreen(authManager)
+                LoginScreen(authManager, appModeManager)
             }
-            is AuthState.Unauthenticated -> LoginScreen(authManager)
-            is AuthState.Authenticated, is AuthState.Refreshing -> AppNavigation()
+
+            RootDestination.App -> {
+                // In Local mode a stale SessionExpired is cleared silently — no toast,
+                // the app works without an account.
+                if (authState is AuthState.SessionExpired) {
+                    LaunchedEffect(Unit) {
+                        authManager.clearSessionExpired()
+                    }
+                }
+                AppNavigation()
+            }
+
+            RootDestination.Migration -> {
+                MigrationScreen()
+            }
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -98,8 +98,18 @@ fun InsightsScreen() {
     val weightLoading by viewModel.weightLoading.collectAsStateWithLifecycle()
     val sleepLoading by viewModel.sleepLoading.collectAsStateWithLifecycle()
 
+    val isLocalMode = viewModel.isLocalMode
+
     val ranges = listOf("7 Days", "30 Days", "90 Days")
-    val tabs = listOf("Overview", "Nutrition", "Weight", "Sleep")
+
+    // Nutrition and Weight analytics are entirely server-backed (AnalyticsRepository),
+    // so those tabs are hidden in Local mode. Pairs of (ViewModel tab index, title).
+    val tabs =
+        if (isLocalMode) {
+            listOf(0 to "Overview", 3 to "Sleep")
+        } else {
+            listOf(0 to "Overview", 1 to "Nutrition", 2 to "Weight", 3 to "Sleep")
+        }
 
     PullToRefreshWrapper(
         onRefresh = {
@@ -135,11 +145,11 @@ fun InsightsScreen() {
             Spacer(modifier = Modifier.height(8.dp))
 
             ScrollableTabRow(
-                selectedTabIndex = selectedTab,
+                selectedTabIndex = tabs.indexOfFirst { it.first == selectedTab }.coerceAtLeast(0),
                 modifier = Modifier.fillMaxWidth(),
                 edgePadding = 0.dp,
             ) {
-                tabs.forEachIndexed { index, title ->
+                tabs.forEach { (index, title) ->
                     Tab(
                         selected = selectedTab == index,
                         onClick = { viewModel.selectTab(index) },
@@ -648,23 +658,27 @@ fun InsightsScreen() {
 
                     Spacer(modifier = Modifier.height(12.dp))
 
-                    if (sleepLoading) {
-                        Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
-                            CircularProgressIndicator()
-                        }
-                    } else {
-                        val foodSleepResult by viewModel.foodSleepResult.collectAsStateWithLifecycle()
-                        val nutrientSleepCorrelations by viewModel.nutrientSleepCorrelations.collectAsStateWithLifecycle()
-                        val preSleepTimingSummary by viewModel.preSleepTimingSummary.collectAsStateWithLifecycle()
-                        val caffeineSleepResult by viewModel.caffeineSleepResult.collectAsStateWithLifecycle()
+                    // Sleep analytics cards are computed from server-only analytics data,
+                    // so they are hidden in Local mode (the sleep log above still works).
+                    if (!isLocalMode) {
+                        if (sleepLoading) {
+                            Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                                CircularProgressIndicator()
+                            }
+                        } else {
+                            val foodSleepResult by viewModel.foodSleepResult.collectAsStateWithLifecycle()
+                            val nutrientSleepCorrelations by viewModel.nutrientSleepCorrelations.collectAsStateWithLifecycle()
+                            val preSleepTimingSummary by viewModel.preSleepTimingSummary.collectAsStateWithLifecycle()
+                            val caffeineSleepResult by viewModel.caffeineSleepResult.collectAsStateWithLifecycle()
 
-                        FoodSleepCard(foodSleepResult)
-                        Spacer(Modifier.height(12.dp))
-                        NutrientSleepCard(nutrientSleepCorrelations)
-                        Spacer(Modifier.height(12.dp))
-                        PreSleepWindowCard(preSleepTimingSummary)
-                        Spacer(Modifier.height(12.dp))
-                        CaffeineSleepCard(caffeineSleepResult)
+                            FoodSleepCard(foodSleepResult)
+                            Spacer(Modifier.height(12.dp))
+                            NutrientSleepCard(nutrientSleepCorrelations)
+                            Spacer(Modifier.height(12.dp))
+                            PreSleepWindowCard(preSleepTimingSummary)
+                            Spacer(Modifier.height(12.dp))
+                            CaffeineSleepCard(caffeineSleepResult)
+                        }
                     }
 
                     if (showSleepDialog) {
@@ -684,6 +698,17 @@ fun InsightsScreen() {
                         )
                     }
                 }
+            }
+
+            if (isLocalMode) {
+                Spacer(modifier = Modifier.height(20.dp))
+                Text(
+                    "More insights available with an account",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                )
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/LoginScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.bissbilanz.android.ui.screens
 
+import android.content.Context
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.*
@@ -8,11 +9,31 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
+
+/** Opens the OIDC login page in a Custom Tab. Shared with the Settings "Sign in to sync" flow. */
+fun launchLoginFlow(
+    context: Context,
+    authManager: AuthManager,
+) {
+    val state =
+        java.util.UUID
+            .randomUUID()
+            .toString()
+    val url = authManager.buildLoginUrl(state)
+    val customTabsIntent = CustomTabsIntent.Builder().build()
+    customTabsIntent.launchUrl(context, Uri.parse(url))
+}
 
 @Composable
-fun LoginScreen(authManager: AuthManager) {
+fun LoginScreen(
+    authManager: AuthManager,
+    appModeManager: AppModeManager,
+) {
     val context = LocalContext.current
 
     Surface(modifier = Modifier.fillMaxSize()) {
@@ -37,19 +58,25 @@ fun LoginScreen(authManager: AuthManager) {
             )
             Spacer(modifier = Modifier.height(48.dp))
             Button(
-                onClick = {
-                    val state =
-                        java.util.UUID
-                            .randomUUID()
-                            .toString()
-                    val url = authManager.buildLoginUrl(state)
-                    val customTabsIntent = CustomTabsIntent.Builder().build()
-                    customTabsIntent.launchUrl(context, Uri.parse(url))
-                },
+                onClick = { launchLoginFlow(context, authManager) },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("Sign in")
             }
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedButton(
+                onClick = { appModeManager.setMode(AppMode.LOCAL) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Continue without account")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Your data stays on this device. Sign in later anytime to sync.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/LoginScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/LoginScreen.kt
@@ -6,11 +6,13 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bissbilanz.auth.AuthManager
 import com.bissbilanz.mode.AppMode
 import com.bissbilanz.mode.AppModeManager
@@ -29,12 +31,23 @@ fun launchLoginFlow(
     customTabsIntent.launchUrl(context, Uri.parse(url))
 }
 
+/**
+ * Whether the login screen may offer the anonymous "Continue without account" option.
+ *
+ * It is only for users who have not chosen a mode yet (`null`). A SYNCED user reaching
+ * the login screen is the session-expired re-login case: offering Local mode there
+ * would turn the leftover account cache into "local data" and duplicate everything on
+ * the next sign-in.
+ */
+fun showContinueWithoutAccount(mode: AppMode?): Boolean = mode != AppMode.SYNCED
+
 @Composable
 fun LoginScreen(
     authManager: AuthManager,
     appModeManager: AppModeManager,
 ) {
     val context = LocalContext.current
+    val mode by appModeManager.mode.collectAsStateWithLifecycle()
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -63,20 +76,22 @@ fun LoginScreen(
             ) {
                 Text("Sign in")
             }
-            Spacer(modifier = Modifier.height(16.dp))
-            OutlinedButton(
-                onClick = { appModeManager.setMode(AppMode.LOCAL) },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text("Continue without account")
+            if (showContinueWithoutAccount(mode)) {
+                Spacer(modifier = Modifier.height(16.dp))
+                OutlinedButton(
+                    onClick = { appModeManager.setMode(AppMode.LOCAL) },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Continue without account")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Your data stays on this device. Sign in later anytime to sync.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "Your data stays on this device. Sign in later anytime to sync.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-            )
         }
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/MigrationScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/MigrationScreen.kt
@@ -7,49 +7,216 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.bissbilanz.android.ui.viewmodels.MigrationUiState
+import com.bissbilanz.android.ui.viewmodels.MigrationViewModel
+import com.bissbilanz.migration.LocalDataMigrator
+import org.koin.androidx.compose.koinViewModel
 
 /**
- * Placeholder shown when a user signs in while in Local mode. The actual migration of
- * local data to the account is implemented in a follow-up work package; this screen is
- * intentionally dumb so it can be replaced wholesale.
+ * Shown when a user signs in while in Local mode: uploads the local data to the account
+ * (or lets the user discard it when the account already has data). Routing leaves this
+ * screen automatically once the app mode flips to Synced.
  */
 @Composable
 fun MigrationScreen() {
+    val viewModel: MigrationViewModel = koinViewModel()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDiscardDialog by remember { mutableStateOf(false) }
+
+    if (showDiscardDialog) {
+        AlertDialog(
+            onDismissRequest = { showDiscardDialog = false },
+            title = { Text("Discard local data?") },
+            text = {
+                Text(
+                    "All foods, recipes, log entries and other data stored on this device " +
+                        "will be permanently deleted. The data in your account is kept.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDiscardDialog = false
+                    viewModel.startFresh()
+                }) { Text("Discard") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDiscardDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
+
     Surface(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(32.dp),
+                    .padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
+            when (val state = uiState) {
+                is MigrationUiState.Loading -> {
                     CircularProgressIndicator()
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        "Finishing sign-in… your local data will be uploaded to your account.",
-                        style = MaterialTheme.typography.bodyLarge,
-                        textAlign = TextAlign.Center,
+                }
+
+                is MigrationUiState.Choice -> {
+                    ChoiceCard(
+                        localItemCount = state.localItemCount,
+                        onUpload = viewModel::startUpload,
+                        onStartFresh = { showDiscardDialog = true },
+                    )
+                }
+
+                is MigrationUiState.InProgress -> {
+                    ProgressCard(done = state.done, total = state.total, step = state.step)
+                }
+
+                is MigrationUiState.Failed -> {
+                    FailureCard(
+                        message = state.message,
+                        onRetry = viewModel::retry,
+                        onContinueWithoutAccount = viewModel::cancelToLocal,
                     )
                 }
             }
         }
     }
 }
+
+@Composable
+private fun ChoiceCard(
+    localItemCount: Int,
+    onUpload: () -> Unit,
+    onStartFresh: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
+            Text(
+                "Your account already has data",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "You can upload the data stored on this device to your account, " +
+                    "or discard it and continue with your account data only.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onUpload, modifier = Modifier.fillMaxWidth()) {
+                Text("Upload local data ($localItemCount items)")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(onClick = onStartFresh, modifier = Modifier.fillMaxWidth()) {
+                Text("Start fresh (discard local data)")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProgressCard(
+    done: Int,
+    total: Int,
+    step: String,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                "Uploading your data",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            LinearProgressIndicator(
+                progress = { if (total > 0) done.toFloat() / total else 0f },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                "${stepLabel(step)} ($done/$total)…",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FailureCard(
+    message: String,
+    onRetry: () -> Unit,
+    onContinueWithoutAccount: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
+            Text(
+                "Upload failed",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "Your local data is safe — already uploaded items are not lost and the " +
+                    "upload continues where it stopped.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onRetry, modifier = Modifier.fillMaxWidth()) {
+                Text("Retry")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(onClick = onContinueWithoutAccount, modifier = Modifier.fillMaxWidth()) {
+                Text("Continue without account")
+            }
+        }
+    }
+}
+
+private fun stepLabel(step: String): String =
+    when (step) {
+        LocalDataMigrator.STEP_PREPARE -> "Preparing"
+        LocalDataMigrator.STEP_FOODS -> "Uploading foods"
+        LocalDataMigrator.STEP_RECIPES -> "Uploading recipes"
+        LocalDataMigrator.STEP_ENTRIES -> "Uploading entries"
+        LocalDataMigrator.STEP_WEIGHTS -> "Uploading weight entries"
+        LocalDataMigrator.STEP_SLEEP -> "Uploading sleep entries"
+        LocalDataMigrator.STEP_SUPPLEMENTS -> "Uploading supplements"
+        LocalDataMigrator.STEP_SUPPLEMENT_LOGS -> "Uploading supplement logs"
+        LocalDataMigrator.STEP_GOALS -> "Uploading goals"
+        LocalDataMigrator.STEP_PREFERENCES -> "Uploading preferences"
+        LocalDataMigrator.STEP_DAY_PROPERTIES -> "Uploading day properties"
+        else -> "Uploading"
+    }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/MigrationScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/MigrationScreen.kt
@@ -1,0 +1,55 @@
+package com.bissbilanz.android.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Placeholder shown when a user signs in while in Local mode. The actual migration of
+ * local data to the account is implemented in a follow-up work package; this screen is
+ * intentionally dumb so it can be replaced wholesale.
+ */
+@Composable
+fun MigrationScreen() {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(32.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    CircularProgressIndicator()
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        "Finishing sign-in… your local data will be uploaded to your account.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/SettingsScreen.kt
@@ -29,6 +29,8 @@ import com.bissbilanz.android.BuildConfig
 import com.bissbilanz.android.ui.components.PullToRefreshWrapper
 import com.bissbilanz.android.ui.theme.rememberHaptic
 import com.bissbilanz.android.ui.viewmodels.SettingsViewModel
+import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.mode.AppMode
 import com.bissbilanz.model.Goals
 import com.bissbilanz.model.PreferencesUpdate
 import kotlinx.coroutines.launch
@@ -41,6 +43,9 @@ import com.bissbilanz.api.generated.model.PreferencesUpdate as GenPreferencesUpd
 fun SettingsScreen(navController: NavController) {
     val viewModel: SettingsViewModel = koinViewModel()
     val healthSync: HealthSyncService = koinInject()
+    val authManager: AuthManager = koinInject()
+    val mode by viewModel.mode.collectAsStateWithLifecycle()
+    val isLocalMode = mode == AppMode.LOCAL
     val goals by viewModel.goals.collectAsStateWithLifecycle()
     val prefs by viewModel.prefs.collectAsStateWithLifecycle()
     val customMealTypes by viewModel.customMealTypes.collectAsStateWithLifecycle()
@@ -161,9 +166,11 @@ fun SettingsScreen(navController: NavController) {
                         SettingsNavItem("Calendar", Icons.Default.CalendarMonth) {
                             navController.navigate("calendar")
                         }
-                        HorizontalDivider()
-                        SettingsNavItem("Maintenance Calculator", Icons.Default.Calculate) {
-                            navController.navigate("maintenance")
+                        if (!isLocalMode) {
+                            HorizontalDivider()
+                            SettingsNavItem("Maintenance Calculator", Icons.Default.Calculate) {
+                                navController.navigate("maintenance")
+                            }
                         }
                         HorizontalDivider()
                         SettingsNavItem("Insights", Icons.Default.BarChart) {
@@ -433,42 +440,44 @@ fun SettingsScreen(navController: NavController) {
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                // Custom meal types
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                        ) {
-                            Text(
-                                "Custom Meal Types",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                            IconButton(onClick = { showMealTypeDialog = true }) {
-                                Icon(Icons.Default.Add, "Add meal type")
+                // Custom meal types (server-only, hidden in Local mode)
+                if (!isLocalMode) {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                Text(
+                                    "Custom Meal Types",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                                IconButton(onClick = { showMealTypeDialog = true }) {
+                                    Icon(Icons.Default.Add, "Add meal type")
+                                }
                             }
-                        }
-                        if (customMealTypes.isEmpty()) {
-                            Text(
-                                "Default meals only (Breakfast, Lunch, Dinner, Snack)",
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        } else {
-                            customMealTypes.forEach { mealType ->
-                                Row(
-                                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                ) {
-                                    Text(mealType.name)
+                            if (customMealTypes.isEmpty()) {
+                                Text(
+                                    "Default meals only (Breakfast, Lunch, Dinner, Snack)",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            } else {
+                                customMealTypes.forEach { mealType ->
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                    ) {
+                                        Text(mealType.name)
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
 
                 // Dashboard Widgets
                 prefs?.let { p ->
@@ -628,13 +637,29 @@ fun SettingsScreen(navController: NavController) {
                 Card(modifier = Modifier.fillMaxWidth()) {
                     Column(modifier = Modifier.padding(16.dp)) {
                         Text("Account", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                        Spacer(modifier = Modifier.height(16.dp))
-                        OutlinedButton(
-                            onClick = { viewModel.logout() },
-                            modifier = Modifier.fillMaxWidth(),
-                            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
-                        ) {
-                            Text("Sign out")
+                        if (isLocalMode) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                "Local mode — data only on this device",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Button(
+                                onClick = { launchLoginFlow(context, authManager) },
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text("Sign in to sync")
+                            }
+                        } else {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            OutlinedButton(
+                                onClick = { viewModel.logout() },
+                                modifier = Modifier.fillMaxWidth(),
+                                colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                            ) {
+                                Text("Sign out")
+                            }
                         }
                     }
                 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.analytics.*
 import com.bissbilanz.android.R
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.*
 import com.bissbilanz.repository.AnalyticsRepository
 import com.bissbilanz.repository.GoalsRepository
@@ -26,7 +27,17 @@ class InsightsViewModel(
     private val sleepRepo: SleepRepository,
     private val errorReporter: ErrorReporter,
     private val analyticsRepo: AnalyticsRepository,
+    appModeManager: AppModeManager,
 ) : ViewModel() {
+    /**
+     * True when the app runs in anonymous Local mode. Server-only insights (weekly/monthly
+     * stats, streaks, top foods, meal breakdown and all AnalyticsRepository-backed cards)
+     * are skipped and their UI is hidden; locally computable data (daily stats, calendar,
+     * goals, sleep log) keeps working. Constant for the lifetime of this ViewModel — mode
+     * changes recreate the whole navigation graph.
+     */
+    val isLocalMode: Boolean = appModeManager.isLocal
+
     private val _weeklyStats = MutableStateFlow<MacroTotals?>(null)
     val weeklyStats: StateFlow<MacroTotals?> = _weeklyStats.asStateFlow()
 
@@ -300,8 +311,11 @@ class InsightsViewModel(
 
             try {
                 coroutineScope {
+                    // Weekly/monthly stats, streaks, top foods and meal breakdown are
+                    // server-only; in Local mode they stay empty and their cards are hidden.
                     val weeklyDeferred =
                         async {
+                            if (isLocalMode) return@async null
                             try {
                                 statsRepo.getWeeklyStats().stats
                             } catch (e: Exception) {
@@ -312,6 +326,7 @@ class InsightsViewModel(
                         }
                     val monthlyDeferred =
                         async {
+                            if (isLocalMode) return@async null
                             try {
                                 statsRepo.getMonthlyStats().stats
                             } catch (e: Exception) {
@@ -322,6 +337,7 @@ class InsightsViewModel(
                         }
                     val streaksDeferred =
                         async {
+                            if (isLocalMode) return@async null
                             try {
                                 statsRepo.getStreaks()
                             } catch (e: Exception) {
@@ -332,6 +348,7 @@ class InsightsViewModel(
                         }
                     val topFoodsDeferred =
                         async {
+                            if (isLocalMode) return@async emptyList()
                             try {
                                 statsRepo.getTopFoods(days).data
                             } catch (e: Exception) {
@@ -352,6 +369,7 @@ class InsightsViewModel(
                         }
                     val mealBreakdownDeferred =
                         async {
+                            if (isLocalMode) return@async emptyList()
                             try {
                                 statsRepo.getMealBreakdown(startDate, endDate).data
                             } catch (e: Exception) {
@@ -387,6 +405,7 @@ class InsightsViewModel(
     }
 
     fun loadNutritionAnalytics() {
+        if (isLocalMode) return
         viewModelScope.launch {
             _nutritionLoading.value = true
             val (startDate, endDate) = dateRange()
@@ -464,6 +483,7 @@ class InsightsViewModel(
     }
 
     fun loadWeightAnalytics() {
+        if (isLocalMode) return
         viewModelScope.launch {
             _weightLoading.value = true
             val (startDate, endDate) = dateRange()
@@ -571,6 +591,7 @@ class InsightsViewModel(
     }
 
     fun loadSleepAnalytics() {
+        if (isLocalMode) return
         viewModelScope.launch {
             _sleepLoading.value = true
             val (startDate, endDate) = dateRange()

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModel.kt
@@ -1,0 +1,160 @@
+package com.bissbilanz.android.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bissbilanz.ErrorReporter
+import com.bissbilanz.android.sync.RefreshManager
+import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.migration.LocalDataMigrator
+import com.bissbilanz.migration.MigrationState
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/** What the migration screen should show. */
+sealed class MigrationUiState {
+    data object Loading : MigrationUiState()
+
+    /** The account already has data — the user must decide what to do with the local data. */
+    data class Choice(
+        val localItemCount: Int,
+    ) : MigrationUiState()
+
+    /** [step] is a stable key (see LocalDataMigrator.STEP_*). */
+    data class InProgress(
+        val done: Int,
+        val total: Int,
+        val step: String,
+    ) : MigrationUiState()
+
+    data class Failed(
+        val message: String,
+    ) : MigrationUiState()
+}
+
+/**
+ * Drives the one-shot migration of local (anonymous) data after a sign-in from Local mode.
+ *
+ * On init: nothing local → flip straight to Synced; account already has data → ask the
+ * user; otherwise start uploading immediately. Routing leaves this screen automatically
+ * once the mode becomes [AppMode.SYNCED] (set by the migrator on success or by
+ * [LocalDataMigrator.discardLocalData]).
+ */
+class MigrationViewModel(
+    private val migrator: LocalDataMigrator,
+    private val appModeManager: AppModeManager,
+    private val authManager: AuthManager,
+    private val refreshManager: RefreshManager,
+    private val errorReporter: ErrorReporter,
+) : ViewModel() {
+    private sealed class Phase {
+        data object Deciding : Phase()
+
+        data class Choice(
+            val localItemCount: Int,
+        ) : Phase()
+
+        data object Migrating : Phase()
+
+        data class PreflightFailed(
+            val message: String,
+        ) : Phase()
+    }
+
+    private val phase = MutableStateFlow<Phase>(Phase.Deciding)
+
+    val uiState: StateFlow<MigrationUiState> =
+        combine(phase, migrator.state) { phase, migrationState ->
+            when (phase) {
+                is Phase.Deciding -> {
+                    MigrationUiState.Loading
+                }
+
+                is Phase.Choice -> {
+                    MigrationUiState.Choice(phase.localItemCount)
+                }
+
+                is Phase.PreflightFailed -> {
+                    MigrationUiState.Failed(phase.message)
+                }
+
+                is Phase.Migrating -> {
+                    when (migrationState) {
+                        is MigrationState.Running -> {
+                            MigrationUiState.InProgress(migrationState.done, migrationState.total, migrationState.step)
+                        }
+
+                        is MigrationState.Failed -> {
+                            MigrationUiState.Failed(migrationState.message)
+                        }
+
+                        // Idle: migrate() is about to start. Completed: the mode flips to
+                        // Synced and the root routing leaves this screen.
+                        is MigrationState.Idle, is MigrationState.Completed -> {
+                            MigrationUiState.Loading
+                        }
+                    }
+                }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, MigrationUiState.Loading)
+
+    init {
+        decide()
+    }
+
+    private fun decide() {
+        viewModelScope.launch {
+            phase.value = Phase.Deciding
+            val localItemCount = migrator.plan().total
+            if (localItemCount == 0) {
+                // Nothing to migrate — just continue as a regular synced account.
+                appModeManager.setMode(AppMode.SYNCED)
+                return@launch
+            }
+            try {
+                if (migrator.serverHasData()) {
+                    phase.value = Phase.Choice(localItemCount)
+                } else {
+                    startUpload()
+                }
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                phase.value = Phase.PreflightFailed(e.message ?: "Could not reach the server")
+            }
+        }
+    }
+
+    fun startUpload() {
+        phase.value = Phase.Migrating
+        viewModelScope.launch {
+            migrator.migrate()
+            if (migrator.state.value is MigrationState.Completed) {
+                refreshManager.refreshAll()
+            }
+        }
+    }
+
+    /** Discards all local data (the UI confirms first) and continues with the account. */
+    fun startFresh() {
+        phase.value = Phase.Deciding
+        viewModelScope.launch {
+            migrator.discardLocalData()
+            refreshManager.refreshAll()
+        }
+    }
+
+    fun retry() {
+        if (phase.value is Phase.Migrating) startUpload() else decide()
+    }
+
+    /** Abandons the sign-in: the mode stays Local, routing returns to the anonymous app. */
+    fun cancelToLocal() {
+        authManager.logout()
+    }
+}

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModel.kt
@@ -155,6 +155,10 @@ class MigrationViewModel(
 
     /** Abandons the sign-in: the mode stays Local, routing returns to the anonymous app. */
     fun cancelToLocal() {
+        // Drop the one-shot normalization marker of this abandoned attempt cycle. Rows
+        // created later in Local mode would otherwise never be normalized (re-keyed)
+        // when the user eventually signs in again.
+        migrator.resetNormalization()
         authManager.logout()
     }
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.bissbilanz.android.sync.RefreshManager
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.Preferences
 import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.cache.LocalDataWiper
 import com.bissbilanz.mode.AppMode
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.Goals
@@ -33,6 +34,7 @@ class SettingsViewModel(
     private val refreshManager: RefreshManager,
     private val errorReporter: ErrorReporter,
     private val appModeManager: AppModeManager,
+    private val localDataWiper: LocalDataWiper,
 ) : ViewModel() {
     val mode: StateFlow<AppMode?> = appModeManager.mode
 
@@ -162,9 +164,20 @@ class SettingsViewModel(
     }
 
     fun logout() {
-        authManager.logout()
-        // Reset the mode so the next start shows the login screen with the mode choice again.
-        appModeManager.clear()
+        viewModelScope.launch {
+            // Deliberate logout: wipe the local store, sync queue and sync markers
+            // BEFORE flipping the auth state. Leftover rows would leak into the next
+            // account that signs in on this device (or be re-uploaded as "local data").
+            try {
+                localDataWiper.wipeAll()
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+            }
+            authManager.logout()
+            // Reset the mode so the next start shows the login screen with the mode choice again.
+            appModeManager.clear()
+        }
     }
 
     fun clearSnackbar() {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModel.kt
@@ -8,6 +8,8 @@ import com.bissbilanz.android.sync.RefreshManager
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.Preferences
 import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.Goals
 import com.bissbilanz.model.MealType
 import com.bissbilanz.model.MealTypeCreate
@@ -30,7 +32,10 @@ class SettingsViewModel(
     private val healthSync: HealthSyncService,
     private val refreshManager: RefreshManager,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) : ViewModel() {
+    val mode: StateFlow<AppMode?> = appModeManager.mode
+
     val goals: StateFlow<Goals?> =
         goalsRepo
             .goals()
@@ -61,12 +66,15 @@ class SettingsViewModel(
         viewModelScope.launch {
             goalsRepo.refresh()
             prefsRepo.refresh()
-            try {
-                val response = api.getMealTypes()
-                _customMealTypes.value = response.mealTypes
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                errorReporter.captureException(e)
+            // Custom meal types are server-only; the management UI is hidden in Local mode.
+            if (!appModeManager.isLocal) {
+                try {
+                    val response = api.getMealTypes()
+                    _customMealTypes.value = response.mealTypes
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    errorReporter.captureException(e)
+                }
             }
             _healthAvailable.value = healthSync.isAvailable()
             if (_healthAvailable.value) {
@@ -155,6 +163,8 @@ class SettingsViewModel(
 
     fun logout() {
         authManager.logout()
+        // Reset the mode so the next start shows the login screen with the mode choice again.
+        appModeManager.clear()
     }
 
     fun clearSnackbar() {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidget.kt
@@ -40,7 +40,7 @@ import androidx.glance.text.TextStyle
 import com.bissbilanz.android.MainActivity
 import com.bissbilanz.android.R
 import com.bissbilanz.api.generated.model.Food
-import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -71,10 +71,10 @@ class FavoritesWidget : GlanceAppWidget() {
         val koin =
             org.koin.java.KoinJavaComponent
                 .getKoin()
-        val db = koin.get<BissbilanzDatabase>()
+        val db = koin.get<UserDataDatabase>()
         val json = koin.get<Json>()
 
-        val rows = db.bissbilanzDatabaseQueries.selectFavorites().executeAsList()
+        val rows = db.userDataDatabaseQueries.selectFavorites().executeAsList()
         val favorites = rows.mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
 
         val imageDir = File(context.cacheDir, "widget_food_images")

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/FavoritesWidgetWorker.kt
@@ -8,9 +8,9 @@ import androidx.work.WorkerParameters
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.Food
-import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.repository.FoodRepository
 import com.bissbilanz.repository.PreferencesRepository
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -27,7 +27,7 @@ class FavoritesWidgetWorker(
         val errorReporter = koin.get<ErrorReporter>()
         val foodRepo = koin.get<FoodRepository>()
         val prefsRepo = koin.get<PreferencesRepository>()
-        val db = koin.get<BissbilanzDatabase>()
+        val db = koin.get<UserDataDatabase>()
         val json = koin.get<Json>()
         val api = koin.get<BissbilanzApi>()
 
@@ -36,7 +36,7 @@ class FavoritesWidgetWorker(
             prefsRepo.refresh()
 
             val favorites =
-                db.bissbilanzDatabaseQueries
+                db.userDataDatabaseQueries
                     .selectFavorites()
                     .executeAsList()
                     .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/widget/LogFavoriteFoodAction.kt
@@ -7,9 +7,9 @@ import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.android.MainActivity
-import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.model.EntryCreate
 import com.bissbilanz.repository.EntryRepository
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.resolveDefaultMeal
 import kotlinx.coroutines.delay
@@ -34,11 +34,11 @@ class LogFavoriteFoodAction : ActionCallback {
             org.koin.java.KoinJavaComponent
                 .getKoin()
         val entryRepo = koin.get<EntryRepository>()
-        val db = koin.get<BissbilanzDatabase>()
+        val db = koin.get<UserDataDatabase>()
         val json = koin.get<Json>()
         val errorReporter = koin.get<ErrorReporter>()
 
-        val cached = db.bissbilanzDatabaseQueries.selectPreferences().executeAsOneOrNull()
+        val cached = db.userDataDatabaseQueries.selectPreferences().executeAsOneOrNull()
         val prefs = cached?.let { json.decodeOrNull<com.bissbilanz.api.generated.model.Preferences>(it.jsonData) }
         val meal = resolveDefaultMeal(prefs)
 

--- a/mobile/androidApp/src/androidMain/res/xml/backup_rules.xml
+++ b/mobile/androidApp/src/androidMain/res/xml/backup_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Auto Backup rules for Android 11 and lower (fullBackupContent).
+     The encrypted token prefs are useless on another device (the Keystore master
+     key never leaves this device) and restoring them crashes EncryptedSharedPreferences.
+     The SQLite database is a server cache plus sync queue today; restoring a stale
+     sync queue onto a new device would replay old operations. -->
+<full-backup-content>
+    <exclude domain="sharedpref" path="bissbilanz_secure_prefs.xml" />
+    <exclude domain="database" path="bissbilanz.db" />
+    <exclude domain="database" path="bissbilanz.db-journal" />
+    <exclude domain="database" path="bissbilanz.db-shm" />
+    <exclude domain="database" path="bissbilanz.db-wal" />
+</full-backup-content>

--- a/mobile/androidApp/src/androidMain/res/xml/backup_rules.xml
+++ b/mobile/androidApp/src/androidMain/res/xml/backup_rules.xml
@@ -1,13 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Auto Backup rules for Android 11 and lower (fullBackupContent).
-     The encrypted token prefs are useless on another device (the Keystore master
-     key never leaves this device) and restoring them crashes EncryptedSharedPreferences.
-     The SQLite database is a server cache plus sync queue today; restoring a stale
-     sync queue onto a new device would replay old operations. -->
+     Exclude-only rules: everything not listed here IS backed up by default.
+
+     Backed up (by default):
+     - userdata.db: the user's own data (foods, entries, recipes, weight, sleep,
+       supplements, goals, preferences, day properties). It runs with
+       journal_mode=DELETE so the single file is self-consistent; only its
+       transient -journal sidecar is excluded.
+     - bissbilanz_app_prefs.xml: plain prefs holding the app mode (Local/Synced).
+
+     Excluded:
+     - bissbilanz_secure_prefs.xml: encrypted token prefs are useless on another
+       device (the Keystore master key never leaves this device) and restoring
+       them crashes EncryptedSharedPreferences.
+     - bissbilanz.db (+ sidecars): server cache plus sync queue; restoring a stale
+       sync queue onto a new device would replay old operations. -->
 <full-backup-content>
     <exclude domain="sharedpref" path="bissbilanz_secure_prefs.xml" />
     <exclude domain="database" path="bissbilanz.db" />
     <exclude domain="database" path="bissbilanz.db-journal" />
     <exclude domain="database" path="bissbilanz.db-shm" />
     <exclude domain="database" path="bissbilanz.db-wal" />
+    <exclude domain="database" path="userdata.db-journal" />
 </full-backup-content>

--- a/mobile/androidApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/mobile/androidApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Auto Backup / device transfer rules for Android 12+ (dataExtractionRules).
+     Token prefs are excluded from both: the Keystore master key that encrypts them
+     never transfers, so restored prefs are undecryptable and crash at init.
+     The cache database is excluded so a stale sync queue is never restored. -->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="bissbilanz_secure_prefs.xml" />
+        <exclude domain="database" path="bissbilanz.db" />
+        <exclude domain="database" path="bissbilanz.db-journal" />
+        <exclude domain="database" path="bissbilanz.db-shm" />
+        <exclude domain="database" path="bissbilanz.db-wal" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="bissbilanz_secure_prefs.xml" />
+        <exclude domain="database" path="bissbilanz.db" />
+        <exclude domain="database" path="bissbilanz.db-journal" />
+        <exclude domain="database" path="bissbilanz.db-shm" />
+        <exclude domain="database" path="bissbilanz.db-wal" />
+    </device-transfer>
+</data-extraction-rules>

--- a/mobile/androidApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/mobile/androidApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Auto Backup / device transfer rules for Android 12+ (dataExtractionRules).
-     Token prefs are excluded from both: the Keystore master key that encrypts them
-     never transfers, so restored prefs are undecryptable and crash at init.
-     The cache database is excluded so a stale sync queue is never restored. -->
+     Exclude-only rules: everything not listed here IS backed up by default.
+
+     Backed up (by default):
+     - userdata.db: the user's own data (foods, entries, recipes, weight, sleep,
+       supplements, goals, preferences, day properties). It runs with
+       journal_mode=DELETE so the single file is self-consistent; only its
+       transient -journal sidecar is excluded.
+     - bissbilanz_app_prefs.xml: plain prefs holding the app mode (Local/Synced).
+
+     Excluded:
+     - bissbilanz_secure_prefs.xml: the Keystore master key that encrypts the token
+       prefs never transfers, so restored prefs are undecryptable and crash at init.
+     - bissbilanz.db (+ sidecars): server cache plus sync queue; a stale sync queue
+       must never be restored. -->
 <data-extraction-rules>
     <cloud-backup>
         <exclude domain="sharedpref" path="bissbilanz_secure_prefs.xml" />
@@ -10,6 +21,7 @@
         <exclude domain="database" path="bissbilanz.db-journal" />
         <exclude domain="database" path="bissbilanz.db-shm" />
         <exclude domain="database" path="bissbilanz.db-wal" />
+        <exclude domain="database" path="userdata.db-journal" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="sharedpref" path="bissbilanz_secure_prefs.xml" />
@@ -17,5 +29,6 @@
         <exclude domain="database" path="bissbilanz.db-journal" />
         <exclude domain="database" path="bissbilanz.db-shm" />
         <exclude domain="database" path="bissbilanz.db-wal" />
+        <exclude domain="database" path="userdata.db-journal" />
     </device-transfer>
 </data-extraction-rules>

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/RootDestinationTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/RootDestinationTest.kt
@@ -1,0 +1,78 @@
+package com.bissbilanz.android.ui
+
+import com.bissbilanz.auth.AuthState
+import com.bissbilanz.mode.AppMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RootDestinationTest {
+    private val allModes = listOf(null, AppMode.LOCAL, AppMode.SYNCED)
+
+    @Test
+    fun loadingShowsSpinnerRegardlessOfMode() {
+        allModes.forEach { mode ->
+            assertEquals(RootDestination.Loading, resolveRootDestination(AuthState.Loading, mode))
+        }
+    }
+
+    @Test
+    fun authenticatedWithLocalModeGoesToMigration() {
+        assertEquals(RootDestination.Migration, resolveRootDestination(AuthState.Authenticated, AppMode.LOCAL))
+    }
+
+    @Test
+    fun refreshingWithLocalModeGoesToMigration() {
+        assertEquals(RootDestination.Migration, resolveRootDestination(AuthState.Refreshing, AppMode.LOCAL))
+    }
+
+    @Test
+    fun authenticatedWithSyncedModeGoesToApp() {
+        assertEquals(RootDestination.App, resolveRootDestination(AuthState.Authenticated, AppMode.SYNCED))
+    }
+
+    @Test
+    fun authenticatedWithNoModeGoesToApp() {
+        // Existing installs and fresh logins: mode is null, sync is allowed.
+        assertEquals(RootDestination.App, resolveRootDestination(AuthState.Authenticated, null))
+    }
+
+    @Test
+    fun refreshingWithSyncedModeGoesToApp() {
+        assertEquals(RootDestination.App, resolveRootDestination(AuthState.Refreshing, AppMode.SYNCED))
+    }
+
+    @Test
+    fun refreshingWithNoModeGoesToApp() {
+        assertEquals(RootDestination.App, resolveRootDestination(AuthState.Refreshing, null))
+    }
+
+    @Test
+    fun unauthenticatedWithLocalModeGoesToAppAnonymously() {
+        assertEquals(RootDestination.App, resolveRootDestination(AuthState.Unauthenticated, AppMode.LOCAL))
+    }
+
+    @Test
+    fun sessionExpiredWithLocalModeGoesToAppAnonymously() {
+        assertEquals(RootDestination.App, resolveRootDestination(AuthState.SessionExpired, AppMode.LOCAL))
+    }
+
+    @Test
+    fun unauthenticatedWithSyncedModeGoesToLogin() {
+        assertEquals(RootDestination.Login, resolveRootDestination(AuthState.Unauthenticated, AppMode.SYNCED))
+    }
+
+    @Test
+    fun unauthenticatedWithNoModeGoesToLogin() {
+        assertEquals(RootDestination.Login, resolveRootDestination(AuthState.Unauthenticated, null))
+    }
+
+    @Test
+    fun sessionExpiredWithSyncedModeGoesToLogin() {
+        assertEquals(RootDestination.Login, resolveRootDestination(AuthState.SessionExpired, AppMode.SYNCED))
+    }
+
+    @Test
+    fun sessionExpiredWithNoModeGoesToLogin() {
+        assertEquals(RootDestination.Login, resolveRootDestination(AuthState.SessionExpired, null))
+    }
+}

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/screens/LoginScreenTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/screens/LoginScreenTest.kt
@@ -1,0 +1,28 @@
+package com.bissbilanz.android.ui.screens
+
+import com.bissbilanz.mode.AppMode
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LoginScreenTest {
+    @Test
+    fun continueWithoutAccountIsHiddenForSessionExpiredSyncedUsers() {
+        // A SYNCED user on the login screen is the session-expired re-login case:
+        // offering Local mode would turn the leftover account cache into "local data"
+        // and duplicate everything on the next sign-in.
+        assertFalse(showContinueWithoutAccount(AppMode.SYNCED))
+    }
+
+    @Test
+    fun continueWithoutAccountIsOfferedWhenNoModeWasChosen() {
+        assertTrue(showContinueWithoutAccount(null))
+    }
+
+    @Test
+    fun continueWithoutAccountStaysAvailableInLocalMode() {
+        // Local-mode users never see the login screen via root routing, but the option
+        // must not regress if they do (e.g. transient states).
+        assertTrue(showContinueWithoutAccount(AppMode.LOCAL))
+    }
+}

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModelTest.kt
@@ -2,6 +2,8 @@ package com.bissbilanz.android.ui.viewmodels
 
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.android.R
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.SleepCreate
 import com.bissbilanz.model.SleepEntry
 import com.bissbilanz.model.SleepFoodCorrelationEntry
@@ -9,6 +11,7 @@ import com.bissbilanz.repository.AnalyticsRepository
 import com.bissbilanz.repository.GoalsRepository
 import com.bissbilanz.repository.SleepRepository
 import com.bissbilanz.repository.StatsRepository
+import com.bissbilanz.storage.KeyValueStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -25,17 +28,37 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class InsightsViewModelTest {
+    private class InMemoryKeyValueStore : KeyValueStore {
+        private val values = mutableMapOf<String, String>()
+
+        override fun save(
+            key: String,
+            value: String,
+        ) {
+            values[key] = value
+        }
+
+        override fun load(key: String): String? = values[key]
+
+        override fun delete(key: String) {
+            values.remove(key)
+        }
+    }
+
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var statsRepo: StatsRepository
     private lateinit var goalsRepo: GoalsRepository
     private lateinit var sleepRepo: SleepRepository
     private lateinit var errorReporter: ErrorReporter
     private lateinit var analyticsRepo: AnalyticsRepository
+    private lateinit var appModeManager: AppModeManager
     private lateinit var sleepEntriesFlow: MutableStateFlow<List<SleepEntry>>
 
     @BeforeTest
@@ -45,6 +68,7 @@ class InsightsViewModelTest {
         statsRepo = mockk(relaxed = true)
         errorReporter = mockk(relaxed = true)
         analyticsRepo = mockk(relaxed = true)
+        appModeManager = AppModeManager(InMemoryKeyValueStore())
         goalsRepo =
             mockk(relaxed = true) {
                 every { goals() } returns MutableStateFlow(null)
@@ -60,10 +84,12 @@ class InsightsViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private fun createViewModel() = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo, appModeManager)
+
     @Test
     fun loadSleepDataCallsRefreshOnRepository() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.loadSleepData()
 
@@ -84,7 +110,7 @@ class InsightsViewModelTest {
                 )
             coEvery { sleepRepo.getSleepFoodCorrelation(any(), any()) } returns correlations
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.loadSleepData()
 
             assertEquals(1, viewModel.sleepFoodCorrelation.value.size)
@@ -96,7 +122,7 @@ class InsightsViewModelTest {
         runTest {
             coEvery { sleepRepo.refresh(any(), any()) } throws RuntimeException("Network error")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.loadSleepData()
 
             // Should not crash — snackbar not set for sleep load failures
@@ -108,7 +134,7 @@ class InsightsViewModelTest {
         runTest {
             coEvery { sleepRepo.getSleepFoodCorrelation(any(), any()) } throws RuntimeException("Network error")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.loadSleepData()
 
             assertEquals(emptyList(), viewModel.sleepFoodCorrelation.value)
@@ -120,7 +146,7 @@ class InsightsViewModelTest {
             val entry = SleepCreate(durationMinutes = 480, quality = 8, entryDate = "2024-01-20")
             coEvery { sleepRepo.createEntry(entry) } returns testSleepEntry("new")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.createSleepEntry(entry)
 
             assertEquals(R.string.sleep_logged, viewModel.snackbarMessage.value)
@@ -132,7 +158,7 @@ class InsightsViewModelTest {
             val entry = SleepCreate(durationMinutes = 480, quality = 8, entryDate = "2024-01-20")
             coEvery { sleepRepo.createEntry(entry) } throws RuntimeException("Network error")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.createSleepEntry(entry)
 
             assertEquals(R.string.sleep_log_failed, viewModel.snackbarMessage.value)
@@ -143,7 +169,7 @@ class InsightsViewModelTest {
         runTest {
             coEvery { sleepRepo.deleteEntry("entry-1") } returns Unit
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.deleteSleepEntry("entry-1")
 
             assertEquals(R.string.sleep_deleted, viewModel.snackbarMessage.value)
@@ -154,7 +180,7 @@ class InsightsViewModelTest {
         runTest {
             coEvery { sleepRepo.deleteEntry("entry-1") } throws RuntimeException("Network error")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.deleteSleepEntry("entry-1")
 
             assertEquals(R.string.sleep_delete_failed, viewModel.snackbarMessage.value)
@@ -166,7 +192,7 @@ class InsightsViewModelTest {
             val entry = testSleepEntry("1")
             sleepEntriesFlow.value = listOf(entry)
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             assertEquals(1, viewModel.sleepEntries.first().size)
             assertEquals("1", viewModel.sleepEntries.first()[0].id)
@@ -177,7 +203,7 @@ class InsightsViewModelTest {
         runTest {
             coEvery { sleepRepo.deleteEntry("entry-1") } returns Unit
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.deleteSleepEntry("entry-1")
             assertEquals(R.string.sleep_deleted, viewModel.snackbarMessage.value)
 
@@ -189,7 +215,7 @@ class InsightsViewModelTest {
     @Test
     fun selectTabTriggersNutritionLoad() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.selectTab(1)
 
@@ -199,7 +225,7 @@ class InsightsViewModelTest {
     @Test
     fun selectTabIsLazySecondCallSkipped() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.selectTab(1)
             viewModel.selectTab(1)
@@ -210,7 +236,7 @@ class InsightsViewModelTest {
     @Test
     fun selectRangeResetsLoadedTabs() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.selectTab(1)
             viewModel.selectRange(1)
@@ -221,7 +247,7 @@ class InsightsViewModelTest {
     @Test
     fun novaResultComputedAfterNutritionLoad() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.loadNutritionAnalytics()
 
@@ -231,7 +257,7 @@ class InsightsViewModelTest {
     @Test
     fun selectTabWeightTriggersWeightLoad() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.selectTab(2)
 
@@ -241,7 +267,7 @@ class InsightsViewModelTest {
     @Test
     fun selectTabSleepTriggersSleepLoad() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.selectTab(3)
 
@@ -251,7 +277,7 @@ class InsightsViewModelTest {
     @Test
     fun selectTabWeightIsLazySecondCallSkipped() =
         runTest {
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
 
             viewModel.selectTab(2)
             viewModel.selectTab(2)
@@ -264,7 +290,7 @@ class InsightsViewModelTest {
         runTest {
             coEvery { analyticsRepo.getNutrientsExtended(any(), any()) } throws RuntimeException("fail")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.loadNutritionAnalytics()
 
             assertEquals(false, viewModel.nutritionLoading.value)
@@ -275,7 +301,7 @@ class InsightsViewModelTest {
         runTest {
             coEvery { analyticsRepo.getWeightFood(any(), any()) } throws RuntimeException("fail")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.loadWeightAnalytics()
 
             assertEquals(false, viewModel.weightLoading.value)
@@ -286,10 +312,83 @@ class InsightsViewModelTest {
         runTest {
             coEvery { analyticsRepo.getSleepFood(any(), any()) } throws RuntimeException("fail")
 
-            val viewModel = InsightsViewModel(statsRepo, goalsRepo, sleepRepo, errorReporter, analyticsRepo)
+            val viewModel = createViewModel()
             viewModel.loadSleepAnalytics()
 
             assertEquals(false, viewModel.sleepLoading.value)
+        }
+
+    @Test
+    fun isLocalModeReflectsAppModeManager() =
+        runTest {
+            assertFalse(createViewModel().isLocalMode)
+
+            appModeManager.setMode(AppMode.LOCAL)
+
+            assertTrue(createViewModel().isLocalMode)
+        }
+
+    @Test
+    fun localModeSkipsServerOnlyStatsButLoadsDailyStats() =
+        runTest {
+            appModeManager.setMode(AppMode.LOCAL)
+
+            createViewModel()
+
+            coVerify(exactly = 0) { statsRepo.getWeeklyStats() }
+            coVerify(exactly = 0) { statsRepo.getMonthlyStats() }
+            coVerify(exactly = 0) { statsRepo.getStreaks() }
+            coVerify(exactly = 0) { statsRepo.getTopFoods(any(), any()) }
+            coVerify(exactly = 0) { statsRepo.getMealBreakdown(any(), any()) }
+            coVerify(atLeast = 1) { statsRepo.getDailyStats(any(), any()) }
+            coVerify(atLeast = 1) { statsRepo.getCalendarStats(any()) }
+        }
+
+    @Test
+    fun localModeSkipsNutritionAnalytics() =
+        runTest {
+            appModeManager.setMode(AppMode.LOCAL)
+
+            val viewModel = createViewModel()
+            viewModel.selectTab(1)
+
+            coVerify(exactly = 0) { analyticsRepo.getNutrientsExtended(any(), any()) }
+            assertEquals(false, viewModel.nutritionLoading.value)
+        }
+
+    @Test
+    fun localModeSkipsWeightAnalytics() =
+        runTest {
+            appModeManager.setMode(AppMode.LOCAL)
+
+            val viewModel = createViewModel()
+            viewModel.selectTab(2)
+
+            coVerify(exactly = 0) { analyticsRepo.getWeightFood(any(), any()) }
+        }
+
+    @Test
+    fun localModeSkipsSleepAnalytics() =
+        runTest {
+            appModeManager.setMode(AppMode.LOCAL)
+
+            val viewModel = createViewModel()
+            viewModel.selectTab(3)
+
+            coVerify(exactly = 0) { analyticsRepo.getSleepFood(any(), any()) }
+        }
+
+    @Test
+    fun syncedModeLoadsServerOnlyStats() =
+        runTest {
+            appModeManager.setMode(AppMode.SYNCED)
+
+            createViewModel()
+
+            coVerify(atLeast = 1) { statsRepo.getWeeklyStats() }
+            coVerify(atLeast = 1) { statsRepo.getStreaks() }
+            coVerify(atLeast = 1) { statsRepo.getTopFoods(any(), any()) }
+            coVerify(atLeast = 1) { statsRepo.getMealBreakdown(any(), any()) }
         }
 
     companion object {

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModelTest.kt
@@ -1,0 +1,225 @@
+package com.bissbilanz.android.ui.viewmodels
+
+import com.bissbilanz.ErrorReporter
+import com.bissbilanz.android.sync.RefreshManager
+import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.migration.LocalDataMigrator
+import com.bissbilanz.migration.MigrationPlan
+import com.bissbilanz.migration.MigrationState
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
+import com.bissbilanz.storage.KeyValueStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MigrationViewModelTest {
+    private class InMemoryKeyValueStore : KeyValueStore {
+        private val values = mutableMapOf<String, String>()
+
+        override fun save(
+            key: String,
+            value: String,
+        ) {
+            values[key] = value
+        }
+
+        override fun load(key: String): String? = values[key]
+
+        override fun delete(key: String) {
+            values.remove(key)
+        }
+    }
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var migrator: LocalDataMigrator
+    private lateinit var migratorState: MutableStateFlow<MigrationState>
+    private lateinit var appModeManager: AppModeManager
+    private lateinit var authManager: AuthManager
+    private lateinit var refreshManager: RefreshManager
+    private lateinit var errorReporter: ErrorReporter
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        migratorState = MutableStateFlow(MigrationState.Idle)
+        migrator =
+            mockk(relaxed = true) {
+                every { state } returns migratorState
+            }
+        appModeManager = AppModeManager(InMemoryKeyValueStore()).apply { setMode(AppMode.LOCAL) }
+        authManager = mockk(relaxed = true)
+        refreshManager = mockk(relaxed = true)
+        errorReporter = mockk(relaxed = true)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun plan(total: Int) =
+        MigrationPlan(
+            foods = total,
+            recipes = 0,
+            entries = 0,
+            weights = 0,
+            sleepEntries = 0,
+            supplements = 0,
+            supplementLogs = 0,
+            dayProperties = 0,
+            hasGoals = false,
+            hasPreferences = false,
+        )
+
+    private fun createViewModel() = MigrationViewModel(migrator, appModeManager, authManager, refreshManager, errorReporter)
+
+    @Test
+    fun noLocalDataFlipsModeDirectlyWithoutMigrating() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 0)
+
+            createViewModel()
+
+            assertEquals(AppMode.SYNCED, appModeManager.mode.value)
+            coVerify(exactly = 0) { migrator.serverHasData() }
+            coVerify(exactly = 0) { migrator.migrate() }
+        }
+
+    @Test
+    fun emptyAccountAutoStartsTheUpload() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 5)
+            coEvery { migrator.serverHasData() } returns false
+
+            createViewModel()
+
+            coVerify(exactly = 1) { migrator.migrate() }
+            assertEquals(AppMode.LOCAL, appModeManager.mode.value)
+        }
+
+    @Test
+    fun accountWithDataShowsChoiceInsteadOfUploading() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 7)
+            coEvery { migrator.serverHasData() } returns true
+
+            val viewModel = createViewModel()
+
+            val state = viewModel.uiState.value
+            assertIs<MigrationUiState.Choice>(state)
+            assertEquals(7, state.localItemCount)
+            coVerify(exactly = 0) { migrator.migrate() }
+        }
+
+    @Test
+    fun startUploadFromChoiceMigratesAndRefreshesOnCompletion() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 7)
+            coEvery { migrator.serverHasData() } returns true
+            coEvery { migrator.migrate() } answers { migratorState.value = MigrationState.Completed }
+
+            val viewModel = createViewModel()
+            viewModel.startUpload()
+
+            coVerify(exactly = 1) { migrator.migrate() }
+            coVerify(exactly = 1) { refreshManager.refreshAll() }
+        }
+
+    @Test
+    fun migrationProgressIsExposedAsInProgressState() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 5)
+            coEvery { migrator.serverHasData() } returns false
+            coEvery { migrator.migrate() } answers {
+                migratorState.value = MigrationState.Running(done = 2, total = 5, step = LocalDataMigrator.STEP_ENTRIES)
+            }
+
+            val viewModel = createViewModel()
+
+            val state = viewModel.uiState.value
+            assertIs<MigrationUiState.InProgress>(state)
+            assertEquals(2, state.done)
+            assertEquals(5, state.total)
+            assertEquals(LocalDataMigrator.STEP_ENTRIES, state.step)
+        }
+
+    @Test
+    fun failedMigrationShowsFailureAndRetryMigratesAgain() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 5)
+            coEvery { migrator.serverHasData() } returns false
+            coEvery { migrator.migrate() } answers { migratorState.value = MigrationState.Failed("network down") }
+
+            val viewModel = createViewModel()
+
+            val state = viewModel.uiState.value
+            assertIs<MigrationUiState.Failed>(state)
+            assertEquals("network down", state.message)
+            assertEquals(AppMode.LOCAL, appModeManager.mode.value)
+
+            viewModel.retry()
+
+            coVerify(exactly = 2) { migrator.migrate() }
+        }
+
+    @Test
+    fun preflightFailureShowsFailureAndRetryReruns() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 5)
+            coEvery { migrator.serverHasData() } throws RuntimeException("offline") andThen false
+
+            val viewModel = createViewModel()
+
+            val state = viewModel.uiState.value
+            assertIs<MigrationUiState.Failed>(state)
+            assertEquals("offline", state.message)
+            coVerify(exactly = 0) { migrator.migrate() }
+
+            viewModel.retry()
+
+            coVerify(exactly = 1) { migrator.migrate() }
+        }
+
+    @Test
+    fun startFreshDiscardsLocalData() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 7)
+            coEvery { migrator.serverHasData() } returns true
+
+            val viewModel = createViewModel()
+            viewModel.startFresh()
+
+            coVerify(exactly = 1) { migrator.discardLocalData() }
+            coVerify(exactly = 0) { migrator.migrate() }
+        }
+
+    @Test
+    fun cancelToLocalLogsOutAndKeepsLocalMode() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 5)
+            coEvery { migrator.serverHasData() } returns false
+            coEvery { migrator.migrate() } answers { migratorState.value = MigrationState.Failed("network down") }
+
+            val viewModel = createViewModel()
+            viewModel.cancelToLocal()
+
+            verify(exactly = 1) { authManager.logout() }
+            assertEquals(AppMode.LOCAL, appModeManager.mode.value)
+        }
+}

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/MigrationViewModelTest.kt
@@ -222,4 +222,19 @@ class MigrationViewModelTest {
             verify(exactly = 1) { authManager.logout() }
             assertEquals(AppMode.LOCAL, appModeManager.mode.value)
         }
+
+    @Test
+    fun cancelToLocalClearsTheNormalizationMarker() =
+        runTest {
+            every { migrator.plan() } returns plan(total = 5)
+            coEvery { migrator.serverHasData() } returns false
+            coEvery { migrator.migrate() } answers { migratorState.value = MigrationState.Failed("network down") }
+
+            val viewModel = createViewModel()
+            viewModel.cancelToLocal()
+
+            // A stale marker would make a later migration skip normalizing rows it has
+            // never seen — the abandoned attempt cycle must reset it.
+            verify(exactly = 1) { migrator.resetNormalization() }
+        }
 }

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModelTest.kt
@@ -5,12 +5,15 @@ import com.bissbilanz.HealthSyncService
 import com.bissbilanz.android.sync.RefreshManager
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.cache.LocalDataWiper
 import com.bissbilanz.mode.AppMode
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.repository.GoalsRepository
 import com.bissbilanz.repository.PreferencesRepository
 import com.bissbilanz.storage.KeyValueStore
+import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -55,6 +58,7 @@ class SettingsViewModelTest {
     private lateinit var refreshManager: RefreshManager
     private lateinit var errorReporter: ErrorReporter
     private lateinit var appModeManager: AppModeManager
+    private lateinit var localDataWiper: LocalDataWiper
 
     @BeforeTest
     fun setup() {
@@ -65,6 +69,7 @@ class SettingsViewModelTest {
         refreshManager = mockk(relaxed = true)
         errorReporter = mockk(relaxed = true)
         appModeManager = AppModeManager(InMemoryKeyValueStore())
+        localDataWiper = mockk(relaxed = true)
         goalsRepo =
             mockk(relaxed = true) {
                 every { goals() } returns MutableStateFlow(null)
@@ -81,7 +86,17 @@ class SettingsViewModelTest {
     }
 
     private fun createViewModel() =
-        SettingsViewModel(authManager, goalsRepo, prefsRepo, api, healthSync, refreshManager, errorReporter, appModeManager)
+        SettingsViewModel(
+            authManager,
+            goalsRepo,
+            prefsRepo,
+            api,
+            healthSync,
+            refreshManager,
+            errorReporter,
+            appModeManager,
+            localDataWiper,
+        )
 
     @Test
     fun modeFlowExposesAppModeManagerMode() =
@@ -117,6 +132,35 @@ class SettingsViewModelTest {
     fun logoutClearsAuthAndMode() =
         runTest {
             appModeManager.setMode(AppMode.SYNCED)
+
+            val viewModel = createViewModel()
+            viewModel.logout()
+
+            verify(exactly = 1) { authManager.logout() }
+            assertNull(appModeManager.mode.value)
+        }
+
+    @Test
+    fun logoutWipesLocalDataBeforeClearingAuth() =
+        runTest {
+            appModeManager.setMode(AppMode.SYNCED)
+
+            val viewModel = createViewModel()
+            viewModel.logout()
+
+            // The wipe must complete before the auth state flips (and the UI leaves).
+            coVerifyOrder {
+                localDataWiper.wipeAll()
+                authManager.logout()
+            }
+            assertNull(appModeManager.mode.value)
+        }
+
+    @Test
+    fun logoutStillClearsAuthWhenTheWipeFails() =
+        runTest {
+            appModeManager.setMode(AppMode.SYNCED)
+            coEvery { localDataWiper.wipeAll() } throws RuntimeException("disk error")
 
             val viewModel = createViewModel()
             viewModel.logout()

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/SettingsViewModelTest.kt
@@ -1,0 +1,127 @@
+package com.bissbilanz.android.ui.viewmodels
+
+import com.bissbilanz.ErrorReporter
+import com.bissbilanz.HealthSyncService
+import com.bissbilanz.android.sync.RefreshManager
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.auth.AuthManager
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
+import com.bissbilanz.repository.GoalsRepository
+import com.bissbilanz.repository.PreferencesRepository
+import com.bissbilanz.storage.KeyValueStore
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+    private class InMemoryKeyValueStore : KeyValueStore {
+        private val values = mutableMapOf<String, String>()
+
+        override fun save(
+            key: String,
+            value: String,
+        ) {
+            values[key] = value
+        }
+
+        override fun load(key: String): String? = values[key]
+
+        override fun delete(key: String) {
+            values.remove(key)
+        }
+    }
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var authManager: AuthManager
+    private lateinit var goalsRepo: GoalsRepository
+    private lateinit var prefsRepo: PreferencesRepository
+    private lateinit var api: BissbilanzApi
+    private lateinit var healthSync: HealthSyncService
+    private lateinit var refreshManager: RefreshManager
+    private lateinit var errorReporter: ErrorReporter
+    private lateinit var appModeManager: AppModeManager
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        authManager = mockk(relaxed = true)
+        api = mockk(relaxed = true)
+        healthSync = mockk(relaxed = true)
+        refreshManager = mockk(relaxed = true)
+        errorReporter = mockk(relaxed = true)
+        appModeManager = AppModeManager(InMemoryKeyValueStore())
+        goalsRepo =
+            mockk(relaxed = true) {
+                every { goals() } returns MutableStateFlow(null)
+            }
+        prefsRepo =
+            mockk(relaxed = true) {
+                every { preferences() } returns MutableStateFlow(null)
+            }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() =
+        SettingsViewModel(authManager, goalsRepo, prefsRepo, api, healthSync, refreshManager, errorReporter, appModeManager)
+
+    @Test
+    fun modeFlowExposesAppModeManagerMode() =
+        runTest {
+            appModeManager.setMode(AppMode.LOCAL)
+
+            val viewModel = createViewModel()
+
+            assertEquals(AppMode.LOCAL, viewModel.mode.value)
+        }
+
+    @Test
+    fun loadDataFetchesMealTypesWhenSynced() =
+        runTest {
+            appModeManager.setMode(AppMode.SYNCED)
+
+            createViewModel()
+
+            coVerify(atLeast = 1) { api.getMealTypes() }
+        }
+
+    @Test
+    fun loadDataSkipsMealTypesInLocalMode() =
+        runTest {
+            appModeManager.setMode(AppMode.LOCAL)
+
+            createViewModel()
+
+            coVerify(exactly = 0) { api.getMealTypes() }
+        }
+
+    @Test
+    fun logoutClearsAuthAndMode() =
+        runTest {
+            appModeManager.setMode(AppMode.SYNCED)
+
+            val viewModel = createViewModel()
+            viewModel.logout()
+
+            verify(exactly = 1) { authManager.logout() }
+            assertNull(appModeManager.mode.value)
+        }
+}

--- a/mobile/iosApp/Bissbilanz/API/AuthManager.swift
+++ b/mobile/iosApp/Bissbilanz/API/AuthManager.swift
@@ -1,9 +1,9 @@
-import Foundation
 import AuthenticationServices
+import Foundation
 import Observation
 import Security
 
-enum AuthState: Sendable {
+enum AuthState {
     case unauthenticated
     case authenticated
     case refreshing
@@ -20,7 +20,9 @@ final class AuthManager {
     private static let accessTokenKey = "bissbilanz_access_token"
     private static let refreshTokenKey = "bissbilanz_refresh_token"
 
-    var isAuthenticated: Bool { authState == .authenticated }
+    var isAuthenticated: Bool {
+        authState == .authenticated
+    }
 
     init(baseURL: String = "https://bissbilanz.orellbuehler.ch") {
         self.baseURL = baseURL
@@ -44,7 +46,8 @@ final class AuthManager {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
               let state = components.queryItems?.first(where: { $0.name == "state" })?.value,
-              state == pendingState else {
+              state == pendingState
+        else {
             return false
         }
         pendingState = nil

--- a/mobile/iosApp/Bissbilanz/API/AuthManager.swift
+++ b/mobile/iosApp/Bissbilanz/API/AuthManager.swift
@@ -141,7 +141,7 @@ enum KeychainHelper {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
             kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
         SecItemAdd(attributes as CFDictionary, nil)
     }

--- a/mobile/iosApp/Bissbilanz/API/AuthManager.swift
+++ b/mobile/iosApp/Bissbilanz/API/AuthManager.swift
@@ -7,6 +7,10 @@ enum AuthState {
     case unauthenticated
     case authenticated
     case refreshing
+    /// Was signed in, but the server definitively rejected the refresh token.
+    /// The user keeps the app (all data is local) and is prompted to sign in
+    /// again — never kicked back to the login screen.
+    case expired
 }
 
 @MainActor
@@ -16,6 +20,10 @@ final class AuthManager {
 
     private let baseURL: String
     private var pendingState: String?
+    /// In-flight refresh, shared by concurrent callers. Refresh tokens rotate
+    /// on use, so two parallel refreshes would invalidate each other and kill
+    /// the session.
+    private var refreshTask: Task<Bool, Never>?
 
     private static let accessTokenKey = "bissbilanz_access_token"
     private static let refreshTokenKey = "bissbilanz_refresh_token"
@@ -77,15 +85,29 @@ final class AuthManager {
 
     @discardableResult
     func refreshAccessToken() async -> Bool {
+        if let task = refreshTask {
+            return await task.value
+        }
+        let task = Task { await performRefresh() }
+        refreshTask = task
+        let result = await task.value
+        refreshTask = nil
+        return result
+    }
+
+    /// Only an explicit rejection of the refresh token ends the session
+    /// (`.expired`). Transient failures — offline, 5xx, malformed response —
+    /// keep the user signed in; the next API call retries the refresh.
+    private func performRefresh() async -> Bool {
         guard let refreshToken = KeychainHelper.load(key: Self.refreshTokenKey) else {
-            authState = .unauthenticated
+            authState = accessToken != nil ? .expired : .unauthenticated
             return false
         }
 
         authState = .refreshing
 
         guard let tokenURL = URL(string: "\(baseURL)/api/auth/mobile/token") else {
-            authState = .unauthenticated
+            authState = .expired
             return false
         }
 
@@ -97,16 +119,32 @@ final class AuthManager {
         request.httpBody = try? JSONEncoder().encode(body)
 
         do {
-            let (data, _) = try await URLSession.shared.data(for: request)
-            let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
-            KeychainHelper.save(key: Self.accessTokenKey, value: tokenResponse.accessToken)
-            if let refresh = tokenResponse.refreshToken {
-                KeychainHelper.save(key: Self.refreshTokenKey, value: refresh)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                authState = .authenticated
+                return false
             }
-            authState = .authenticated
-            return true
+            switch http.statusCode {
+            case 200 ..< 300:
+                guard let tokenResponse = try? JSONDecoder().decode(TokenResponse.self, from: data) else {
+                    authState = .authenticated
+                    return false
+                }
+                KeychainHelper.save(key: Self.accessTokenKey, value: tokenResponse.accessToken)
+                if let refresh = tokenResponse.refreshToken {
+                    KeychainHelper.save(key: Self.refreshTokenKey, value: refresh)
+                }
+                authState = .authenticated
+                return true
+            case 400, 401, 403:
+                authState = .expired
+                return false
+            default:
+                authState = .authenticated
+                return false
+            }
         } catch {
-            authState = .unauthenticated
+            authState = .authenticated
             return false
         }
     }

--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -49,6 +49,11 @@ final class BissbilanzAPI {
         return response.foods
     }
 
+    func getFoods(limit: Int = 100) async throws -> [Food] {
+        let response: FoodsResponse = try await get("/api/foods", params: ["limit": "\(limit)"])
+        return response.foods
+    }
+
     func getRecentFoods(limit: Int = 20) async throws -> [Food] {
         let response: FoodsResponse = try await get("/api/foods/recent", params: ["limit": "\(limit)"])
         return response.foods

--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -11,12 +11,12 @@ enum APIError: Error, LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .unauthorized: return "Not authenticated"
-        case .notFound: return "Not found"
-        case .badRequest(let msg): return msg ?? "Bad request"
-        case .serverError(let code, let msg): return msg ?? "Server error (\(code))"
-        case .networkError(let err): return err.localizedDescription
-        case .decodingError(let err): return "Failed to parse response: \(err.localizedDescription)"
+        case .unauthorized: "Not authenticated"
+        case .notFound: "Not found"
+        case let .badRequest(msg): msg ?? "Bad request"
+        case let .serverError(code, msg): msg ?? "Server error (\(code))"
+        case let .networkError(err): err.localizedDescription
+        case let .decodingError(err): "Failed to parse response: \(err.localizedDescription)"
         }
     }
 }
@@ -30,12 +30,16 @@ final class BissbilanzAPI {
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
 
-    init(baseURL: String = "https://bissbilanz.orellbuehler.ch", authManager: AuthManager) {
+    init(
+        baseURL: String = "https://bissbilanz.orellbuehler.ch",
+        authManager: AuthManager,
+        session: URLSession = .shared
+    ) {
         self.baseURL = baseURL
         self.authManager = authManager
-        self.session = URLSession.shared
-        self.decoder = JSONDecoder()
-        self.encoder = JSONEncoder()
+        self.session = session
+        decoder = JSONDecoder()
+        encoder = JSONEncoder()
     }
 
     // MARK: - Foods
@@ -344,7 +348,7 @@ final class BissbilanzAPI {
         return try await performRequest(request)
     }
 
-    private func post<T: Decodable, B: Encodable>(_ path: String, body: B) async throws -> T {
+    private func post<T: Decodable>(_ path: String, body: some Encodable) async throws -> T {
         var request = URLRequest(url: URL(string: "\(baseURL)\(path)")!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -352,7 +356,7 @@ final class BissbilanzAPI {
         return try await performRequest(request)
     }
 
-    private func patch<T: Decodable, B: Encodable>(_ path: String, body: B) async throws -> T {
+    private func patch<T: Decodable>(_ path: String, body: some Encodable) async throws -> T {
         var request = URLRequest(url: URL(string: "\(baseURL)\(path)")!)
         request.httpMethod = "PATCH"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -408,7 +408,14 @@ final class BissbilanzAPI {
                 }
                 return try decoder.decode(T.self, from: retryData)
             }
-            throw APIError.unauthorized
+            // `unauthorized` means "session is dead, prompt to sign in" — a
+            // transient refresh failure (offline, 5xx) is just retryable.
+            switch authManager.authState {
+            case .expired, .unauthenticated:
+                throw APIError.unauthorized
+            case .authenticated, .refreshing:
+                throw APIError.networkError(URLError(.cannotConnectToHost))
+            }
         }
 
         if httpResponse.statusCode == 404 {

--- a/mobile/iosApp/Bissbilanz/API/OpenFoodFactsClient.swift
+++ b/mobile/iosApp/Bissbilanz/API/OpenFoodFactsClient.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Direct Open Food Facts v2 client used in Local mode, where there is no
+/// backend to proxy barcode lookups through. Replicates the field selection
+/// and mapping of the server proxy (`src/lib/server/openfoodfacts.ts`) and the
+/// Android shared `OpenFoodFactsClient`, returning the `Food` prefill shape
+/// the barcode scanner uses.
+struct OpenFoodFactsClient {
+    private let session: URLSession
+
+    private static let apiBase = "https://world.openfoodfacts.org/api/v2/product"
+    private static let userAgent = "Bissbilanz/1.0 (https://bissbilanz.orellbuehler.ch)"
+    private static let fields = [
+        "product_name", "brands", "nutriscore_grade", "nova_group",
+        "additives_tags", "ingredients_text", "image_front_url", "nutriments",
+    ].joined(separator: ",")
+
+    private static let gToMg = 1000.0
+    private static let gToUg = 1_000_000.0
+
+    /// (Food key, OFF nutriments key, unit conversion) for the optional
+    /// extended nutrients — mirrors the Android client's mapping.
+    private static let extendedNutrients: [(String, String, Double)] = [
+        ("saturatedFat", "saturated-fat_100g", 1), ("monounsaturatedFat", "monounsaturated-fat_100g", 1),
+        ("polyunsaturatedFat", "polyunsaturated-fat_100g", 1), ("transFat", "trans-fat_100g", 1),
+        ("cholesterol", "cholesterol_100g", gToMg), ("omega3", "omega-3-fat_100g", 1),
+        ("omega6", "omega-6-fat_100g", 1), ("sugar", "sugars_100g", 1),
+        ("addedSugars", "added-sugars_100g", 1), ("sugarAlcohols", "sugar-alcohols_100g", 1),
+        ("starch", "starch_100g", 1), ("sodium", "sodium_100g", gToMg),
+        ("potassium", "potassium_100g", gToMg), ("calcium", "calcium_100g", gToMg),
+        ("iron", "iron_100g", gToMg), ("magnesium", "magnesium_100g", gToMg),
+        ("phosphorus", "phosphorus_100g", gToMg), ("zinc", "zinc_100g", gToMg),
+        ("copper", "copper_100g", gToMg), ("manganese", "manganese_100g", gToMg),
+        ("selenium", "selenium_100g", gToUg), ("iodine", "iodine_100g", gToUg),
+        ("fluoride", "fluoride_100g", gToMg), ("chromium", "chromium_100g", gToUg),
+        ("molybdenum", "molybdenum_100g", gToUg), ("chloride", "chloride_100g", gToMg),
+        ("vitaminA", "vitamin-a_100g", gToUg), ("vitaminC", "vitamin-c_100g", gToMg),
+        ("vitaminD", "vitamin-d_100g", gToUg), ("vitaminE", "vitamin-e_100g", gToMg),
+        ("vitaminK", "vitamin-k_100g", gToUg), ("vitaminB1", "vitamin-b1_100g", gToMg),
+        ("vitaminB2", "vitamin-b2_100g", gToMg), ("vitaminB3", "vitamin-b3_100g", gToMg),
+        ("vitaminB5", "vitamin-b5_100g", gToMg), ("vitaminB6", "vitamin-b6_100g", gToMg),
+        ("vitaminB7", "vitamin-b7_100g", gToUg), ("vitaminB9", "vitamin-b9_100g", gToUg),
+        ("vitaminB12", "vitamin-b12_100g", gToUg), ("caffeine", "caffeine_100g", gToMg),
+        ("alcohol", "alcohol_100g", 1), ("water", "water_100g", 1), ("salt", "salt_100g", 1),
+    ]
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    /// Looks the barcode up on Open Food Facts. Returns nil for unknown
+    /// products or unparseable responses; throws on transport errors.
+    func lookupBarcode(_ barcode: String) async throws -> Food? {
+        var components = URLComponents(string: "\(Self.apiBase)/\(barcode).json")!
+        components.queryItems = [URLQueryItem(name: "fields", value: Self.fields)]
+        var request = URLRequest(url: components.url!)
+        request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
+            return nil
+        }
+        guard let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              Self.number(root["status"]) == 1,
+              let product = root["product"] as? [String: Any]
+        else {
+            return nil
+        }
+        return Self.mapProduct(product, barcode: barcode)
+    }
+
+    /// Maps an OFF product onto the `Food` prefill shape (per-100g values,
+    /// like the server proxy). Internal for tests.
+    static func mapProduct(_ product: [String: Any], barcode: String) -> Food? {
+        let nutriments = product["nutriments"] as? [String: Any] ?? [:]
+
+        var dict: [String: Any] = [
+            // The proxy has no separate id; the barcode identifies the product.
+            "id": barcode,
+            "userId": "",
+            "name": (product["product_name"] as? String) ?? "",
+            "servingSize": 100,
+            "servingUnit": "g",
+            "calories": number(nutriments["energy-kcal_100g"]) ?? 0,
+            "protein": number(nutriments["proteins_100g"]) ?? 0,
+            "carbs": number(nutriments["carbohydrates_100g"]) ?? 0,
+            "fat": number(nutriments["fat_100g"]) ?? 0,
+            "fiber": number(nutriments["fiber_100g"]) ?? 0,
+            "barcode": barcode,
+            "isFavorite": false,
+        ]
+        if let brand = product["brands"] as? String, !brand.isEmpty {
+            dict["brand"] = brand
+        }
+        if let grade = product["nutriscore_grade"] as? String,
+           ["a", "b", "c", "d", "e"].contains(grade)
+        {
+            dict["nutriScore"] = grade
+        }
+        if let novaGroup = number(product["nova_group"]), (1.0 ... 4.0).contains(novaGroup) {
+            dict["novaGroup"] = Int(novaGroup)
+        }
+        if let additives = product["additives_tags"] as? [String] {
+            dict["additives"] = additives
+        }
+        if let ingredientsText = product["ingredients_text"] as? String {
+            dict["ingredientsText"] = ingredientsText
+        }
+        if let imageUrl = product["image_front_url"] as? String {
+            dict["imageUrl"] = imageUrl
+        }
+        for (foodKey, offKey, conversion) in extendedNutrients {
+            if let value = extractNutrient(nutriments[offKey], conversion: conversion) {
+                dict[foodKey] = value
+            }
+        }
+        return try? JSONPatch.decode(Food.self, from: dict)
+    }
+
+    /// Mirrors the proxy's `extractNutrient`: optional unit conversion and
+    /// rounding to 2 decimal places, nil when missing or not numeric.
+    private static func extractNutrient(_ value: Any?, conversion: Double) -> Double? {
+        guard let raw = number(value) else { return nil }
+        return (raw * conversion * 100).rounded() / 100
+    }
+
+    /// OFF nutriment values may be numbers or numeric strings.
+    private static func number(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue.isNaN ? nil : number.doubleValue
+        }
+        if let string = value as? String {
+            return Double(string)
+        }
+        return nil
+    }
+}

--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -1,14 +1,48 @@
+import SwiftData
 import SwiftUI
 
 @main
 struct BissbilanzApp: App {
     @State private var authManager: AuthManager
     @State private var api: BissbilanzAPI
+    @State private var entryRepository: EntryRepository
+    @State private var foodRepository: FoodRepository
+    @State private var recipeRepository: RecipeRepository
+    @State private var weightRepository: WeightRepository
+    @State private var supplementRepository: SupplementRepository
+    @State private var goalsRepository: GoalsRepository
+    @State private var preferencesRepository: PreferencesRepository
+    private let modelContainer: ModelContainer
 
     init() {
         let auth = AuthManager()
+        let api = BissbilanzAPI(authManager: auth)
+
+        let container: ModelContainer
+        do {
+            container = try LocalStore.makeContainer()
+        } catch {
+            // The on-disk store is unusable (e.g. failed migration). Fall back
+            // to an in-memory store rather than crashing — data refreshes from
+            // the API while the app is online.
+            do {
+                container = try LocalStore.makeContainer(inMemory: true)
+            } catch {
+                fatalError("Failed to create SwiftData container: \(error)")
+            }
+        }
+        modelContainer = container
+        let context = container.mainContext
+
         _authManager = State(wrappedValue: auth)
-        _api = State(wrappedValue: BissbilanzAPI(authManager: auth))
+        _api = State(wrappedValue: api)
+        _entryRepository = State(wrappedValue: EntryRepository(context: context, api: api))
+        _foodRepository = State(wrappedValue: FoodRepository(context: context, api: api))
+        _recipeRepository = State(wrappedValue: RecipeRepository(context: context, api: api))
+        _weightRepository = State(wrappedValue: WeightRepository(context: context, api: api))
+        _supplementRepository = State(wrappedValue: SupplementRepository(context: context, api: api))
+        _goalsRepository = State(wrappedValue: GoalsRepository(context: context, api: api))
+        _preferencesRepository = State(wrappedValue: PreferencesRepository(context: context, api: api))
     }
 
     var body: some Scene {
@@ -22,6 +56,14 @@ struct BissbilanzApp: App {
             }
             .environment(authManager)
             .environment(api)
+            .environment(entryRepository)
+            .environment(foodRepository)
+            .environment(recipeRepository)
+            .environment(weightRepository)
+            .environment(supplementRepository)
+            .environment(goalsRepository)
+            .environment(preferencesRepository)
+            .modelContainer(modelContainer)
             .onOpenURL { url in
                 Task {
                     await authManager.handleCallback(url: url)

--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -14,14 +14,18 @@ enum RootDestination {
 /// - Local mode is fully anonymous, so an unauthenticated user still sees the app.
 /// - A successful login while in Local mode means the local data must be
 ///   migrated to the account first, so the migration screen is shown.
-/// - A `nil` mode means "not chosen yet" and is treated as sync-allowed
-///   (existing installs and fresh logins).
+/// - The login screen only shows when no mode was chosen yet — a fresh install
+///   or after an explicit sign-out (which clears the mode). A Synced user whose
+///   session dies stays in the app (all data is local) and is prompted to sign
+///   in again from there.
 func resolveRootDestination(authState: AuthState, mode: AppMode?) -> RootDestination {
     switch authState {
     case .authenticated, .refreshing:
         mode == .local ? .migration : .app
+    case .expired:
+        .app
     case .unauthenticated:
-        mode == .local ? .app : .login
+        mode == nil ? .login : .app
     }
 }
 
@@ -135,8 +139,12 @@ struct BissbilanzApp: App {
             }
             // Existing installs and fresh logins that never chose a mode
             // default to Synced (mirrors the Android root).
-            .onChange(of: authManager.authState, initial: true) { _, _ in
+            .onChange(of: authManager.authState, initial: true) { _, state in
                 defaultModeToSyncedIfNeeded()
+                // Upload anything queued while the session was expired.
+                if state == .authenticated {
+                    syncManager.scheduleDrain()
+                }
             }
             .onChange(of: appModeManager.mode) { _, _ in
                 defaultModeToSyncedIfNeeded()

--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -1,10 +1,39 @@
 import SwiftData
 import SwiftUI
 
+/// Top-level destination shown at the app root, resolved from auth state and app mode.
+enum RootDestination {
+    case login
+    case app
+    case migration
+}
+
+/// Pure routing decision: which root destination to show for the given
+/// `authState` and `mode`.
+///
+/// - Local mode is fully anonymous, so an unauthenticated user still sees the app.
+/// - A successful login while in Local mode means the local data must be
+///   migrated to the account first, so the migration screen is shown.
+/// - A `nil` mode means "not chosen yet" and is treated as sync-allowed
+///   (existing installs and fresh logins).
+func resolveRootDestination(authState: AuthState, mode: AppMode?) -> RootDestination {
+    switch authState {
+    case .authenticated, .refreshing:
+        mode == .local ? .migration : .app
+    case .unauthenticated:
+        mode == .local ? .app : .login
+    }
+}
+
 @main
 struct BissbilanzApp: App {
+    @Environment(\.scenePhase) private var scenePhase
     @State private var authManager: AuthManager
     @State private var api: BissbilanzAPI
+    @State private var appModeManager: AppModeManager
+    @State private var connectivityMonitor: ConnectivityMonitor
+    @State private var syncManager: SyncManager
+    @State private var migrator: LocalDataMigrator
     @State private var entryRepository: EntryRepository
     @State private var foodRepository: FoodRepository
     @State private var recipeRepository: RecipeRepository
@@ -17,6 +46,9 @@ struct BissbilanzApp: App {
     init() {
         let auth = AuthManager()
         let api = BissbilanzAPI(authManager: auth)
+        let appMode = AppModeManager()
+        let connectivity = ConnectivityMonitor()
+        connectivity.start()
 
         let container: ModelContainer
         do {
@@ -34,28 +66,60 @@ struct BissbilanzApp: App {
         modelContainer = container
         let context = container.mainContext
 
+        let sync = SyncManager(context: context, api: api, appMode: appMode, connectivity: connectivity)
+
         _authManager = State(wrappedValue: auth)
         _api = State(wrappedValue: api)
-        _entryRepository = State(wrappedValue: EntryRepository(context: context, api: api))
-        _foodRepository = State(wrappedValue: FoodRepository(context: context, api: api))
-        _recipeRepository = State(wrappedValue: RecipeRepository(context: context, api: api))
-        _weightRepository = State(wrappedValue: WeightRepository(context: context, api: api))
-        _supplementRepository = State(wrappedValue: SupplementRepository(context: context, api: api))
-        _goalsRepository = State(wrappedValue: GoalsRepository(context: context, api: api))
-        _preferencesRepository = State(wrappedValue: PreferencesRepository(context: context, api: api))
+        _appModeManager = State(wrappedValue: appMode)
+        _connectivityMonitor = State(wrappedValue: connectivity)
+        _syncManager = State(wrappedValue: sync)
+        _migrator = State(wrappedValue: LocalDataMigrator(
+            context: context,
+            api: api,
+            appMode: appMode,
+            syncManager: sync
+        ))
+        _entryRepository = State(wrappedValue: EntryRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
+        _foodRepository = State(wrappedValue: FoodRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
+        _recipeRepository = State(wrappedValue: RecipeRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
+        _weightRepository = State(wrappedValue: WeightRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
+        _supplementRepository = State(wrappedValue: SupplementRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
+        _goalsRepository = State(wrappedValue: GoalsRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
+        _preferencesRepository = State(wrappedValue: PreferencesRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
     }
 
     var body: some Scene {
         WindowGroup {
             Group {
-                if authManager.isAuthenticated {
-                    ContentView()
-                } else {
+                switch resolveRootDestination(authState: authManager.authState, mode: appModeManager.mode) {
+                case .login:
                     LoginView()
+                case .app:
+                    ContentView()
+                case .migration:
+                    MigrationView()
                 }
             }
             .environment(authManager)
             .environment(api)
+            .environment(appModeManager)
+            .environment(connectivityMonitor)
+            .environment(syncManager)
+            .environment(migrator)
             .environment(entryRepository)
             .environment(foodRepository)
             .environment(recipeRepository)
@@ -69,6 +133,26 @@ struct BissbilanzApp: App {
                     await authManager.handleCallback(url: url)
                 }
             }
+            // Existing installs and fresh logins that never chose a mode
+            // default to Synced (mirrors the Android root).
+            .onChange(of: authManager.authState, initial: true) { _, _ in
+                defaultModeToSyncedIfNeeded()
+            }
+            .onChange(of: appModeManager.mode) { _, _ in
+                defaultModeToSyncedIfNeeded()
+            }
+            .onChange(of: scenePhase) { _, phase in
+                if phase == .active {
+                    syncManager.scheduleDrain()
+                }
+            }
+        }
+    }
+
+    private func defaultModeToSyncedIfNeeded() {
+        let authState = authManager.authState
+        if authState == .authenticated || authState == .refreshing, appModeManager.mode == nil {
+            appModeManager.setMode(.synced)
         }
     }
 }

--- a/mobile/iosApp/Bissbilanz/Components/MacroColors.swift
+++ b/mobile/iosApp/Bissbilanz/Components/MacroColors.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 enum MacroColors {
-    static let calories = Color(red: 0.231, green: 0.510, blue: 0.965)  // #3B82F6
-    static let protein = Color(red: 0.937, green: 0.267, blue: 0.267)   // #EF4444
-    static let carbs = Color(red: 0.976, green: 0.451, blue: 0.086)     // #F97316
-    static let fat = Color(red: 0.918, green: 0.702, blue: 0.031)       // #EAB308
-    static let fiber = Color(red: 0.133, green: 0.773, blue: 0.369)     // #22C55E
+    static let calories = Color(red: 0.231, green: 0.510, blue: 0.965) // #3B82F6
+    static let protein = Color(red: 0.937, green: 0.267, blue: 0.267) // #EF4444
+    static let carbs = Color(red: 0.976, green: 0.451, blue: 0.086) // #F97316
+    static let fat = Color(red: 0.918, green: 0.702, blue: 0.031) // #EAB308
+    static let fiber = Color(red: 0.133, green: 0.773, blue: 0.369) // #22C55E
 }

--- a/mobile/iosApp/Bissbilanz/Components/MealCard.swift
+++ b/mobile/iosApp/Bissbilanz/Components/MealCard.swift
@@ -11,11 +11,11 @@ struct MealCard: View {
 
     private var mealColor: Color {
         switch mealType.lowercased() {
-        case "breakfast": return .orange
-        case "lunch": return .blue
-        case "dinner": return .purple
-        case "snacks", "snack": return .green
-        default: return .gray
+        case "breakfast": .orange
+        case "lunch": .blue
+        case "dinner": .purple
+        case "snacks", "snack": .green
+        default: .gray
         }
     }
 
@@ -57,11 +57,11 @@ struct MealCard: View {
 
     private var mealIcon: String {
         switch mealType.lowercased() {
-        case "breakfast": return "sunrise"
-        case "lunch": return "sun.max"
-        case "dinner": return "moon.stars"
-        case "snacks", "snack": return "carrot"
-        default: return "fork.knife"
+        case "breakfast": "sunrise"
+        case "lunch": "sun.max"
+        case "dinner": "moon.stars"
+        case "snacks", "snack": "carrot"
+        default: "fork.knife"
         }
     }
 }

--- a/mobile/iosApp/Bissbilanz/Components/NutrientRow.swift
+++ b/mobile/iosApp/Bissbilanz/Components/NutrientRow.swift
@@ -18,7 +18,7 @@ struct NutrientRow: View {
     }
 
     private var formattedValue: String {
-        if value == value.rounded() && value < 10000 {
+        if value == value.rounded(), value < 10000 {
             return "\(Int(value))"
         }
         return String(format: "%.1f", value)

--- a/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
+++ b/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
@@ -1,0 +1,470 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// What would be uploaded by `LocalDataMigrator.migrate`, counted from the local store.
+struct MigrationPlan {
+    let foods: Int
+    let recipes: Int
+    let entries: Int
+    let weights: Int
+    let supplements: Int
+    let supplementLogs: Int
+    let dayProperties: Int
+    let hasGoals: Bool
+    let hasPreferences: Bool
+
+    var total: Int {
+        foods + recipes + entries + weights + supplements + supplementLogs
+            + dayProperties + (hasGoals ? 1 : 0) + (hasPreferences ? 1 : 0)
+    }
+}
+
+enum MigrationStep: String {
+    case prepare
+    case foods
+    case recipes
+    case entries
+    case weights
+    case supplements
+    case supplementLogs = "supplement_logs"
+    case goals
+    case preferences
+    case dayProperties = "day_properties"
+}
+
+enum MigrationState: Equatable {
+    case idle
+    case running(done: Int, total: Int, step: MigrationStep)
+    case completed
+    case failed(String)
+}
+
+/// One-shot upload of the local (anonymous) store to a freshly logged-in
+/// account, mirroring the Android `LocalDataMigrator`.
+///
+/// Algorithm:
+/// 1. Defensively clear the sync queue (it must already be empty in Local mode;
+///    queued ops would double-apply what this migrator uploads from the store).
+/// 2. Normalize: every local row whose id does NOT start with `temp_` is
+///    re-keyed to a fresh `temp_` UUID (stale leftovers from an earlier synced
+///    session — logout does not wipe the store). References are rewritten with
+///    the row via `LocalRemap`. After this pass "`temp_` prefix == not yet
+///    uploaded" holds, which makes a failed run resumable. Normalization runs
+///    once per migration cycle — a UserDefaults marker skips it on retries so
+///    rows that already received server ids from a partial run are not
+///    re-keyed (and re-uploaded) again. The marker is cleared on success and
+///    by `discardLocalData`.
+/// 3. Upload in dependency order — foods, recipes, entries, weights,
+///    supplements, supplement logs, goals, preferences, day properties. After
+///    every successful create the local row is immediately replaced with the
+///    server record and all local references re-keyed, so recipe/supplement
+///    ingredients and entry references point at server ids by the time their
+///    owning row uploads. Dangling references (food deleted locally) still
+///    carry a `temp_` id at upload time: entries fall back to a quick entry
+///    built from the cached display values, ingredients are dropped.
+/// 4. Only after everything succeeded the mode flips to `.synced`.
+/// 5. Any failure aborts the run (`.failed`) with all partial progress
+///    preserved locally — calling `migrate` again resumes by uploading only
+///    the remaining `temp_` rows. Goals, preferences and day properties have
+///    no ids; they are idempotent set-calls and simply re-run.
+@MainActor
+@Observable
+final class LocalDataMigrator {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
+    private let defaults: UserDefaults
+
+    private(set) var state: MigrationState = .idle
+
+    @ObservationIgnored private var isMigrating = false
+
+    private static let normalizedMarkerKey = "migration_normalized"
+
+    init(
+        context: ModelContext,
+        api: BissbilanzAPI,
+        appMode: AppModeManager,
+        syncManager: SyncManager,
+        defaults: UserDefaults = .standard
+    ) {
+        self.context = context
+        self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
+        self.defaults = defaults
+    }
+
+    // MARK: - Plan / preflight
+
+    /// Counts the local rows that `migrate` would upload.
+    func plan() -> MigrationPlan {
+        MigrationPlan(
+            foods: count(LocalFood.self),
+            recipes: count(LocalRecipe.self),
+            entries: count(LocalEntry.self),
+            weights: count(LocalWeightEntry.self),
+            supplements: count(LocalSupplement.self),
+            supplementLogs: count(LocalSupplementLog.self),
+            dayProperties: count(LocalDayProperties.self),
+            hasGoals: count(LocalGoals.self) > 0,
+            hasPreferences: count(LocalPreferences.self) > 0
+        )
+    }
+
+    /// True when the account already has foods or logged entries (cheap API checks).
+    func serverHasData() async throws -> Bool {
+        if try await !api.getFoods(limit: 1).isEmpty {
+            return true
+        }
+        return try await !api.getRecentFoods(limit: 1).isEmpty
+    }
+
+    // MARK: - Migration
+
+    /// Uploads the local store to the account. Safe to call again after a failure.
+    func migrate() async {
+        guard !isMigrating else { return }
+        isMigrating = true
+        defer { isMigrating = false }
+
+        let total = plan().total
+        do {
+            state = .running(done: 0, total: total, step: .prepare)
+            syncManager.clearQueue()
+            normalizeOnce()
+            var done = uploadedCount()
+            done = try await uploadFoods(done: done, total: total)
+            done = try await uploadRecipes(done: done, total: total)
+            done = try await uploadEntries(done: done, total: total)
+            done = try await uploadWeights(done: done, total: total)
+            done = try await uploadSupplements(done: done, total: total)
+            done = try await uploadSupplementLogs(done: done, total: total)
+            done = try await uploadGoals(done: done, total: total)
+            done = try await uploadPreferences(done: done, total: total)
+            _ = try await uploadDayProperties(done: done, total: total)
+            defaults.removeObject(forKey: Self.normalizedMarkerKey)
+            appMode.setMode(.synced)
+            state = .completed
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Wipes all local user data and the sync queue (the user chose "start
+    /// fresh"), then flips the mode to `.synced`.
+    func discardLocalData() {
+        syncManager.clearQueue()
+        try? context.delete(model: LocalEntry.self)
+        try? context.delete(model: LocalFood.self)
+        try? context.delete(model: LocalRecipe.self)
+        try? context.delete(model: LocalWeightEntry.self)
+        try? context.delete(model: LocalSupplement.self)
+        try? context.delete(model: LocalSupplementLog.self)
+        try? context.delete(model: LocalGoals.self)
+        try? context.delete(model: LocalPreferences.self)
+        try? context.delete(model: LocalDayProperties.self)
+        try? context.save()
+        defaults.removeObject(forKey: Self.normalizedMarkerKey)
+        appMode.setMode(.synced)
+    }
+
+    // MARK: - Normalization
+
+    /// Re-keys every non-`temp_` row to a fresh temp id (with reference
+    /// rewriting) so the temp prefix reliably means "not uploaded yet".
+    private func normalizeOnce() {
+        guard !defaults.bool(forKey: Self.normalizedMarkerKey) else { return }
+
+        for row in fetchAll(LocalFood.self) where !LocalStore.isTempId(row.id) {
+            let newId = LocalStore.makeTempId()
+            if let food = row.toFood(),
+               let patched = try? JSONPatch.merged(Food.self, base: food, patch: ["id": newId])
+            {
+                LocalRemap.replaceFood(id: row.id, with: patched, in: context)
+            }
+        }
+        for row in fetchAll(LocalRecipe.self) where !LocalStore.isTempId(row.id) {
+            let newId = LocalStore.makeTempId()
+            if let recipe = row.toRecipe(),
+               let patched = try? JSONPatch.merged(Recipe.self, base: recipe, patch: ["id": newId])
+            {
+                LocalRemap.replaceRecipe(id: row.id, with: patched, in: context)
+            }
+        }
+        for row in fetchAll(LocalSupplement.self) where !LocalStore.isTempId(row.id) {
+            let newId = LocalStore.makeTempId()
+            if let supplement = row.toSupplement(),
+               let patched = try? JSONPatch.merged(Supplement.self, base: supplement, patch: ["id": newId])
+            {
+                LocalRemap.replaceSupplement(id: row.id, with: patched, rekeyLogIds: true, in: context)
+            }
+        }
+        for row in fetchAll(LocalEntry.self) where !LocalStore.isTempId(row.id) {
+            let newId = LocalStore.makeTempId()
+            if let entry = row.toEntry(),
+               let patched = try? JSONPatch.merged(Entry.self, base: entry, patch: ["id": newId])
+            {
+                LocalRemap.replaceEntry(id: row.id, with: patched, date: row.date, in: context)
+            }
+        }
+        for row in fetchAll(LocalWeightEntry.self) where !LocalStore.isTempId(row.id) {
+            let newId = LocalStore.makeTempId()
+            if let entry = row.toWeightEntry(),
+               let patched = try? JSONPatch.merged(WeightEntry.self, base: entry, patch: ["id": newId])
+            {
+                LocalRemap.replaceWeight(id: row.id, with: patched, in: context)
+            }
+        }
+        try? context.save()
+        defaults.set(true, forKey: Self.normalizedMarkerKey)
+    }
+
+    /// Items already carrying server ids from a previous partial run.
+    private func uploadedCount() -> Int {
+        fetchAll(LocalFood.self).count { !LocalStore.isTempId($0.id) }
+            + fetchAll(LocalRecipe.self).count { !LocalStore.isTempId($0.id) }
+            + fetchAll(LocalEntry.self).count { !LocalStore.isTempId($0.id) }
+            + fetchAll(LocalWeightEntry.self).count { !LocalStore.isTempId($0.id) }
+            + fetchAll(LocalSupplement.self).count { !LocalStore.isTempId($0.id) }
+            + fetchAll(LocalSupplementLog.self).count { !LocalStore.isTempId($0.id) }
+    }
+
+    // MARK: - Upload steps
+
+    private func progress(_ done: Int, _ total: Int, _ step: MigrationStep) {
+        state = .running(done: done, total: total, step: step)
+    }
+
+    private func uploadFoods(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .foods)
+        for row in fetchAll(LocalFood.self) where LocalStore.isTempId(row.id) {
+            guard let food = row.toFood(),
+                  let create = try? JSONPatch.decode(FoodCreate.self, from: JSONPatch.dictionary(of: food))
+            else {
+                throw MigrationError.unreadableRow("food \"\(row.name)\"")
+            }
+            let server = try await api.createFood(create)
+            LocalRemap.replaceFood(id: row.id, with: server, in: context)
+            done += 1
+            progress(done, total, .foods)
+        }
+        return done
+    }
+
+    private func uploadRecipes(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .recipes)
+        for row in fetchAll(LocalRecipe.self) where LocalStore.isTempId(row.id) {
+            guard let recipe = row.toRecipe() else {
+                throw MigrationError.unreadableRow("recipe \"\(row.name)\"")
+            }
+            let create = RecipeCreate(
+                name: recipe.name,
+                totalServings: recipe.totalServings,
+                ingredients: (recipe.ingredients ?? [])
+                    // Dangling food references (food deleted locally) are dropped.
+                    .filter { !LocalStore.isTempId($0.foodId) }
+                    .map { RecipeIngredientInput(foodId: $0.foodId, quantity: $0.quantity, servingUnit: $0.servingUnit)
+                    },
+                isFavorite: recipe.isFavorite,
+                imageUrl: recipe.imageUrl
+            )
+            let server = try await api.createRecipe(create)
+            LocalRemap.replaceRecipe(id: row.id, with: server, in: context)
+            done += 1
+            progress(done, total, .recipes)
+        }
+        return done
+    }
+
+    private func uploadEntries(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .entries)
+        for row in fetchAll(LocalEntry.self) where LocalStore.isTempId(row.id) {
+            guard let entry = row.toEntry() else {
+                throw MigrationError.unreadableRow("entry from \(row.date)")
+            }
+            let server = try await api.createEntry(Self.entryCreate(from: entry, date: row.date))
+            let merged = EntryRepository.merge(server: server, local: entry)
+            LocalRemap.replaceEntry(id: row.id, with: merged, date: row.date, in: context)
+            done += 1
+            progress(done, total, .entries)
+        }
+        return done
+    }
+
+    private func uploadWeights(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .weights)
+        for row in fetchAll(LocalWeightEntry.self) where LocalStore.isTempId(row.id) {
+            guard let entry = row.toWeightEntry() else {
+                throw MigrationError.unreadableRow("weight entry from \(row.entryDate)")
+            }
+            let server = try await api.createWeightEntry(
+                WeightCreate(weightKg: entry.weightKg, entryDate: entry.entryDate, notes: entry.notes)
+            )
+            LocalRemap.replaceWeight(id: row.id, with: server, in: context)
+            done += 1
+            progress(done, total, .weights)
+        }
+        return done
+    }
+
+    private func uploadSupplements(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .supplements)
+        for row in fetchAll(LocalSupplement.self) where LocalStore.isTempId(row.id) {
+            guard let supplement = row.toSupplement() else {
+                throw MigrationError.unreadableRow("supplement \"\(row.name)\"")
+            }
+            let create = SupplementCreate(
+                name: supplement.name,
+                scheduleType: supplement.scheduleType,
+                scheduleDays: supplement.scheduleDays,
+                scheduleStartDate: supplement.scheduleStartDate,
+                isActive: supplement.isActive,
+                sortOrder: supplement.sortOrder,
+                timeOfDay: supplement.timeOfDay,
+                ingredients: supplement.ingredients
+                    // Dangling food references (food deleted locally) are dropped.
+                    .filter { !LocalStore.isTempId($0.foodId) }
+                    .map { SupplementIngredientInput(foodId: $0.foodId, servings: $0.servings, sortOrder: $0.sortOrder)
+                    }
+            )
+            let server = try await api.createSupplement(create)
+            LocalRemap.replaceSupplement(id: row.id, with: server, rekeyLogIds: false, in: context)
+            done += 1
+            progress(done, total, .supplements)
+        }
+        return done
+    }
+
+    private func uploadSupplementLogs(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .supplementLogs)
+        for row in fetchAll(LocalSupplementLog.self) where LocalStore.isTempId(row.id) {
+            if LocalStore.isTempId(row.supplementId) {
+                // Orphan log (supplement deleted locally) — nothing to log it against.
+                context.delete(row)
+                try? context.save()
+                done += 1
+                progress(done, total, .supplementLogs)
+                continue
+            }
+            _ = try await api.logSupplement(id: row.supplementId, date: row.date)
+            let uploaded = LocalSupplementLog(supplementId: row.supplementId, date: row.date, takenAt: row.takenAt)
+            context.delete(row)
+            context.insert(uploaded)
+            try? context.save()
+            done += 1
+            progress(done, total, .supplementLogs)
+        }
+        return done
+    }
+
+    private func uploadGoals(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        guard let goals = fetchAll(LocalGoals.self).first?.toGoals() else { return done }
+        progress(done, total, .goals)
+        _ = try await api.setGoals(goals)
+        done += 1
+        progress(done, total, .goals)
+        return done
+    }
+
+    private func uploadPreferences(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        guard let preferences = fetchAll(LocalPreferences.self).first?.toPreferences() else { return done }
+        progress(done, total, .preferences)
+        _ = try await api.updatePreferences(Self.preferencesUpdate(from: preferences))
+        done += 1
+        progress(done, total, .preferences)
+        return done
+    }
+
+    private func uploadDayProperties(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .dayProperties)
+        for row in fetchAll(LocalDayProperties.self) {
+            let server = try await api.setDayProperties(date: row.date, isFastingDay: row.isFastingDay)
+            row.update(from: server)
+            try? context.save()
+            done += 1
+            progress(done, total, .dayProperties)
+        }
+        return done
+    }
+
+    // MARK: - Model mapping
+
+    /// copyEntries-style mapping. Food/recipe references that are still
+    /// unresolved (`temp_` id) fall back to a quick entry built from the
+    /// cached display values so the log line survives the migration.
+    static func entryCreate(from entry: Entry, date: String) -> EntryCreate {
+        let resolvedFoodId = entry.foodId.flatMap { LocalStore.isTempId($0) ? nil : $0 }
+        let resolvedRecipeId = entry.recipeId.flatMap { LocalStore.isTempId($0) ? nil : $0 }
+        let orphan = (entry.foodId != nil && resolvedFoodId == nil)
+            || (entry.recipeId != nil && resolvedRecipeId == nil)
+        return EntryCreate(
+            foodId: resolvedFoodId,
+            recipeId: resolvedRecipeId,
+            mealType: entry.mealType,
+            servings: entry.servings,
+            date: entry.date ?? date,
+            notes: entry.notes,
+            quickName: entry.quickName ?? (orphan ? entry.foodName : nil),
+            quickCalories: entry.quickCalories ?? (orphan ? entry.calories : nil),
+            quickProtein: entry.quickProtein ?? (orphan ? entry.protein : nil),
+            quickCarbs: entry.quickCarbs ?? (orphan ? entry.carbs : nil),
+            quickFat: entry.quickFat ?? (orphan ? entry.fat : nil),
+            quickFiber: entry.quickFiber ?? (orphan ? entry.fiber : nil),
+            eatenAt: entry.eatenAt
+        )
+    }
+
+    /// Empty lists are sent as `nil` (server default wins) because the local
+    /// default state is indistinguishable from "user cleared everything".
+    static func preferencesUpdate(from preferences: Preferences) -> PreferencesUpdate {
+        var update = PreferencesUpdate()
+        update.showChartWidget = preferences.showChartWidget
+        update.showFavoritesWidget = preferences.showFavoritesWidget
+        update.showSupplementsWidget = preferences.showSupplementsWidget
+        update.showWeightWidget = preferences.showWeightWidget
+        update.showMealBreakdownWidget = preferences.showMealBreakdownWidget
+        update.showTopFoodsWidget = preferences.showTopFoodsWidget
+        update.showSummaryWidget = preferences.showSummaryWidget
+        update.showDayLogWidget = preferences.showDayLogWidget
+        update.showStreakWidget = preferences.showStreakWidget
+        update.widgetOrder = preferences.widgetOrder.isEmpty ? nil : preferences.widgetOrder
+        update.startPage = preferences.startPage
+        update.favoriteTapAction = preferences.favoriteTapAction
+        update.favoriteMealAssignmentMode = preferences.favoriteMealAssignmentMode
+        update.visibleNutrients = preferences.visibleNutrients.isEmpty ? nil : preferences.visibleNutrients
+        update.locale = preferences.locale
+        return update
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchAll<T: PersistentModel>(_ type: T.Type) -> [T] {
+        (try? context.fetch(FetchDescriptor<T>())) ?? []
+    }
+
+    private func count<T: PersistentModel>(_ type: T.Type) -> Int {
+        (try? context.fetchCount(FetchDescriptor<T>())) ?? 0
+    }
+}
+
+enum MigrationError: LocalizedError {
+    case unreadableRow(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unreadableRow(what): "Could not read local \(what)"
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
+++ b/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
@@ -156,6 +156,16 @@ final class LocalDataMigrator {
     /// Wipes all local user data and the sync queue (the user chose "start
     /// fresh"), then flips the mode to `.synced`.
     func discardLocalData() {
+        wipeLocalData()
+        appMode.setMode(.synced)
+    }
+
+    /// Wipes every local user-data model, the pending sync queue and the
+    /// normalization marker — without touching tokens or the app mode. Used
+    /// by `discardLocalData` and by the Settings sign-out (the local store
+    /// belongs to the signed-out account and must not leak into the next
+    /// session).
+    func wipeLocalData() {
         syncManager.clearQueue()
         try? context.delete(model: LocalEntry.self)
         try? context.delete(model: LocalFood.self)
@@ -168,7 +178,16 @@ final class LocalDataMigrator {
         try? context.delete(model: LocalDayProperties.self)
         try? context.save()
         defaults.removeObject(forKey: Self.normalizedMarkerKey)
-        appMode.setMode(.synced)
+    }
+
+    /// The user abandoned a (possibly partially run) migration and stays in
+    /// Local mode with their data. Clears the normalization marker: rows that
+    /// already received server ids from the abandoned run must be re-keyed
+    /// (and re-uploaded) when a later sign-in — possibly into a different
+    /// account — migrates again, instead of being mistaken for uploaded.
+    func abandonMigration() {
+        defaults.removeObject(forKey: Self.normalizedMarkerKey)
+        state = .idle
     }
 
     // MARK: - Normalization
@@ -329,11 +348,35 @@ final class LocalDataMigrator {
                 isActive: supplement.isActive,
                 sortOrder: supplement.sortOrder,
                 timeOfDay: supplement.timeOfDay,
-                ingredients: supplement.ingredients
-                    // Dangling food references (food deleted locally) are dropped.
-                    .filter { !LocalStore.isTempId($0.foodId) }
-                    .map { SupplementIngredientInput(foodId: $0.foodId, servings: $0.servings, sortOrder: $0.sortOrder)
+                ingredients: supplement.ingredients.map { ingredient in
+                    if LocalStore.isTempId(ingredient.foodId) {
+                        // Local-only backing food (the Local-mode supplement
+                        // editor materializes inline inputs with synthetic
+                        // temp ids) — upload it inline, like the editor would.
+                        SupplementIngredientInput(
+                            foodId: nil,
+                            food: SupplementBackingFoodInput(
+                                name: ingredient.food.name,
+                                servingSize: ingredient.food.servingSize,
+                                servingUnit: ingredient.food.servingUnit,
+                                calories: ingredient.food.calories,
+                                protein: ingredient.food.protein,
+                                carbs: ingredient.food.carbs,
+                                fat: ingredient.food.fat,
+                                fiber: ingredient.food.fiber,
+                                ingredientsText: ingredient.food.ingredientsText
+                            ),
+                            servings: ingredient.servings,
+                            sortOrder: ingredient.sortOrder
+                        )
+                    } else {
+                        SupplementIngredientInput(
+                            foodId: ingredient.foodId,
+                            servings: ingredient.servings,
+                            sortOrder: ingredient.sortOrder
+                        )
                     }
+                }
             )
             let server = try await api.createSupplement(create)
             LocalRemap.replaceSupplement(id: row.id, with: server, rekeyLogIds: false, in: context)

--- a/mobile/iosApp/Bissbilanz/Models/ServingUnit.swift
+++ b/mobile/iosApp/Bissbilanz/Models/ServingUnit.swift
@@ -14,16 +14,16 @@ enum ServingUnit: String, Codable, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .g: return "g"
-        case .kg: return "kg"
-        case .ml: return "ml"
-        case .l: return "L"
-        case .oz: return "oz"
-        case .lb: return "lb"
-        case .flOz: return "fl oz"
-        case .cup: return "cup"
-        case .tbsp: return "tbsp"
-        case .tsp: return "tsp"
+        case .g: "g"
+        case .kg: "kg"
+        case .ml: "ml"
+        case .l: "L"
+        case .oz: "oz"
+        case .lb: "lb"
+        case .flOz: "fl oz"
+        case .cup: "cup"
+        case .tbsp: "tbsp"
+        case .tsp: "tsp"
         }
     }
 }

--- a/mobile/iosApp/Bissbilanz/Models/Stats.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Stats.swift
@@ -57,7 +57,9 @@ struct TopFoodEntry: Codable, Identifiable {
     let fat: Double
     let fiber: Double
 
-    var id: String { foodId ?? recipeId ?? foodName }
+    var id: String {
+        foodId ?? recipeId ?? foodName
+    }
 }
 
 struct TopFoodsResponse: Codable {
@@ -106,11 +108,13 @@ struct SupplementHistoryItem: Codable, Identifiable {
     let date: String
     let takenAt: String
 
-    // Synthetic id so SwiftUI can diff: one entry per (supplement, day).
-    var id: String { "\(supplementId)-\(date)" }
+    /// Synthetic id so SwiftUI can diff: one entry per (supplement, day).
+    var id: String {
+        "\(supplementId)-\(date)"
+    }
 }
 
-// Alias retained for existing call sites that read `.history` as a list of "entries".
+/// Alias retained for existing call sites that read `.history` as a list of "entries".
 typealias SupplementHistoryEntry = SupplementHistoryItem
 
 struct MealTypeCreate: Codable {

--- a/mobile/iosApp/Bissbilanz/Models/Supplement.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Supplement.swift
@@ -63,7 +63,9 @@ struct SupplementChecklist: Codable, Identifiable {
     let taken: Bool
     let takenAt: String?
 
-    var id: String { supplement.id }
+    var id: String {
+        supplement.id
+    }
 }
 
 struct SupplementsResponse: Codable {
@@ -111,8 +113,8 @@ struct SupplementIngredientInput: Codable {
     var sortOrder: Int?
 }
 
-// Inline backing food payload — kept minimal to match the web form; the server
-// normalises any missing macro fields to zero.
+/// Inline backing food payload — kept minimal to match the web form; the server
+/// normalises any missing macro fields to zero.
 struct SupplementBackingFoodInput: Codable {
     let name: String
     let servingSize: Double

--- a/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
@@ -4,19 +4,26 @@ import SwiftData
 
 /// Local-first repository for food entries and day properties.
 ///
-/// Reads come from SwiftData, `refresh(date:)` replaces the cached day with
-/// the server response (mirroring Android's `cacheEntries`), and writes go to
-/// SwiftData first with the API call layered on top. On API failure the local
-/// row is kept and the error is rethrown for the view to surface.
+/// Reads come from SwiftData and `refresh(date:)` replaces the cached day with
+/// the server response (mirroring Android's `cacheEntries`). Writes are
+/// SwiftData-first: the local row is written immediately and the API call is
+/// queued via the sync manager. In Synced mode the queue drains right away
+/// when online and replaces optimistic `temp_` rows with server records; in
+/// Local mode nothing is enqueued, refresh is a no-op and temp ids stay until
+/// the login migration uploads them.
 @MainActor
 @Observable
 final class EntryRepository {
     private let context: ModelContext
     private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
 
-    init(context: ModelContext, api: BissbilanzAPI) {
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
         self.context = context
         self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
     }
 
     // MARK: - Reads (local)
@@ -32,34 +39,55 @@ final class EntryRepository {
         }
     }
 
+    /// Local month aggregation for the calendar (used in Local mode, where
+    /// the local store holds every entry).
+    func calendarDays(year: Int, month: Int, calorieGoal: Double?) -> [CalendarDay] {
+        let monthPrefix = String(format: "%04d-%02d-", year, month)
+        let start = monthPrefix + "01"
+        let end = monthPrefix + "31"
+        let descriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.date >= start && $0.date <= end })
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return Dictionary(grouping: rows, by: \.date)
+            .map { date, dayRows in
+                let calories = dayRows.reduce(0.0) { $0 + $1.calories * $1.servings }
+                let hasGoal = calorieGoal != nil
+                return CalendarDay(
+                    date: date,
+                    calories: calories,
+                    hasGoal: hasGoal,
+                    metGoal: hasGoal && calories > 0 && calories <= (calorieGoal ?? 0)
+                )
+            }
+            .sorted { $0.date < $1.date }
+    }
+
     // MARK: - Refresh (API → store)
 
     func refresh(date: String) async throws {
+        guard !appMode.isLocal else { return }
         let fetched = try await api.getEntries(date: date)
-        try? context.delete(model: LocalEntry.self, where: #Predicate { $0.date == date })
+        // Keep optimistic temp rows the server doesn't know about yet — their
+        // queued creates replace them with server records when they drain.
+        let tempPrefix = LocalStore.tempIdPrefix
+        try? context.delete(
+            model: LocalEntry.self,
+            where: #Predicate { $0.date == date && !$0.id.starts(with: tempPrefix) }
+        )
         for entry in fetched {
             upsert(entry, date: date)
         }
         save()
     }
 
-    // MARK: - Writes (local first, then API)
+    // MARK: - Writes (local first + queued upload)
 
     @discardableResult
     func createEntry(_ create: EntryCreate, food: Food? = nil, recipe: Recipe? = nil) async throws -> Entry {
         let temp = Self.makeEntry(from: create, id: LocalStore.makeTempId(), food: food, recipe: recipe)
         upsert(temp, date: create.date)
         save()
-        // POST responses are raw DB rows without resolved macros — merge the
-        // resolved display fields from the optimistic local entry. On failure
-        // the local row is kept (the sync-queue package will upload it later;
-        // for now the rethrown error keeps this flow online-required).
-        let server = try await api.createEntry(create)
-        let merged = Self.merge(server: server, local: temp)
-        deleteRow(id: temp.id)
-        upsert(merged, date: merged.date ?? create.date)
-        save()
-        return merged
+        syncManager.enqueue(.createEntry(body: create, localId: temp.id))
+        return temp
     }
 
     @discardableResult
@@ -72,36 +100,79 @@ final class EntryRepository {
             save()
             local = updated
         }
-        // Temp rows don't exist server-side yet; the local edit is all we can do.
-        if LocalStore.isTempId(id), let local {
+        if LocalStore.isTempId(id) {
+            // The row hasn't been uploaded — rewrite the queued create instead.
+            coalesceQueuedCreate(tempId: id, update: update)
+        } else {
+            syncManager.enqueue(.updateEntry(id: id, body: update))
+        }
+        if let local {
             return local
         }
-        let server = try await api.updateEntry(id: id, update)
-        // PATCH responses are raw DB rows without resolved macros — prefer the
-        // locally merged entry for display and keep server bookkeeping fields.
-        if let local {
-            let merged = Self.merge(server: server, local: local)
-            upsert(merged, date: merged.date ?? DateFormatting.today)
-            save()
-            return merged
-        }
-        return server
+        throw APIError.notFound
     }
 
     func deleteEntry(id: String) async throws {
         deleteRow(id: id)
         save()
-        guard !LocalStore.isTempId(id) else { return }
-        try await api.deleteEntry(id: id)
+        if LocalStore.isTempId(id) {
+            syncManager.removeQueued(table: "entries", affectedId: id)
+        } else {
+            syncManager.enqueue(.deleteEntry(id: id))
+        }
     }
 
-    /// Server-side copy (responses are raw rows), then re-fetch the target day
-    /// so resolved macros land in the store. Returns the number copied.
+    /// Client-side copy (mirrors the Android repository): each source entry is
+    /// re-created locally for the target day and queued for upload, so the
+    /// copy works offline and in Local mode. Returns the number copied.
     @discardableResult
     func copyEntries(fromDate: String, toDate: String) async throws -> Int {
-        let copied = try await api.copyEntries(fromDate: fromDate, toDate: toDate)
-        try await refresh(date: toDate)
-        return copied.count
+        var copied = 0
+        for entry in entries(date: fromDate) {
+            let create = EntryCreate(
+                foodId: entry.foodId,
+                recipeId: entry.recipeId,
+                mealType: entry.mealType,
+                servings: entry.servings,
+                date: toDate,
+                notes: entry.notes,
+                quickName: entry.quickName,
+                quickCalories: entry.quickCalories,
+                quickProtein: entry.quickProtein,
+                quickCarbs: entry.quickCarbs,
+                quickFat: entry.quickFat,
+                quickFiber: entry.quickFiber,
+                eatenAt: entry.eatenAt
+            )
+            // Patch the source entry instead of rebuilding so resolved display
+            // macros survive the copy.
+            let tempId = LocalStore.makeTempId()
+            let copy = (try? JSONPatch.merged(Entry.self, base: entry, patch: [
+                "id": tempId,
+                "date": toDate,
+                "createdAt": ISO8601DateFormatter().string(from: Date()),
+            ])) ?? Self.makeEntry(from: create, id: tempId, food: nil, recipe: nil)
+            upsert(copy, date: toDate)
+            save()
+            syncManager.enqueue(.createEntry(body: create, localId: copy.id))
+            copied += 1
+        }
+        return copied
+    }
+
+    /// Rewrites the still-queued create for a temp-id entry so the eventual
+    /// upload carries the edited values. If the create has already drained
+    /// (no queued op found), the edit stays local-only — the temp id is
+    /// unknown server-side.
+    private func coalesceQueuedCreate(tempId: String, update: EntryUpdate) {
+        for row in syncManager.queuedOperations(table: "entries", affectedId: tempId) {
+            guard let operation = row.operation(),
+                  case let .createEntry(body, localId) = operation
+            else { continue }
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let merged = (try? JSONPatch.merged(EntryCreate.self, base: body, patch: patch)) ?? body
+            syncManager.replace(row, with: .createEntry(body: merged, localId: localId))
+        }
     }
 
     // MARK: - Day properties
@@ -111,6 +182,7 @@ final class EntryRepository {
     }
 
     func refreshDayProperties(date: String) async throws {
+        guard !appMode.isLocal else { return }
         if let properties = try await api.getDayProperties(date: date) {
             upsertDayProperties(properties)
         } else if let row = fetchDayPropertiesRow(date: date) {
@@ -122,9 +194,7 @@ final class EntryRepository {
     func setDayProperties(date: String, isFastingDay: Bool) async throws {
         upsertDayProperties(DayProperties(date: date, userId: "", isFastingDay: isFastingDay))
         save()
-        let server = try await api.setDayProperties(date: date, isFastingDay: isFastingDay)
-        upsertDayProperties(server)
-        save()
+        syncManager.enqueue(.setDayProperties(date: date, isFastingDay: isFastingDay))
     }
 
     func deleteDayProperties(date: String) async throws {
@@ -132,7 +202,7 @@ final class EntryRepository {
             context.delete(row)
             save()
         }
-        try await api.deleteDayProperties(date: date)
+        syncManager.enqueue(.deleteDayProperties(date: date))
     }
 
     // MARK: - Conversion helpers

--- a/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
@@ -127,8 +127,20 @@ final class EntryRepository {
     /// copy works offline and in Local mode. Returns the number copied.
     @discardableResult
     func copyEntries(fromDate: String, toDate: String) async throws -> Int {
+        let source = entries(date: fromDate)
+        // Right after an upgrade the local store may not hold the source day
+        // yet — in Synced mode fall back to the server-side copy (main
+        // parity) and cache the results.
+        if source.isEmpty, !appMode.isLocal {
+            let serverCopies = try await api.copyEntries(fromDate: fromDate, toDate: toDate)
+            for entry in serverCopies {
+                upsert(entry, date: entry.date ?? toDate)
+            }
+            save()
+            return serverCopies.count
+        }
         var copied = 0
-        for entry in entries(date: fromDate) {
+        for entry in source {
             let create = EntryCreate(
                 foodId: entry.foodId,
                 recipeId: entry.recipeId,

--- a/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
@@ -1,0 +1,240 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for food entries and day properties.
+///
+/// Reads come from SwiftData, `refresh(date:)` replaces the cached day with
+/// the server response (mirroring Android's `cacheEntries`), and writes go to
+/// SwiftData first with the API call layered on top. On API failure the local
+/// row is kept and the error is rethrown for the view to surface.
+@MainActor
+@Observable
+final class EntryRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+
+    init(context: ModelContext, api: BissbilanzAPI) {
+        self.context = context
+        self.api = api
+    }
+
+    // MARK: - Reads (local)
+
+    func entries(date: String) -> [Entry] {
+        let descriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.date == date })
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toEntry() }.sorted { lhs, rhs in
+            let l = lhs.createdAt ?? lhs.eatenAt ?? ""
+            let r = rhs.createdAt ?? rhs.eatenAt ?? ""
+            if l != r { return l < r }
+            return lhs.id < rhs.id
+        }
+    }
+
+    // MARK: - Refresh (API → store)
+
+    func refresh(date: String) async throws {
+        let fetched = try await api.getEntries(date: date)
+        try? context.delete(model: LocalEntry.self, where: #Predicate { $0.date == date })
+        for entry in fetched {
+            upsert(entry, date: date)
+        }
+        save()
+    }
+
+    // MARK: - Writes (local first, then API)
+
+    @discardableResult
+    func createEntry(_ create: EntryCreate, food: Food? = nil, recipe: Recipe? = nil) async throws -> Entry {
+        let temp = Self.makeEntry(from: create, id: LocalStore.makeTempId(), food: food, recipe: recipe)
+        upsert(temp, date: create.date)
+        save()
+        // POST responses are raw DB rows without resolved macros — merge the
+        // resolved display fields from the optimistic local entry. On failure
+        // the local row is kept (the sync-queue package will upload it later;
+        // for now the rethrown error keeps this flow online-required).
+        let server = try await api.createEntry(create)
+        let merged = Self.merge(server: server, local: temp)
+        deleteRow(id: temp.id)
+        upsert(merged, date: merged.date ?? create.date)
+        save()
+        return merged
+    }
+
+    @discardableResult
+    func updateEntry(id: String, _ update: EntryUpdate) async throws -> Entry {
+        var local: Entry?
+        if let row = fetchRow(id: id), let existing = row.toEntry() {
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let updated = (try? JSONPatch.merged(Entry.self, base: existing, patch: patch)) ?? existing
+            row.update(from: updated, date: update.date ?? row.date)
+            save()
+            local = updated
+        }
+        // Temp rows don't exist server-side yet; the local edit is all we can do.
+        if LocalStore.isTempId(id), let local {
+            return local
+        }
+        let server = try await api.updateEntry(id: id, update)
+        // PATCH responses are raw DB rows without resolved macros — prefer the
+        // locally merged entry for display and keep server bookkeeping fields.
+        if let local {
+            let merged = Self.merge(server: server, local: local)
+            upsert(merged, date: merged.date ?? DateFormatting.today)
+            save()
+            return merged
+        }
+        return server
+    }
+
+    func deleteEntry(id: String) async throws {
+        deleteRow(id: id)
+        save()
+        guard !LocalStore.isTempId(id) else { return }
+        try await api.deleteEntry(id: id)
+    }
+
+    /// Server-side copy (responses are raw rows), then re-fetch the target day
+    /// so resolved macros land in the store. Returns the number copied.
+    @discardableResult
+    func copyEntries(fromDate: String, toDate: String) async throws -> Int {
+        let copied = try await api.copyEntries(fromDate: fromDate, toDate: toDate)
+        try await refresh(date: toDate)
+        return copied.count
+    }
+
+    // MARK: - Day properties
+
+    func isFastingDay(date: String) -> Bool {
+        fetchDayPropertiesRow(date: date)?.isFastingDay ?? false
+    }
+
+    func refreshDayProperties(date: String) async throws {
+        if let properties = try await api.getDayProperties(date: date) {
+            upsertDayProperties(properties)
+        } else if let row = fetchDayPropertiesRow(date: date) {
+            context.delete(row)
+        }
+        save()
+    }
+
+    func setDayProperties(date: String, isFastingDay: Bool) async throws {
+        upsertDayProperties(DayProperties(date: date, userId: "", isFastingDay: isFastingDay))
+        save()
+        let server = try await api.setDayProperties(date: date, isFastingDay: isFastingDay)
+        upsertDayProperties(server)
+        save()
+    }
+
+    func deleteDayProperties(date: String) async throws {
+        if let row = fetchDayPropertiesRow(date: date) {
+            context.delete(row)
+            save()
+        }
+        try await api.deleteDayProperties(date: date)
+    }
+
+    // MARK: - Conversion helpers
+
+    static func makeEntry(from create: EntryCreate, id: String, food: Food?, recipe: Recipe?) -> Entry {
+        let recipeServings = (recipe?.totalServings).map { max($0, 1) } ?? 1
+        return Entry(
+            id: id,
+            mealType: create.mealType,
+            servings: create.servings,
+            notes: create.notes,
+            foodId: create.foodId,
+            recipeId: create.recipeId,
+            quickName: create.quickName,
+            quickCalories: create.quickCalories,
+            quickProtein: create.quickProtein,
+            quickCarbs: create.quickCarbs,
+            quickFat: create.quickFat,
+            quickFiber: create.quickFiber,
+            foodName: food?.name ?? recipe?.name,
+            calories: food?.calories ?? recipe?.calories.map { $0 / recipeServings },
+            protein: food?.protein ?? recipe?.protein.map { $0 / recipeServings },
+            carbs: food?.carbs ?? recipe?.carbs.map { $0 / recipeServings },
+            fat: food?.fat ?? recipe?.fat.map { $0 / recipeServings },
+            fiber: food?.fiber ?? recipe?.fiber.map { $0 / recipeServings },
+            servingSize: food?.servingSize,
+            servingUnit: food?.servingUnit,
+            date: create.date,
+            eatenAt: create.eatenAt,
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            updatedAt: nil
+        )
+    }
+
+    /// Server rows win where present; resolved display fields missing from raw
+    /// POST/PATCH responses fall back to the optimistic local entry.
+    static func merge(server: Entry, local: Entry) -> Entry {
+        Entry(
+            id: server.id,
+            mealType: server.mealType,
+            servings: server.servings,
+            notes: server.notes ?? local.notes,
+            foodId: server.foodId ?? local.foodId,
+            recipeId: server.recipeId ?? local.recipeId,
+            quickName: server.quickName ?? local.quickName,
+            quickCalories: server.quickCalories ?? local.quickCalories,
+            quickProtein: server.quickProtein ?? local.quickProtein,
+            quickCarbs: server.quickCarbs ?? local.quickCarbs,
+            quickFat: server.quickFat ?? local.quickFat,
+            quickFiber: server.quickFiber ?? local.quickFiber,
+            foodName: server.foodName ?? local.foodName,
+            calories: server.calories ?? local.calories,
+            protein: server.protein ?? local.protein,
+            carbs: server.carbs ?? local.carbs,
+            fat: server.fat ?? local.fat,
+            fiber: server.fiber ?? local.fiber,
+            servingSize: server.servingSize ?? local.servingSize,
+            servingUnit: server.servingUnit ?? local.servingUnit,
+            date: server.date ?? local.date,
+            eatenAt: server.eatenAt ?? local.eatenAt,
+            createdAt: server.createdAt ?? local.createdAt,
+            updatedAt: server.updatedAt ?? local.updatedAt
+        )
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow(id: String) -> LocalEntry? {
+        var descriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ entry: Entry, date: String) {
+        if let row = fetchRow(id: entry.id) {
+            row.update(from: entry, date: date)
+        } else {
+            context.insert(LocalEntry(entry: entry, date: date))
+        }
+    }
+
+    private func deleteRow(id: String) {
+        if let row = fetchRow(id: id) {
+            context.delete(row)
+        }
+    }
+
+    private func fetchDayPropertiesRow(date: String) -> LocalDayProperties? {
+        var descriptor = FetchDescriptor<LocalDayProperties>(predicate: #Predicate { $0.date == date })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsertDayProperties(_ properties: DayProperties) {
+        if let row = fetchDayPropertiesRow(date: properties.date) {
+            row.update(from: properties)
+        } else {
+            context.insert(LocalDayProperties(properties: properties))
+        }
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/FoodRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/FoodRepository.swift
@@ -154,12 +154,27 @@ final class FoodRepository {
 
     @discardableResult
     func updateFood(id: String, _ create: FoodCreate) async throws -> Food {
-        let optimistic = try Self.makeFood(from: create, id: id)
+        // Merge-patch the form fields onto the existing row: the edit form
+        // only carries the basic fields, so rebuilding the row wholesale
+        // would wipe extended nutrients and OFF metadata (nutriScore,
+        // additives, imageUrl, …) of e.g. a scanned food.
+        let patch = (try? JSONPatch.dictionary(of: create)) ?? [:]
+        let optimistic: Food = if let existing = food(id: id),
+                                  let merged = try? JSONPatch.merged(Food.self, base: existing, patch: patch)
+        {
+            merged
+        } else {
+            try Self.makeFood(from: create, id: id)
+        }
         upsert(optimistic)
         save()
         if LocalStore.isTempId(id) {
-            // Not uploaded yet — the queued create simply carries the new body.
-            coalesceQueuedCreate(tempId: id) { _ in create }
+            // Not uploaded yet — merge the edit into the queued create body
+            // (replacing it wholesale would strip fields the form doesn't
+            // carry from the eventual upload too).
+            coalesceQueuedCreate(tempId: id) { body in
+                (try? JSONPatch.merged(FoodCreate.self, base: body, patch: patch)) ?? body
+            }
         } else {
             syncManager.enqueue(.updateFood(id: id, body: create))
         }

--- a/mobile/iosApp/Bissbilanz/Persistence/FoodRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/FoodRepository.swift
@@ -1,0 +1,236 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for the personal food database.
+///
+/// Favorites, recents and detail reads come from SwiftData; search stays
+/// API-first (the server searches the full DB) with a local fallback,
+/// mirroring the Android repository. Writes are optimistic: local row first,
+/// then the API call, with temp ids replaced by the server record on success.
+@MainActor
+@Observable
+final class FoodRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+
+    init(context: ModelContext, api: BissbilanzAPI) {
+        self.context = context
+        self.api = api
+    }
+
+    // MARK: - Reads (local)
+
+    func food(id: String) -> Food? {
+        fetchRow(id: id)?.toFood()
+    }
+
+    func favorites() -> [Food] {
+        let descriptor = FetchDescriptor<LocalFood>(
+            predicate: #Predicate { $0.isFavorite },
+            sortBy: [SortDescriptor(\.name)]
+        )
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toFood() }
+    }
+
+    /// Recents derived from the local entry log — instant render across
+    /// launches; `refreshRecentFoods` replaces this with the server ordering.
+    func localRecentFoods(limit: Int = 20) -> [Food] {
+        let descriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.foodId != nil })
+        let entryRows = (try? context.fetch(descriptor)) ?? []
+        var lastDateByFood: [String: String] = [:]
+        for row in entryRows {
+            guard let foodId = row.foodId else { continue }
+            if let current = lastDateByFood[foodId], current >= row.date { continue }
+            lastDateByFood[foodId] = row.date
+        }
+        return lastDateByFood
+            .sorted { $0.value > $1.value }
+            .prefix(limit)
+            .compactMap { food(id: $0.key) }
+    }
+
+    func searchLocal(_ query: String, limit: Int = 50) -> [Food] {
+        let descriptor = FetchDescriptor<LocalFood>(sortBy: [SortDescriptor(\.name)])
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows
+            .filter { row in
+                row.name.localizedCaseInsensitiveContains(query)
+                    || (row.brand?.localizedCaseInsensitiveContains(query) ?? false)
+            }
+            .prefix(limit)
+            .compactMap { $0.toFood() }
+    }
+
+    func findLocalByBarcode(_ barcode: String) -> Food? {
+        var descriptor = FetchDescriptor<LocalFood>(predicate: #Predicate { $0.barcode == barcode })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first?.toFood()
+    }
+
+    // MARK: - Refresh (API → store)
+
+    func refreshFood(id: String) async throws {
+        guard !LocalStore.isTempId(id) else { return }
+        let food = try await api.getFood(id: id)
+        upsert(food)
+        save()
+    }
+
+    /// Refreshes favorites and reconciles un-favorited rows. Also caches the
+    /// favorite recipes carried in the same response.
+    func refreshFavorites() async throws {
+        let response = try await api.getFavorites()
+        let favoriteIds = Set(response.foods.map(\.id))
+        for stale in favorites() where !favoriteIds.contains(stale.id) && !LocalStore.isTempId(stale.id) {
+            if let row = fetchRow(id: stale.id), let patched = patchedFavorite(stale, isFavorite: false) {
+                row.update(from: patched)
+            }
+        }
+        for food in response.foods {
+            upsert(food)
+        }
+        for recipe in response.recipes ?? [] {
+            upsertRecipe(recipe)
+        }
+        save()
+    }
+
+    /// Server-ordered recents (trimmed foods, not cached — mirrors Android);
+    /// falls back to the locally derived list when the API is unavailable.
+    func refreshRecentFoods(limit: Int = 20) async -> [Food] {
+        if let recents = try? await api.getRecentFoods(limit: limit) {
+            return recents
+        }
+        return localRecentFoods(limit: limit)
+    }
+
+    /// API-first search over the full server-side food DB; results are cached
+    /// and the local store answers when the network is unavailable.
+    func searchFoods(query: String) async -> [Food] {
+        do {
+            let results = try await api.searchFoods(query: query)
+            for food in results {
+                upsert(food)
+            }
+            save()
+            return results
+        } catch {
+            return searchLocal(query)
+        }
+    }
+
+    func findByBarcode(_ barcode: String) async throws -> Food? {
+        if let local = findLocalByBarcode(barcode) {
+            return local
+        }
+        guard let food = try await api.findFoodByBarcode(barcode) else { return nil }
+        upsert(food)
+        save()
+        return food
+    }
+
+    // MARK: - Writes (local first, then API)
+
+    @discardableResult
+    func createFood(_ create: FoodCreate) async throws -> Food {
+        let temp = try Self.makeFood(from: create, id: LocalStore.makeTempId())
+        upsert(temp)
+        save()
+        let server = try await api.createFood(create)
+        deleteRow(id: temp.id)
+        upsert(server)
+        save()
+        return server
+    }
+
+    @discardableResult
+    func updateFood(id: String, _ create: FoodCreate) async throws -> Food {
+        let optimistic = try Self.makeFood(from: create, id: id)
+        upsert(optimistic)
+        save()
+        guard !LocalStore.isTempId(id) else { return optimistic }
+        let server = try await api.updateFood(id: id, create)
+        upsert(server)
+        save()
+        return server
+    }
+
+    func deleteFood(id: String) async throws {
+        deleteRow(id: id)
+        save()
+        guard !LocalStore.isTempId(id) else { return }
+        try await api.deleteFood(id: id)
+    }
+
+    @discardableResult
+    func toggleFavorite(foodId: String, isFavorite: Bool) async throws -> Food {
+        var optimistic: Food?
+        if let row = fetchRow(id: foodId), let current = row.toFood(),
+           let patched = patchedFavorite(current, isFavorite: isFavorite)
+        {
+            row.update(from: patched)
+            save()
+            optimistic = patched
+        }
+        if LocalStore.isTempId(foodId), let optimistic {
+            return optimistic
+        }
+        let server = try await api.toggleFavorite(foodId: foodId, isFavorite: isFavorite)
+        upsert(server)
+        save()
+        return server
+    }
+
+    // MARK: - Conversion helpers
+
+    static func makeFood(from create: FoodCreate, id: String) throws -> Food {
+        try JSONPatch.merged(Food.self, base: create, patch: [
+            "id": id,
+            "userId": "",
+            "isFavorite": create.isFavorite ?? false,
+        ])
+    }
+
+    private func patchedFavorite(_ food: Food, isFavorite: Bool) -> Food? {
+        try? JSONPatch.merged(Food.self, base: food, patch: ["isFavorite": isFavorite])
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow(id: String) -> LocalFood? {
+        var descriptor = FetchDescriptor<LocalFood>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ food: Food) {
+        if let row = fetchRow(id: food.id) {
+            row.update(from: food)
+        } else {
+            context.insert(LocalFood(food: food))
+        }
+    }
+
+    private func deleteRow(id: String) {
+        if let row = fetchRow(id: id) {
+            context.delete(row)
+        }
+    }
+
+    private func upsertRecipe(_ recipe: Recipe) {
+        let id = recipe.id
+        var descriptor = FetchDescriptor<LocalRecipe>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        if let row = (try? context.fetch(descriptor))?.first {
+            row.update(from: recipe)
+        } else {
+            context.insert(LocalRecipe(recipe: recipe))
+        }
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/FoodRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/FoodRepository.swift
@@ -5,18 +5,25 @@ import SwiftData
 /// Local-first repository for the personal food database.
 ///
 /// Favorites, recents and detail reads come from SwiftData; search stays
-/// API-first (the server searches the full DB) with a local fallback,
-/// mirroring the Android repository. Writes are optimistic: local row first,
-/// then the API call, with temp ids replaced by the server record on success.
+/// API-first (the server searches the full DB) with a local fallback. Writes
+/// are SwiftData-first with the upload queued via the sync manager: the
+/// drained create replaces the optimistic `temp_` row with the server record,
+/// and edits/deletes of a still-queued temp row coalesce with the queued
+/// create. In Local mode nothing is queued and refreshes/search are
+/// local-only — the store is the primary database.
 @MainActor
 @Observable
 final class FoodRepository {
     private let context: ModelContext
     private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
 
-    init(context: ModelContext, api: BissbilanzAPI) {
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
         self.context = context
         self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
     }
 
     // MARK: - Reads (local)
@@ -72,7 +79,7 @@ final class FoodRepository {
     // MARK: - Refresh (API → store)
 
     func refreshFood(id: String) async throws {
-        guard !LocalStore.isTempId(id) else { return }
+        guard !appMode.isLocal, !LocalStore.isTempId(id) else { return }
         let food = try await api.getFood(id: id)
         upsert(food)
         save()
@@ -81,6 +88,7 @@ final class FoodRepository {
     /// Refreshes favorites and reconciles un-favorited rows. Also caches the
     /// favorite recipes carried in the same response.
     func refreshFavorites() async throws {
+        guard !appMode.isLocal else { return }
         let response = try await api.getFavorites()
         let favoriteIds = Set(response.foods.map(\.id))
         for stale in favorites() where !favoriteIds.contains(stale.id) && !LocalStore.isTempId(stale.id) {
@@ -92,23 +100,24 @@ final class FoodRepository {
             upsert(food)
         }
         for recipe in response.recipes ?? [] {
-            upsertRecipe(recipe)
+            LocalRemap.upsertRecipe(recipe, in: context)
         }
         save()
     }
 
     /// Server-ordered recents (trimmed foods, not cached — mirrors Android);
-    /// falls back to the locally derived list when the API is unavailable.
+    /// falls back to the locally derived list offline and in Local mode.
     func refreshRecentFoods(limit: Int = 20) async -> [Food] {
-        if let recents = try? await api.getRecentFoods(limit: limit) {
+        if !appMode.isLocal, let recents = try? await api.getRecentFoods(limit: limit) {
             return recents
         }
         return localRecentFoods(limit: limit)
     }
 
     /// API-first search over the full server-side food DB; results are cached
-    /// and the local store answers when the network is unavailable.
+    /// and the local store answers offline and in Local mode.
     func searchFoods(query: String) async -> [Food] {
+        guard !appMode.isLocal else { return searchLocal(query) }
         do {
             let results = try await api.searchFoods(query: query)
             for food in results {
@@ -125,24 +134,22 @@ final class FoodRepository {
         if let local = findLocalByBarcode(barcode) {
             return local
         }
+        guard !appMode.isLocal else { return nil }
         guard let food = try await api.findFoodByBarcode(barcode) else { return nil }
         upsert(food)
         save()
         return food
     }
 
-    // MARK: - Writes (local first, then API)
+    // MARK: - Writes (local first + queued upload)
 
     @discardableResult
     func createFood(_ create: FoodCreate) async throws -> Food {
         let temp = try Self.makeFood(from: create, id: LocalStore.makeTempId())
         upsert(temp)
         save()
-        let server = try await api.createFood(create)
-        deleteRow(id: temp.id)
-        upsert(server)
-        save()
-        return server
+        syncManager.enqueue(.createFood(body: create, localId: temp.id))
+        return temp
     }
 
     @discardableResult
@@ -150,37 +157,53 @@ final class FoodRepository {
         let optimistic = try Self.makeFood(from: create, id: id)
         upsert(optimistic)
         save()
-        guard !LocalStore.isTempId(id) else { return optimistic }
-        let server = try await api.updateFood(id: id, create)
-        upsert(server)
-        save()
-        return server
+        if LocalStore.isTempId(id) {
+            // Not uploaded yet — the queued create simply carries the new body.
+            coalesceQueuedCreate(tempId: id) { _ in create }
+        } else {
+            syncManager.enqueue(.updateFood(id: id, body: create))
+        }
+        return optimistic
     }
 
     func deleteFood(id: String) async throws {
         deleteRow(id: id)
         save()
-        guard !LocalStore.isTempId(id) else { return }
-        try await api.deleteFood(id: id)
+        if LocalStore.isTempId(id) {
+            syncManager.removeQueued(table: "foods", affectedId: id)
+        } else {
+            syncManager.enqueue(.deleteFood(id: id))
+        }
     }
 
     @discardableResult
     func toggleFavorite(foodId: String, isFavorite: Bool) async throws -> Food {
-        var optimistic: Food?
-        if let row = fetchRow(id: foodId), let current = row.toFood(),
-           let patched = patchedFavorite(current, isFavorite: isFavorite)
-        {
-            row.update(from: patched)
-            save()
-            optimistic = patched
+        guard let row = fetchRow(id: foodId), let current = row.toFood(),
+              let patched = patchedFavorite(current, isFavorite: isFavorite)
+        else {
+            throw APIError.notFound
         }
-        if LocalStore.isTempId(foodId), let optimistic {
-            return optimistic
-        }
-        let server = try await api.toggleFavorite(foodId: foodId, isFavorite: isFavorite)
-        upsert(server)
+        row.update(from: patched)
         save()
-        return server
+        if LocalStore.isTempId(foodId) {
+            coalesceQueuedCreate(tempId: foodId) { body in
+                (try? JSONPatch.merged(FoodCreate.self, base: body, patch: ["isFavorite": isFavorite])) ?? body
+            }
+        } else {
+            syncManager.enqueue(.toggleFavorite(id: foodId, isFavorite: isFavorite))
+        }
+        return patched
+    }
+
+    /// Rewrites the still-queued create for a temp-id food. If the create has
+    /// already drained (no queued op found), the edit stays local-only.
+    private func coalesceQueuedCreate(tempId: String, rewrite: (FoodCreate) -> FoodCreate) {
+        for row in syncManager.queuedOperations(table: "foods", affectedId: tempId) {
+            guard let operation = row.operation(),
+                  case let .createFood(body, localId) = operation
+            else { continue }
+            syncManager.replace(row, with: .createFood(body: rewrite(body), localId: localId))
+        }
     }
 
     // MARK: - Conversion helpers
@@ -216,17 +239,6 @@ final class FoodRepository {
     private func deleteRow(id: String) {
         if let row = fetchRow(id: id) {
             context.delete(row)
-        }
-    }
-
-    private func upsertRecipe(_ recipe: Recipe) {
-        let id = recipe.id
-        var descriptor = FetchDescriptor<LocalRecipe>(predicate: #Predicate { $0.id == id })
-        descriptor.fetchLimit = 1
-        if let row = (try? context.fetch(descriptor))?.first {
-            row.update(from: recipe)
-        } else {
-            context.insert(LocalRecipe(recipe: recipe))
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Persistence/GoalsRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/GoalsRepository.swift
@@ -2,16 +2,21 @@ import Foundation
 import Observation
 import SwiftData
 
-/// Local-first repository for daily macro goals (singleton row).
+/// Local-first repository for daily macro goals (singleton row). Writes are
+/// SwiftData-first with the idempotent set-call queued via the sync manager.
 @MainActor
 @Observable
 final class GoalsRepository {
     private let context: ModelContext
     private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
 
-    init(context: ModelContext, api: BissbilanzAPI) {
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
         self.context = context
         self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
     }
 
     func goals() -> Goals? {
@@ -19,6 +24,7 @@ final class GoalsRepository {
     }
 
     func refresh() async throws {
+        guard !appMode.isLocal else { return }
         guard let goals = try await api.getGoals() else { return }
         upsert(goals)
         save()
@@ -28,10 +34,8 @@ final class GoalsRepository {
     func setGoals(_ goals: Goals) async throws -> Goals {
         upsert(goals)
         save()
-        let server = try await api.setGoals(goals)
-        upsert(server)
-        save()
-        return server
+        syncManager.enqueue(.setGoals(body: goals))
+        return goals
     }
 
     // MARK: - Store helpers

--- a/mobile/iosApp/Bissbilanz/Persistence/GoalsRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/GoalsRepository.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for daily macro goals (singleton row).
+@MainActor
+@Observable
+final class GoalsRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+
+    init(context: ModelContext, api: BissbilanzAPI) {
+        self.context = context
+        self.api = api
+    }
+
+    func goals() -> Goals? {
+        fetchRow()?.toGoals()
+    }
+
+    func refresh() async throws {
+        guard let goals = try await api.getGoals() else { return }
+        upsert(goals)
+        save()
+    }
+
+    @discardableResult
+    func setGoals(_ goals: Goals) async throws -> Goals {
+        upsert(goals)
+        save()
+        let server = try await api.setGoals(goals)
+        upsert(server)
+        save()
+        return server
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow() -> LocalGoals? {
+        let singletonId = LocalGoals.singletonId
+        var descriptor = FetchDescriptor<LocalGoals>(predicate: #Predicate { $0.id == singletonId })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ goals: Goals) {
+        if let row = fetchRow() {
+            row.update(from: goals)
+        } else {
+            context.insert(LocalGoals(goals: goals))
+        }
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalModels.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalModels.swift
@@ -1,0 +1,343 @@
+import Foundation
+import SwiftData
+
+/// Shared coding for the `jsonData` payload columns. Each local model keeps a
+/// few typed, queryable columns (mirroring the Android SQLDelight cache
+/// tables) plus the full encoded Codable struct so conversions are lossless.
+enum LocalStoreCoding {
+    static func encode(_ value: some Encodable) -> Data {
+        (try? JSONEncoder().encode(value)) ?? Data()
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from data: Data) -> T? {
+        try? JSONDecoder().decode(type, from: data)
+    }
+}
+
+// MARK: - Entries
+
+@Model
+final class LocalEntry {
+    @Attribute(.unique) var id: String
+    var date: String
+    var mealType: String
+    var servings: Double
+    var foodId: String?
+    var recipeId: String?
+    var foodName: String?
+    var calories: Double
+    var protein: Double
+    var carbs: Double
+    var fat: Double
+    var fiber: Double
+    var jsonData: Data
+
+    init(entry: Entry, date: String) {
+        let dated = entry.replacingDate(date)
+        id = dated.id
+        self.date = date
+        mealType = dated.mealType
+        servings = dated.servings
+        foodId = dated.foodId
+        recipeId = dated.recipeId
+        foodName = dated.foodName ?? dated.quickName
+        calories = dated.calories ?? dated.quickCalories ?? 0
+        protein = dated.protein ?? dated.quickProtein ?? 0
+        carbs = dated.carbs ?? dated.quickCarbs ?? 0
+        fat = dated.fat ?? dated.quickFat ?? 0
+        fiber = dated.fiber ?? dated.quickFiber ?? 0
+        jsonData = LocalStoreCoding.encode(dated)
+    }
+
+    func update(from entry: Entry, date: String) {
+        let dated = entry.replacingDate(date)
+        self.date = date
+        mealType = dated.mealType
+        servings = dated.servings
+        foodId = dated.foodId
+        recipeId = dated.recipeId
+        foodName = dated.foodName ?? dated.quickName
+        calories = dated.calories ?? dated.quickCalories ?? 0
+        protein = dated.protein ?? dated.quickProtein ?? 0
+        carbs = dated.carbs ?? dated.quickCarbs ?? 0
+        fat = dated.fat ?? dated.quickFat ?? 0
+        fiber = dated.fiber ?? dated.quickFiber ?? 0
+        jsonData = LocalStoreCoding.encode(dated)
+    }
+
+    func toEntry() -> Entry? {
+        LocalStoreCoding.decode(Entry.self, from: jsonData)
+    }
+}
+
+extension Entry {
+    /// Returns a copy with `date` set — list responses omit it, but the local
+    /// store keys entries by date.
+    func replacingDate(_ newDate: String) -> Entry {
+        if date == newDate { return self }
+        return (try? JSONPatch.merged(Entry.self, base: self, patch: ["date": newDate])) ?? self
+    }
+}
+
+// MARK: - Foods
+
+@Model
+final class LocalFood {
+    @Attribute(.unique) var id: String
+    var name: String
+    var brand: String?
+    var calories: Double
+    var protein: Double
+    var carbs: Double
+    var fat: Double
+    var fiber: Double
+    var isFavorite: Bool
+    var barcode: String?
+    var jsonData: Data
+
+    init(food: Food) {
+        id = food.id
+        name = food.name
+        brand = food.brand
+        calories = food.calories
+        protein = food.protein
+        carbs = food.carbs
+        fat = food.fat
+        fiber = food.fiber
+        isFavorite = food.isFavorite
+        barcode = food.barcode
+        jsonData = LocalStoreCoding.encode(food)
+    }
+
+    func update(from food: Food) {
+        name = food.name
+        brand = food.brand
+        calories = food.calories
+        protein = food.protein
+        carbs = food.carbs
+        fat = food.fat
+        fiber = food.fiber
+        isFavorite = food.isFavorite
+        barcode = food.barcode
+        jsonData = LocalStoreCoding.encode(food)
+    }
+
+    func toFood() -> Food? {
+        LocalStoreCoding.decode(Food.self, from: jsonData)
+    }
+}
+
+// MARK: - Recipes
+
+@Model
+final class LocalRecipe {
+    @Attribute(.unique) var id: String
+    var name: String
+    var totalServings: Double
+    var isFavorite: Bool
+    var calories: Double
+    var protein: Double
+    var carbs: Double
+    var fat: Double
+    var fiber: Double
+    var jsonData: Data
+
+    init(recipe: Recipe) {
+        id = recipe.id
+        name = recipe.name
+        totalServings = recipe.totalServings
+        isFavorite = recipe.isFavorite
+        calories = recipe.calories ?? 0
+        protein = recipe.protein ?? 0
+        carbs = recipe.carbs ?? 0
+        fat = recipe.fat ?? 0
+        fiber = recipe.fiber ?? 0
+        jsonData = LocalStoreCoding.encode(recipe)
+    }
+
+    func update(from recipe: Recipe) {
+        name = recipe.name
+        totalServings = recipe.totalServings
+        isFavorite = recipe.isFavorite
+        calories = recipe.calories ?? 0
+        protein = recipe.protein ?? 0
+        carbs = recipe.carbs ?? 0
+        fat = recipe.fat ?? 0
+        fiber = recipe.fiber ?? 0
+        jsonData = LocalStoreCoding.encode(recipe)
+    }
+
+    func toRecipe() -> Recipe? {
+        LocalStoreCoding.decode(Recipe.self, from: jsonData)
+    }
+}
+
+// MARK: - Weight
+
+@Model
+final class LocalWeightEntry {
+    @Attribute(.unique) var id: String
+    var entryDate: String
+    var weightKg: Double
+    var loggedAt: String?
+    var jsonData: Data
+
+    init(entry: WeightEntry) {
+        id = entry.id
+        entryDate = entry.entryDate
+        weightKg = entry.weightKg
+        loggedAt = entry.loggedAt
+        jsonData = LocalStoreCoding.encode(entry)
+    }
+
+    func update(from entry: WeightEntry) {
+        entryDate = entry.entryDate
+        weightKg = entry.weightKg
+        loggedAt = entry.loggedAt
+        jsonData = LocalStoreCoding.encode(entry)
+    }
+
+    func toWeightEntry() -> WeightEntry? {
+        LocalStoreCoding.decode(WeightEntry.self, from: jsonData)
+    }
+}
+
+// MARK: - Supplements
+
+@Model
+final class LocalSupplement {
+    @Attribute(.unique) var id: String
+    var name: String
+    var isActive: Bool
+    var sortOrder: Int
+    var jsonData: Data
+
+    init(supplement: Supplement) {
+        id = supplement.id
+        name = supplement.name
+        isActive = supplement.isActive
+        sortOrder = supplement.sortOrder
+        jsonData = LocalStoreCoding.encode(supplement)
+    }
+
+    func update(from supplement: Supplement) {
+        name = supplement.name
+        isActive = supplement.isActive
+        sortOrder = supplement.sortOrder
+        jsonData = LocalStoreCoding.encode(supplement)
+    }
+
+    func toSupplement() -> Supplement? {
+        LocalStoreCoding.decode(Supplement.self, from: jsonData)
+    }
+}
+
+/// Taken-log rows keyed by the natural (supplementId, date) pair — the server
+/// has no row id for these, mirroring the Android cache.
+@Model
+final class LocalSupplementLog {
+    @Attribute(.unique) var id: String
+    var supplementId: String
+    var date: String
+    var takenAt: String
+    var jsonData: Data
+
+    init(log: SupplementLog) {
+        id = Self.key(supplementId: log.supplementId, date: log.date)
+        supplementId = log.supplementId
+        date = log.date
+        takenAt = log.takenAt
+        jsonData = LocalStoreCoding.encode(log)
+    }
+
+    /// Synthetic log without server bookkeeping (`entryIds`) — used for
+    /// optimistic writes and checklist-derived rows.
+    convenience init(supplementId: String, date: String, takenAt: String) {
+        self.init(log: SupplementLog(supplementId: supplementId, date: date, takenAt: takenAt, entryIds: []))
+    }
+
+    func update(from log: SupplementLog) {
+        supplementId = log.supplementId
+        date = log.date
+        takenAt = log.takenAt
+        jsonData = LocalStoreCoding.encode(log)
+    }
+
+    func toSupplementLog() -> SupplementLog? {
+        LocalStoreCoding.decode(SupplementLog.self, from: jsonData)
+    }
+
+    static func key(supplementId: String, date: String) -> String {
+        "\(supplementId)-\(date)"
+    }
+}
+
+// MARK: - Goals (singleton row)
+
+@Model
+final class LocalGoals {
+    @Attribute(.unique) var id: String
+    var jsonData: Data
+
+    static let singletonId = "goals"
+
+    init(goals: Goals) {
+        id = Self.singletonId
+        jsonData = LocalStoreCoding.encode(goals)
+    }
+
+    func update(from goals: Goals) {
+        jsonData = LocalStoreCoding.encode(goals)
+    }
+
+    func toGoals() -> Goals? {
+        LocalStoreCoding.decode(Goals.self, from: jsonData)
+    }
+}
+
+// MARK: - Preferences (singleton row)
+
+@Model
+final class LocalPreferences {
+    @Attribute(.unique) var id: String
+    var jsonData: Data
+
+    static let singletonId = "preferences"
+
+    init(preferences: Preferences) {
+        id = Self.singletonId
+        jsonData = LocalStoreCoding.encode(preferences)
+    }
+
+    func update(from preferences: Preferences) {
+        jsonData = LocalStoreCoding.encode(preferences)
+    }
+
+    func toPreferences() -> Preferences? {
+        LocalStoreCoding.decode(Preferences.self, from: jsonData)
+    }
+}
+
+// MARK: - Day properties
+
+@Model
+final class LocalDayProperties {
+    @Attribute(.unique) var date: String
+    var isFastingDay: Bool
+    var jsonData: Data
+
+    init(properties: DayProperties) {
+        date = properties.date
+        isFastingDay = properties.isFastingDay
+        jsonData = LocalStoreCoding.encode(properties)
+    }
+
+    func update(from properties: DayProperties) {
+        isFastingDay = properties.isFastingDay
+        jsonData = LocalStoreCoding.encode(properties)
+    }
+
+    func toDayProperties() -> DayProperties? {
+        LocalStoreCoding.decode(DayProperties.self, from: jsonData)
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalRemap.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalRemap.swift
@@ -1,0 +1,228 @@
+import Foundation
+import SwiftData
+
+/// Shared SwiftData mutations for re-keying a local row to a (server) record
+/// and rewriting every local reference to the old id. Used by the sync queue
+/// (replacing optimistic `temp_` rows once their queued create drains) and by
+/// the login migrator (normalization + upload re-keying) — the one place that
+/// owns "what points at a food/recipe/supplement id locally".
+@MainActor
+enum LocalRemap {
+    // MARK: - Replacements (old row → new record)
+
+    static func replaceFood(id oldId: String, with food: Food, in context: ModelContext) {
+        if let row = foodRow(id: oldId, in: context), food.id != oldId {
+            context.delete(row)
+        }
+        upsertFood(food, in: context)
+        remapFoodReferences(from: oldId, to: food.id, in: context)
+        try? context.save()
+    }
+
+    static func replaceRecipe(id oldId: String, with recipe: Recipe, in context: ModelContext) {
+        if let row = recipeRow(id: oldId, in: context), recipe.id != oldId {
+            context.delete(row)
+        }
+        upsertRecipe(recipe, in: context)
+        remapRecipeReferences(from: oldId, to: recipe.id, in: context)
+        try? context.save()
+    }
+
+    static func replaceEntry(id oldId: String, with entry: Entry, date: String, in context: ModelContext) {
+        if let row = entryRow(id: oldId, in: context), entry.id != oldId {
+            context.delete(row)
+        }
+        upsertEntry(entry, date: date, in: context)
+        try? context.save()
+    }
+
+    static func replaceWeight(id oldId: String, with entry: WeightEntry, in context: ModelContext) {
+        if let row = weightRow(id: oldId, in: context), entry.id != oldId {
+            context.delete(row)
+        }
+        upsertWeight(entry, in: context)
+        try? context.save()
+    }
+
+    static func replaceSupplement(
+        id oldId: String,
+        with supplement: Supplement,
+        rekeyLogIds: Bool,
+        in context: ModelContext
+    ) {
+        if let row = supplementRow(id: oldId, in: context), supplement.id != oldId {
+            context.delete(row)
+        }
+        upsertSupplement(supplement, in: context)
+        remapSupplementReferences(from: oldId, to: supplement.id, rekeyLogIds: rekeyLogIds, in: context)
+        try? context.save()
+    }
+
+    // MARK: - Reference rewriting
+
+    /// Rewrites entry, recipe-ingredient and supplement-ingredient references
+    /// to a food id (typed columns and the embedded ids inside `jsonData`).
+    static func remapFoodReferences(from oldId: String, to newId: String, in context: ModelContext) {
+        guard oldId != newId else { return }
+        let entryDescriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.foodId == oldId })
+        for row in (try? context.fetch(entryDescriptor)) ?? [] {
+            row.foodId = newId
+            if let entry = row.toEntry(),
+               let patched = try? JSONPatch.merged(Entry.self, base: entry, patch: ["foodId": newId])
+            {
+                row.jsonData = LocalStoreCoding.encode(patched)
+            }
+        }
+        for row in (try? context.fetch(FetchDescriptor<LocalRecipe>())) ?? [] {
+            if let patched = patchIngredientFoodIds(in: row.jsonData, from: oldId, to: newId) {
+                row.jsonData = patched
+            }
+        }
+        for row in (try? context.fetch(FetchDescriptor<LocalSupplement>())) ?? [] {
+            if let patched = patchIngredientFoodIds(in: row.jsonData, from: oldId, to: newId) {
+                row.jsonData = patched
+            }
+        }
+    }
+
+    static func remapRecipeReferences(from oldId: String, to newId: String, in context: ModelContext) {
+        guard oldId != newId else { return }
+        let descriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.recipeId == oldId })
+        for row in (try? context.fetch(descriptor)) ?? [] {
+            row.recipeId = newId
+            if let entry = row.toEntry(),
+               let patched = try? JSONPatch.merged(Entry.self, base: entry, patch: ["recipeId": newId])
+            {
+                row.jsonData = LocalStoreCoding.encode(patched)
+            }
+        }
+    }
+
+    /// Rewrites supplement-log rows to a new supplement id. The synthesized
+    /// log row id (`"<supplementId>-<date>"`) doubles as the uploaded-marker
+    /// during migration: it is only re-keyed during normalization
+    /// (`rekeyLogIds` true) or after the log itself was uploaded — NOT when
+    /// the owning supplement gets its server id, so a `temp_`-prefixed log id
+    /// still means "this log has not been uploaded yet".
+    static func remapSupplementReferences(
+        from oldId: String,
+        to newId: String,
+        rekeyLogIds: Bool,
+        in context: ModelContext
+    ) {
+        guard oldId != newId else { return }
+        let descriptor = FetchDescriptor<LocalSupplementLog>(predicate: #Predicate { $0.supplementId == oldId })
+        for row in (try? context.fetch(descriptor)) ?? [] {
+            let keptId = row.id
+            let date = row.date
+            let takenAt = row.takenAt
+            context.delete(row)
+            let replacement = LocalSupplementLog(supplementId: newId, date: date, takenAt: takenAt)
+            if !rekeyLogIds {
+                replacement.id = keptId
+            }
+            context.insert(replacement)
+        }
+    }
+
+    // MARK: - Upserts
+
+    static func upsertFood(_ food: Food, in context: ModelContext) {
+        if let row = foodRow(id: food.id, in: context) {
+            row.update(from: food)
+        } else {
+            context.insert(LocalFood(food: food))
+        }
+    }
+
+    static func upsertRecipe(_ recipe: Recipe, in context: ModelContext) {
+        if let row = recipeRow(id: recipe.id, in: context) {
+            row.update(from: recipe)
+        } else {
+            context.insert(LocalRecipe(recipe: recipe))
+        }
+    }
+
+    static func upsertEntry(_ entry: Entry, date: String, in context: ModelContext) {
+        if let row = entryRow(id: entry.id, in: context) {
+            row.update(from: entry, date: date)
+        } else {
+            context.insert(LocalEntry(entry: entry, date: date))
+        }
+    }
+
+    static func upsertWeight(_ entry: WeightEntry, in context: ModelContext) {
+        if let row = weightRow(id: entry.id, in: context) {
+            row.update(from: entry)
+        } else {
+            context.insert(LocalWeightEntry(entry: entry))
+        }
+    }
+
+    static func upsertSupplement(_ supplement: Supplement, in context: ModelContext) {
+        if let row = supplementRow(id: supplement.id, in: context) {
+            row.update(from: supplement)
+        } else {
+            context.insert(LocalSupplement(supplement: supplement))
+        }
+    }
+
+    // MARK: - Row lookups
+
+    static func foodRow(id: String, in context: ModelContext) -> LocalFood? {
+        var descriptor = FetchDescriptor<LocalFood>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    static func recipeRow(id: String, in context: ModelContext) -> LocalRecipe? {
+        var descriptor = FetchDescriptor<LocalRecipe>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    static func entryRow(id: String, in context: ModelContext) -> LocalEntry? {
+        var descriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    static func weightRow(id: String, in context: ModelContext) -> LocalWeightEntry? {
+        var descriptor = FetchDescriptor<LocalWeightEntry>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    static func supplementRow(id: String, in context: ModelContext) -> LocalSupplement? {
+        var descriptor = FetchDescriptor<LocalSupplement>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    // MARK: - JSON ingredient patching
+
+    /// Rewrites `ingredients[].foodId` (and the embedded `food.id`) inside an
+    /// encoded recipe/supplement payload. Returns nil when nothing referenced
+    /// the old id.
+    private static func patchIngredientFoodIds(in data: Data, from oldId: String, to newId: String) -> Data? {
+        guard var dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              var ingredients = dict["ingredients"] as? [[String: Any]]
+        else { return nil }
+
+        var changed = false
+        for index in ingredients.indices {
+            if ingredients[index]["foodId"] as? String == oldId {
+                ingredients[index]["foodId"] = newId
+                changed = true
+            }
+            if var food = ingredients[index]["food"] as? [String: Any], food["id"] as? String == oldId {
+                food["id"] = newId
+                ingredients[index]["food"] = food
+                changed = true
+            }
+        }
+        guard changed else { return nil }
+        dict["ingredients"] = ingredients
+        return try? JSONSerialization.data(withJSONObject: dict)
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalStore.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalStore.swift
@@ -20,6 +20,7 @@ enum LocalStore {
             LocalGoals.self,
             LocalPreferences.self,
             LocalDayProperties.self,
+            PendingSyncOperation.self,
         ])
     }
 

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalStore.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalStore.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftData
+
+/// Central schema and container factory for the local SwiftData store.
+///
+/// The default on-disk store lives in Application Support, which is included
+/// in iCloud Backup automatically — an explicit project goal. Tests use the
+/// in-memory variant.
+enum LocalStore {
+    /// Computed because `Schema` is not Sendable — a stored static would not be
+    /// concurrency-safe under Swift 6.
+    static var schema: Schema {
+        Schema([
+            LocalEntry.self,
+            LocalFood.self,
+            LocalRecipe.self,
+            LocalWeightEntry.self,
+            LocalSupplement.self,
+            LocalSupplementLog.self,
+            LocalGoals.self,
+            LocalPreferences.self,
+            LocalDayProperties.self,
+        ])
+    }
+
+    static func makeContainer(inMemory: Bool = false) throws -> ModelContainer {
+        let schema = schema
+        let configuration = if inMemory {
+            // Unique name so simultaneous in-memory containers (unit tests) stay isolated.
+            ModelConfiguration(UUID().uuidString, schema: schema, isStoredInMemoryOnly: true)
+        } else {
+            ModelConfiguration(schema: schema)
+        }
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    /// Client-generated id prefix for optimistic creates. The "temp_" prefix
+    /// matches the Android implementation so the future sync-queue package can
+    /// coalesce pending creates the same way on both platforms.
+    static let tempIdPrefix = "temp_"
+
+    static func makeTempId() -> String {
+        "\(tempIdPrefix)\(UUID().uuidString)"
+    }
+
+    static func isTempId(_ id: String) -> Bool {
+        id.hasPrefix(tempIdPrefix)
+    }
+}
+
+/// JSON helpers used by the repositories to derive one Codable value from
+/// another (e.g. a full `Food` from a `FoodCreate` plus an id) without
+/// hand-writing 60-field memberwise initializers.
+enum JSONPatch {
+    static func dictionary(of value: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from dictionary: [String: Any]) throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: dictionary)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    /// Overlays `patch` keys onto the encoded form of `base` and decodes the result.
+    static func merged<T: Decodable>(_ type: T.Type, base: some Encodable, patch: [String: Any]) throws -> T {
+        let combined = try dictionary(of: base).merging(patch) { _, new in new }
+        return try decode(type, from: combined)
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/PreferencesRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/PreferencesRepository.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for user preferences (singleton row). Updates merge
+/// the partial `PreferencesUpdate` onto the cached value locally before the
+/// API call, mirroring the Android repository.
+@MainActor
+@Observable
+final class PreferencesRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+
+    init(context: ModelContext, api: BissbilanzAPI) {
+        self.context = context
+        self.api = api
+    }
+
+    func preferences() -> Preferences? {
+        fetchRow()?.toPreferences()
+    }
+
+    func refresh() async throws {
+        let prefs = try await api.getPreferences()
+        upsert(prefs)
+        save()
+    }
+
+    @discardableResult
+    func update(_ update: PreferencesUpdate) async throws -> Preferences {
+        let current = preferences() ?? .defaults
+        let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+        let merged = (try? JSONPatch.merged(Preferences.self, base: current, patch: patch)) ?? current
+        upsert(merged)
+        save()
+        let server = try await api.updatePreferences(update)
+        upsert(server)
+        save()
+        return server
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow() -> LocalPreferences? {
+        let singletonId = LocalPreferences.singletonId
+        var descriptor = FetchDescriptor<LocalPreferences>(predicate: #Predicate { $0.id == singletonId })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ preferences: Preferences) {
+        if let row = fetchRow() {
+            row.update(from: preferences)
+        } else {
+            context.insert(LocalPreferences(preferences: preferences))
+        }
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/PreferencesRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/PreferencesRepository.swift
@@ -3,17 +3,21 @@ import Observation
 import SwiftData
 
 /// Local-first repository for user preferences (singleton row). Updates merge
-/// the partial `PreferencesUpdate` onto the cached value locally before the
-/// API call, mirroring the Android repository.
+/// the partial `PreferencesUpdate` onto the cached value locally and queue
+/// the patch via the sync manager, mirroring the Android repository.
 @MainActor
 @Observable
 final class PreferencesRepository {
     private let context: ModelContext
     private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
 
-    init(context: ModelContext, api: BissbilanzAPI) {
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
         self.context = context
         self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
     }
 
     func preferences() -> Preferences? {
@@ -21,6 +25,7 @@ final class PreferencesRepository {
     }
 
     func refresh() async throws {
+        guard !appMode.isLocal else { return }
         let prefs = try await api.getPreferences()
         upsert(prefs)
         save()
@@ -33,10 +38,8 @@ final class PreferencesRepository {
         let merged = (try? JSONPatch.merged(Preferences.self, base: current, patch: patch)) ?? current
         upsert(merged)
         save()
-        let server = try await api.updatePreferences(update)
-        upsert(server)
-        save()
-        return server
+        syncManager.enqueue(.updatePreferences(body: update))
+        return merged
     }
 
     // MARK: - Store helpers

--- a/mobile/iosApp/Bissbilanz/Persistence/RecipeRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/RecipeRepository.swift
@@ -4,9 +4,11 @@ import SwiftData
 
 /// Local-first repository for recipes. List/detail reads come from SwiftData;
 /// `refresh()` upserts the server list by id (Android parity). Writes are
-/// SwiftData-first with the upload queued via the sync manager; macros stay
-/// nil on optimistic rows because they are computed server-side. In Local
-/// mode nothing is queued and refreshes are no-ops.
+/// SwiftData-first with the upload queued via the sync manager; optimistic
+/// rows carry macros computed from the ingredient foods in the local store
+/// (replicating the server's aggregation, which replaces them on refresh in
+/// Synced mode). In Local mode nothing is queued and refreshes are no-ops —
+/// the locally computed macros are authoritative.
 @MainActor
 @Observable
 final class RecipeRepository {
@@ -82,11 +84,17 @@ final class RecipeRepository {
     func updateRecipe(id: String, _ update: RecipeUpdate) async throws -> Recipe {
         var optimistic: Recipe?
         if let row = fetchRow(id: id), let existing = row.toRecipe() {
-            // Scalar fields only — update ingredients are inputs, not the
-            // full resolved shape; a refresh replaces them server-side.
             var patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
             patch.removeValue(forKey: "ingredients")
-            let updated = (try? JSONPatch.merged(Recipe.self, base: existing, patch: patch)) ?? existing
+            var updated = (try? JSONPatch.merged(Recipe.self, base: existing, patch: patch)) ?? existing
+            // Ingredient edits apply to the local row in BOTH modes (in Local
+            // mode there is no server to reconcile from; in Synced mode the
+            // refresh replaces this with the resolved server shape). Macros
+            // are recomputed from the local food store.
+            if let inputs = update.ingredients {
+                let ingredients = resolvedIngredients(inputs, recipeId: id)
+                updated = Self.applying(ingredients: ingredients, to: updated)
+            }
             row.update(from: updated)
             save()
             optimistic = updated
@@ -128,17 +136,8 @@ final class RecipeRepository {
     // MARK: - Conversion helpers
 
     private func makeRecipe(from create: RecipeCreate, id: String) -> Recipe {
-        let ingredients = create.ingredients.enumerated().map { index, input in
-            RecipeIngredient(
-                id: nil,
-                recipeId: id,
-                foodId: input.foodId,
-                quantity: input.quantity,
-                servingUnit: input.servingUnit,
-                sortOrder: index,
-                food: localFood(id: input.foodId)
-            )
-        }
+        let ingredients = resolvedIngredients(create.ingredients, recipeId: id)
+        let macros = Self.recipeMacros(of: ingredients)
         return Recipe(
             id: id,
             userId: "",
@@ -146,13 +145,70 @@ final class RecipeRepository {
             totalServings: create.totalServings,
             isFavorite: create.isFavorite ?? false,
             imageUrl: create.imageUrl,
-            calories: nil,
-            protein: nil,
-            carbs: nil,
-            fat: nil,
-            fiber: nil,
+            calories: macros.calories,
+            protein: macros.protein,
+            carbs: macros.carbs,
+            fat: macros.fat,
+            fiber: macros.fiber,
             createdAt: ISO8601DateFormatter().string(from: Date()),
             updatedAt: nil,
+            ingredients: ingredients
+        )
+    }
+
+    /// Ingredient inputs resolved against the local food store.
+    private func resolvedIngredients(_ inputs: [RecipeIngredientInput], recipeId: String) -> [RecipeIngredient] {
+        inputs.enumerated().map { index, input in
+            RecipeIngredient(
+                id: nil,
+                recipeId: recipeId,
+                foodId: input.foodId,
+                quantity: input.quantity,
+                servingUnit: input.servingUnit,
+                sortOrder: index,
+                food: localFood(id: input.foodId)
+            )
+        }
+    }
+
+    /// Whole-recipe macro totals, replicating the server aggregation in
+    /// `src/lib/server/recipes.ts`: each ingredient contributes
+    /// `food.macro * quantity / food.servingSize`; unresolved foods contribute
+    /// nothing. Per-serving division happens at entry creation
+    /// (`EntryRepository.makeEntry`), matching the server's entry shape.
+    static func recipeMacros(
+        of ingredients: [RecipeIngredient]
+    ) -> (calories: Double, protein: Double, carbs: Double, fat: Double, fiber: Double) {
+        var totals = (calories: 0.0, protein: 0.0, carbs: 0.0, fat: 0.0, fiber: 0.0)
+        for ingredient in ingredients {
+            guard let food = ingredient.food, food.servingSize > 0 else { continue }
+            let factor = ingredient.quantity / food.servingSize
+            totals.calories += food.calories * factor
+            totals.protein += food.protein * factor
+            totals.carbs += food.carbs * factor
+            totals.fat += food.fat * factor
+            totals.fiber += food.fiber * factor
+        }
+        return totals
+    }
+
+    /// Copy of `recipe` with `ingredients` swapped in and macros recomputed.
+    private static func applying(ingredients: [RecipeIngredient], to recipe: Recipe) -> Recipe {
+        let macros = recipeMacros(of: ingredients)
+        return Recipe(
+            id: recipe.id,
+            userId: recipe.userId,
+            name: recipe.name,
+            totalServings: recipe.totalServings,
+            isFavorite: recipe.isFavorite,
+            imageUrl: recipe.imageUrl,
+            calories: macros.calories,
+            protein: macros.protein,
+            carbs: macros.carbs,
+            fat: macros.fat,
+            fiber: macros.fiber,
+            createdAt: recipe.createdAt,
+            updatedAt: recipe.updatedAt,
             ingredients: ingredients
         )
     }

--- a/mobile/iosApp/Bissbilanz/Persistence/RecipeRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/RecipeRepository.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for recipes. List/detail reads come from SwiftData;
+/// `refresh()` upserts the server list by id (Android parity). Writes are
+/// optimistic with temp ids replaced by the server record; macros stay nil on
+/// optimistic rows because they are computed server-side.
+@MainActor
+@Observable
+final class RecipeRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+
+    init(context: ModelContext, api: BissbilanzAPI) {
+        self.context = context
+        self.api = api
+    }
+
+    // MARK: - Reads (local)
+
+    func recipes() -> [Recipe] {
+        let descriptor = FetchDescriptor<LocalRecipe>(sortBy: [SortDescriptor(\.name)])
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toRecipe() }
+    }
+
+    func favoriteRecipes() -> [Recipe] {
+        let descriptor = FetchDescriptor<LocalRecipe>(
+            predicate: #Predicate { $0.isFavorite },
+            sortBy: [SortDescriptor(\.name)]
+        )
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toRecipe() }
+    }
+
+    func recipe(id: String) -> Recipe? {
+        fetchRow(id: id)?.toRecipe()
+    }
+
+    // MARK: - Refresh (API → store)
+
+    func refresh() async throws {
+        let fetched = try await api.getRecipes()
+        let serverIds = Set(fetched.map(\.id))
+        // The list endpoint is the complete set — drop rows deleted elsewhere
+        // (keeping optimistic temp rows the server doesn't know about yet).
+        for stale in recipes() where !serverIds.contains(stale.id) && !LocalStore.isTempId(stale.id) {
+            deleteRow(id: stale.id)
+        }
+        for recipe in fetched {
+            upsert(recipe)
+        }
+        save()
+    }
+
+    func refreshRecipe(id: String) async throws {
+        guard !LocalStore.isTempId(id) else { return }
+        let recipe = try await api.getRecipe(id: id)
+        upsert(recipe)
+        save()
+    }
+
+    // MARK: - Writes (local first, then API)
+
+    @discardableResult
+    func createRecipe(_ create: RecipeCreate) async throws -> Recipe {
+        let temp = makeRecipe(from: create, id: LocalStore.makeTempId())
+        upsert(temp)
+        save()
+        let server = try await api.createRecipe(create)
+        deleteRow(id: temp.id)
+        upsert(server)
+        save()
+        return server
+    }
+
+    @discardableResult
+    func updateRecipe(id: String, _ update: RecipeUpdate) async throws -> Recipe {
+        var optimistic: Recipe?
+        if let row = fetchRow(id: id), let existing = row.toRecipe() {
+            // Scalar fields only — update ingredients are inputs, not the
+            // full resolved shape; the server response replaces them below.
+            var patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            patch.removeValue(forKey: "ingredients")
+            let updated = (try? JSONPatch.merged(Recipe.self, base: existing, patch: patch)) ?? existing
+            row.update(from: updated)
+            save()
+            optimistic = updated
+        }
+        if LocalStore.isTempId(id), let optimistic {
+            return optimistic
+        }
+        let server = try await api.updateRecipe(id: id, update)
+        upsert(server)
+        save()
+        return server
+    }
+
+    func deleteRecipe(id: String) async throws {
+        deleteRow(id: id)
+        save()
+        guard !LocalStore.isTempId(id) else { return }
+        try await api.deleteRecipe(id: id)
+    }
+
+    // MARK: - Conversion helpers
+
+    private func makeRecipe(from create: RecipeCreate, id: String) -> Recipe {
+        let ingredients = create.ingredients.enumerated().map { index, input in
+            RecipeIngredient(
+                id: nil,
+                recipeId: id,
+                foodId: input.foodId,
+                quantity: input.quantity,
+                servingUnit: input.servingUnit,
+                sortOrder: index,
+                food: localFood(id: input.foodId)
+            )
+        }
+        return Recipe(
+            id: id,
+            userId: "",
+            name: create.name,
+            totalServings: create.totalServings,
+            isFavorite: create.isFavorite ?? false,
+            imageUrl: create.imageUrl,
+            calories: nil,
+            protein: nil,
+            carbs: nil,
+            fat: nil,
+            fiber: nil,
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            updatedAt: nil,
+            ingredients: ingredients
+        )
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow(id: String) -> LocalRecipe? {
+        var descriptor = FetchDescriptor<LocalRecipe>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ recipe: Recipe) {
+        if let row = fetchRow(id: recipe.id) {
+            row.update(from: recipe)
+        } else {
+            context.insert(LocalRecipe(recipe: recipe))
+        }
+    }
+
+    private func deleteRow(id: String) {
+        if let row = fetchRow(id: id) {
+            context.delete(row)
+        }
+    }
+
+    private func localFood(id: String) -> Food? {
+        var descriptor = FetchDescriptor<LocalFood>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first?.toFood()
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/RecipeRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/RecipeRepository.swift
@@ -4,17 +4,22 @@ import SwiftData
 
 /// Local-first repository for recipes. List/detail reads come from SwiftData;
 /// `refresh()` upserts the server list by id (Android parity). Writes are
-/// optimistic with temp ids replaced by the server record; macros stay nil on
-/// optimistic rows because they are computed server-side.
+/// SwiftData-first with the upload queued via the sync manager; macros stay
+/// nil on optimistic rows because they are computed server-side. In Local
+/// mode nothing is queued and refreshes are no-ops.
 @MainActor
 @Observable
 final class RecipeRepository {
     private let context: ModelContext
     private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
 
-    init(context: ModelContext, api: BissbilanzAPI) {
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
         self.context = context
         self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
     }
 
     // MARK: - Reads (local)
@@ -41,6 +46,7 @@ final class RecipeRepository {
     // MARK: - Refresh (API → store)
 
     func refresh() async throws {
+        guard !appMode.isLocal else { return }
         let fetched = try await api.getRecipes()
         let serverIds = Set(fetched.map(\.id))
         // The list endpoint is the complete set — drop rows deleted elsewhere
@@ -55,24 +61,21 @@ final class RecipeRepository {
     }
 
     func refreshRecipe(id: String) async throws {
-        guard !LocalStore.isTempId(id) else { return }
+        guard !appMode.isLocal, !LocalStore.isTempId(id) else { return }
         let recipe = try await api.getRecipe(id: id)
         upsert(recipe)
         save()
     }
 
-    // MARK: - Writes (local first, then API)
+    // MARK: - Writes (local first + queued upload)
 
     @discardableResult
     func createRecipe(_ create: RecipeCreate) async throws -> Recipe {
         let temp = makeRecipe(from: create, id: LocalStore.makeTempId())
         upsert(temp)
         save()
-        let server = try await api.createRecipe(create)
-        deleteRow(id: temp.id)
-        upsert(server)
-        save()
-        return server
+        syncManager.enqueue(.createRecipe(body: create, localId: temp.id))
+        return temp
     }
 
     @discardableResult
@@ -80,7 +83,7 @@ final class RecipeRepository {
         var optimistic: Recipe?
         if let row = fetchRow(id: id), let existing = row.toRecipe() {
             // Scalar fields only — update ingredients are inputs, not the
-            // full resolved shape; the server response replaces them below.
+            // full resolved shape; a refresh replaces them server-side.
             var patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
             patch.removeValue(forKey: "ingredients")
             let updated = (try? JSONPatch.merged(Recipe.self, base: existing, patch: patch)) ?? existing
@@ -88,20 +91,38 @@ final class RecipeRepository {
             save()
             optimistic = updated
         }
-        if LocalStore.isTempId(id), let optimistic {
+        if LocalStore.isTempId(id) {
+            coalesceQueuedCreate(tempId: id, update: update)
+        } else {
+            syncManager.enqueue(.updateRecipe(id: id, body: update))
+        }
+        if let optimistic {
             return optimistic
         }
-        let server = try await api.updateRecipe(id: id, update)
-        upsert(server)
-        save()
-        return server
+        throw APIError.notFound
     }
 
     func deleteRecipe(id: String) async throws {
         deleteRow(id: id)
         save()
-        guard !LocalStore.isTempId(id) else { return }
-        try await api.deleteRecipe(id: id)
+        if LocalStore.isTempId(id) {
+            syncManager.removeQueued(table: "recipes", affectedId: id)
+        } else {
+            syncManager.enqueue(.deleteRecipe(id: id))
+        }
+    }
+
+    /// Rewrites the still-queued create for a temp-id recipe so the eventual
+    /// upload carries the edited values.
+    private func coalesceQueuedCreate(tempId: String, update: RecipeUpdate) {
+        for row in syncManager.queuedOperations(table: "recipes", affectedId: tempId) {
+            guard let operation = row.operation(),
+                  case let .createRecipe(body, localId) = operation
+            else { continue }
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let merged = (try? JSONPatch.merged(RecipeCreate.self, base: body, patch: patch)) ?? body
+            syncManager.replace(row, with: .createRecipe(body: merged, localId: localId))
+        }
     }
 
     // MARK: - Conversion helpers
@@ -159,9 +180,7 @@ final class RecipeRepository {
     }
 
     private func localFood(id: String) -> Food? {
-        var descriptor = FetchDescriptor<LocalFood>(predicate: #Predicate { $0.id == id })
-        descriptor.fetchLimit = 1
-        return (try? context.fetch(descriptor))?.first?.toFood()
+        LocalRemap.foodRow(id: id, in: context)?.toFood()
     }
 
     private func save() {

--- a/mobile/iosApp/Bissbilanz/Persistence/SupplementRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/SupplementRepository.swift
@@ -8,16 +8,22 @@ import SwiftData
 /// checklist is server-computed (schedule logic lives there); a local
 /// approximation (active supplements + logged state) renders instantly and
 /// `refreshChecklist` returns the authoritative server result while caching
-/// the taken-logs for the day.
+/// the taken-logs for the day. Writes are SwiftData-first with the upload
+/// queued via the sync manager; deleting a still-queued temp supplement also
+/// removes its queued logs (they share the affected table/id).
 @MainActor
 @Observable
 final class SupplementRepository {
     private let context: ModelContext
     private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
 
-    init(context: ModelContext, api: BissbilanzAPI) {
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
         self.context = context
         self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
     }
 
     // MARK: - Reads (local)
@@ -51,6 +57,7 @@ final class SupplementRepository {
     // MARK: - Refresh (API → store)
 
     func refresh() async throws {
+        guard !appMode.isLocal else { return }
         let fetched = try await api.getSupplements()
         // The list endpoint returns the complete set — replace wholesale
         // (mirrors Android's getAllSupplements), keeping optimistic temp rows.
@@ -66,6 +73,7 @@ final class SupplementRepository {
 
     @discardableResult
     func refreshChecklist(date: String) async throws -> [SupplementChecklist] {
+        guard !appMode.isLocal else { return localChecklist(date: date) }
         let checklist = try await api.getSupplementChecklist(date: date)
         try? context.delete(model: LocalSupplementLog.self, where: #Predicate { $0.date == date })
         for item in checklist where item.taken {
@@ -79,8 +87,9 @@ final class SupplementRepository {
         return checklist
     }
 
-    /// History is server-computed; the cached logs answer when offline.
+    /// History is server-computed; the cached logs answer offline and in Local mode.
     func history(startDate: String, endDate: String) async -> [SupplementHistoryItem] {
+        guard !appMode.isLocal else { return localHistory(startDate: startDate, endDate: endDate) }
         do {
             return try await api.getSupplementHistory(startDate: startDate, endDate: endDate)
         } catch {
@@ -105,7 +114,7 @@ final class SupplementRepository {
         }
     }
 
-    // MARK: - Writes (local first, then API)
+    // MARK: - Writes (local first + queued upload)
 
     func logSupplement(id: String, date: String) async throws {
         upsertLog(SupplementLog(
@@ -115,17 +124,23 @@ final class SupplementRepository {
             entryIds: []
         ))
         save()
-        guard !LocalStore.isTempId(id) else { return }
-        let log = try await api.logSupplement(id: id, date: date)
-        upsertLog(log)
-        save()
+        syncManager.enqueue(.logSupplement(supplementId: id, date: date))
     }
 
     func unlogSupplement(id: String, date: String) async throws {
         deleteLog(supplementId: id, date: date)
         save()
-        guard !LocalStore.isTempId(id) else { return }
-        try await api.unlogSupplement(id: id, date: date)
+        if LocalStore.isTempId(id) {
+            // The supplement isn't on the server — cancel the queued log instead.
+            for row in syncManager.queuedOperations(table: "supplements", affectedId: id) {
+                guard let operation = row.operation(),
+                      case let .logSupplement(_, queuedDate) = operation, queuedDate == date
+                else { continue }
+                syncManager.remove(row)
+            }
+        } else {
+            syncManager.enqueue(.unlogSupplement(supplementId: id, date: date))
+        }
     }
 
     @discardableResult
@@ -133,11 +148,8 @@ final class SupplementRepository {
         let temp = makeSupplement(from: create, id: LocalStore.makeTempId())
         upsert(temp)
         save()
-        let server = try await api.createSupplement(create)
-        deleteRow(id: temp.id)
-        upsert(server)
-        save()
-        return server
+        syncManager.enqueue(.createSupplement(body: create, localId: temp.id))
+        return temp
     }
 
     @discardableResult
@@ -145,7 +157,7 @@ final class SupplementRepository {
         var optimistic: Supplement?
         if let row = fetchRow(id: id), let existing = row.toSupplement() {
             // Scalar fields only — update ingredients are inputs, not the
-            // full resolved shape; the server response replaces them below.
+            // full resolved shape; a refresh replaces them server-side.
             var patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
             patch.removeValue(forKey: "ingredients")
             let updated = (try? JSONPatch.merged(Supplement.self, base: existing, patch: patch)) ?? existing
@@ -153,20 +165,40 @@ final class SupplementRepository {
             save()
             optimistic = updated
         }
-        if LocalStore.isTempId(id), let optimistic {
+        if LocalStore.isTempId(id) {
+            coalesceQueuedCreate(tempId: id, update: update)
+        } else {
+            syncManager.enqueue(.updateSupplement(id: id, body: update))
+        }
+        if let optimistic {
             return optimistic
         }
-        let server = try await api.updateSupplement(id: id, update)
-        upsert(server)
-        save()
-        return server
+        throw APIError.notFound
     }
 
     func deleteSupplement(id: String) async throws {
         deleteRow(id: id)
         save()
-        guard !LocalStore.isTempId(id) else { return }
-        try await api.deleteSupplement(id: id)
+        if LocalStore.isTempId(id) {
+            // Removes the queued create AND any queued logs for this
+            // supplement — they share affectedTable/affectedId.
+            syncManager.removeQueued(table: "supplements", affectedId: id)
+        } else {
+            syncManager.enqueue(.deleteSupplement(id: id))
+        }
+    }
+
+    /// Rewrites the still-queued create for a temp-id supplement so the
+    /// eventual upload carries the edited values.
+    private func coalesceQueuedCreate(tempId: String, update: SupplementUpdate) {
+        for row in syncManager.queuedOperations(table: "supplements", affectedId: tempId) {
+            guard let operation = row.operation(),
+                  case let .createSupplement(body, localId) = operation
+            else { continue }
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let merged = (try? JSONPatch.merged(SupplementCreate.self, base: body, patch: patch)) ?? body
+            syncManager.replace(row, with: .createSupplement(body: merged, localId: localId))
+        }
     }
 
     // MARK: - Conversion helpers

--- a/mobile/iosApp/Bissbilanz/Persistence/SupplementRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/SupplementRepository.swift
@@ -156,11 +156,18 @@ final class SupplementRepository {
     func updateSupplement(id: String, _ update: SupplementUpdate) async throws -> Supplement {
         var optimistic: Supplement?
         if let row = fetchRow(id: id), let existing = row.toSupplement() {
-            // Scalar fields only — update ingredients are inputs, not the
-            // full resolved shape; a refresh replaces them server-side.
             var patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
             patch.removeValue(forKey: "ingredients")
-            let updated = (try? JSONPatch.merged(Supplement.self, base: existing, patch: patch)) ?? existing
+            var updated = (try? JSONPatch.merged(Supplement.self, base: existing, patch: patch)) ?? existing
+            // Ingredient edits apply to the local row in BOTH modes (in Local
+            // mode there is no server to reconcile from; in Synced mode the
+            // refresh replaces this with the resolved server shape).
+            if let inputs = update.ingredients {
+                updated = Self.applying(
+                    ingredients: resolvedIngredients(inputs, supplementId: id),
+                    to: updated
+                )
+            }
             row.update(from: updated)
             save()
             optimistic = updated
@@ -216,7 +223,83 @@ final class SupplementRepository {
             timeOfDay: create.timeOfDay,
             createdAt: ISO8601DateFormatter().string(from: Date()),
             updatedAt: nil,
-            ingredients: []
+            ingredients: resolvedIngredients(create.ingredients, supplementId: id)
+        )
+    }
+
+    /// Materializes ingredient inputs for the local row: referenced foods are
+    /// resolved from the local store, inline backing-food payloads (the
+    /// supplement editor's shape, normally materialized server-side) become
+    /// synthetic temp-id backing foods. Unresolvable inputs are dropped from
+    /// the local row (the queued upload still carries them).
+    private func resolvedIngredients(
+        _ inputs: [SupplementIngredientInput],
+        supplementId: String
+    ) -> [SupplementIngredient] {
+        inputs.enumerated().compactMap { index, input in
+            let foodId: String
+            let backing: SupplementBackingFood
+            if let id = input.foodId, let food = LocalRemap.foodRow(id: id, in: context)?.toFood() {
+                foodId = id
+                backing = SupplementBackingFood(
+                    id: food.id,
+                    name: food.name,
+                    brand: food.brand,
+                    kind: .food,
+                    servingSize: food.servingSize,
+                    servingUnit: food.servingUnit.rawValue,
+                    calories: food.calories,
+                    protein: food.protein,
+                    carbs: food.carbs,
+                    fat: food.fat,
+                    fiber: food.fiber,
+                    ingredientsText: food.ingredientsText
+                )
+            } else if let inline = input.food {
+                foodId = input.foodId ?? LocalStore.makeTempId()
+                backing = SupplementBackingFood(
+                    id: foodId,
+                    name: inline.name,
+                    brand: nil,
+                    kind: .supplement,
+                    servingSize: inline.servingSize,
+                    servingUnit: inline.servingUnit,
+                    calories: inline.calories,
+                    protein: inline.protein,
+                    carbs: inline.carbs,
+                    fat: inline.fat,
+                    fiber: inline.fiber,
+                    ingredientsText: inline.ingredientsText
+                )
+            } else {
+                return nil
+            }
+            return SupplementIngredient(
+                id: LocalStore.makeTempId(),
+                supplementId: supplementId,
+                foodId: foodId,
+                servings: input.servings ?? 1,
+                sortOrder: input.sortOrder ?? index,
+                food: backing
+            )
+        }
+    }
+
+    /// Copy of `supplement` with `ingredients` swapped in.
+    private static func applying(ingredients: [SupplementIngredient], to supplement: Supplement) -> Supplement {
+        Supplement(
+            id: supplement.id,
+            userId: supplement.userId,
+            name: supplement.name,
+            scheduleType: supplement.scheduleType,
+            scheduleDays: supplement.scheduleDays,
+            scheduleStartDate: supplement.scheduleStartDate,
+            isActive: supplement.isActive,
+            sortOrder: supplement.sortOrder,
+            timeOfDay: supplement.timeOfDay,
+            createdAt: supplement.createdAt,
+            updatedAt: supplement.updatedAt,
+            ingredients: ingredients
         )
     }
 

--- a/mobile/iosApp/Bissbilanz/Persistence/SupplementRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/SupplementRepository.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for supplements and taken-logs.
+///
+/// The supplement list and per-day logged ids come from SwiftData. The due
+/// checklist is server-computed (schedule logic lives there); a local
+/// approximation (active supplements + logged state) renders instantly and
+/// `refreshChecklist` returns the authoritative server result while caching
+/// the taken-logs for the day.
+@MainActor
+@Observable
+final class SupplementRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+
+    init(context: ModelContext, api: BissbilanzAPI) {
+        self.context = context
+        self.api = api
+    }
+
+    // MARK: - Reads (local)
+
+    func supplements() -> [Supplement] {
+        let descriptor = FetchDescriptor<LocalSupplement>(sortBy: [SortDescriptor(\.sortOrder)])
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toSupplement() }
+    }
+
+    func loggedSupplementIds(date: String) -> Set<String> {
+        let descriptor = FetchDescriptor<LocalSupplementLog>(predicate: #Predicate { $0.date == date })
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return Set(rows.map(\.supplementId))
+    }
+
+    /// Local approximation of the server checklist: all active supplements
+    /// with taken state from the cached logs (no schedule filtering).
+    func localChecklist(date: String) -> [SupplementChecklist] {
+        let logs = fetchLogs(date: date)
+        let takenAtById = Dictionary(uniqueKeysWithValues: logs.map { ($0.supplementId, $0.takenAt) })
+        return supplements().filter(\.isActive).map { supplement in
+            SupplementChecklist(
+                supplement: supplement,
+                taken: takenAtById[supplement.id] != nil,
+                takenAt: takenAtById[supplement.id]
+            )
+        }
+    }
+
+    // MARK: - Refresh (API → store)
+
+    func refresh() async throws {
+        let fetched = try await api.getSupplements()
+        // The list endpoint returns the complete set — replace wholesale
+        // (mirrors Android's getAllSupplements), keeping optimistic temp rows.
+        let serverIds = Set(fetched.map(\.id))
+        for stale in supplements() where !serverIds.contains(stale.id) && !LocalStore.isTempId(stale.id) {
+            deleteRow(id: stale.id)
+        }
+        for supplement in fetched {
+            upsert(supplement)
+        }
+        save()
+    }
+
+    @discardableResult
+    func refreshChecklist(date: String) async throws -> [SupplementChecklist] {
+        let checklist = try await api.getSupplementChecklist(date: date)
+        try? context.delete(model: LocalSupplementLog.self, where: #Predicate { $0.date == date })
+        for item in checklist where item.taken {
+            context.insert(LocalSupplementLog(
+                supplementId: item.supplement.id,
+                date: date,
+                takenAt: item.takenAt ?? ISO8601DateFormatter().string(from: Date())
+            ))
+        }
+        save()
+        return checklist
+    }
+
+    /// History is server-computed; the cached logs answer when offline.
+    func history(startDate: String, endDate: String) async -> [SupplementHistoryItem] {
+        do {
+            return try await api.getSupplementHistory(startDate: startDate, endDate: endDate)
+        } catch {
+            return localHistory(startDate: startDate, endDate: endDate)
+        }
+    }
+
+    func localHistory(startDate: String, endDate: String) -> [SupplementHistoryItem] {
+        let descriptor = FetchDescriptor<LocalSupplementLog>(
+            predicate: #Predicate { $0.date >= startDate && $0.date <= endDate },
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+        let logs = (try? context.fetch(descriptor)) ?? []
+        let namesById = Dictionary(uniqueKeysWithValues: supplements().map { ($0.id, $0.name) })
+        return logs.map { log in
+            SupplementHistoryItem(
+                supplementId: log.supplementId,
+                supplementName: namesById[log.supplementId] ?? "",
+                date: log.date,
+                takenAt: log.takenAt
+            )
+        }
+    }
+
+    // MARK: - Writes (local first, then API)
+
+    func logSupplement(id: String, date: String) async throws {
+        upsertLog(SupplementLog(
+            supplementId: id,
+            date: date,
+            takenAt: ISO8601DateFormatter().string(from: Date()),
+            entryIds: []
+        ))
+        save()
+        guard !LocalStore.isTempId(id) else { return }
+        let log = try await api.logSupplement(id: id, date: date)
+        upsertLog(log)
+        save()
+    }
+
+    func unlogSupplement(id: String, date: String) async throws {
+        deleteLog(supplementId: id, date: date)
+        save()
+        guard !LocalStore.isTempId(id) else { return }
+        try await api.unlogSupplement(id: id, date: date)
+    }
+
+    @discardableResult
+    func createSupplement(_ create: SupplementCreate) async throws -> Supplement {
+        let temp = makeSupplement(from: create, id: LocalStore.makeTempId())
+        upsert(temp)
+        save()
+        let server = try await api.createSupplement(create)
+        deleteRow(id: temp.id)
+        upsert(server)
+        save()
+        return server
+    }
+
+    @discardableResult
+    func updateSupplement(id: String, _ update: SupplementUpdate) async throws -> Supplement {
+        var optimistic: Supplement?
+        if let row = fetchRow(id: id), let existing = row.toSupplement() {
+            // Scalar fields only — update ingredients are inputs, not the
+            // full resolved shape; the server response replaces them below.
+            var patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            patch.removeValue(forKey: "ingredients")
+            let updated = (try? JSONPatch.merged(Supplement.self, base: existing, patch: patch)) ?? existing
+            row.update(from: updated)
+            save()
+            optimistic = updated
+        }
+        if LocalStore.isTempId(id), let optimistic {
+            return optimistic
+        }
+        let server = try await api.updateSupplement(id: id, update)
+        upsert(server)
+        save()
+        return server
+    }
+
+    func deleteSupplement(id: String) async throws {
+        deleteRow(id: id)
+        save()
+        guard !LocalStore.isTempId(id) else { return }
+        try await api.deleteSupplement(id: id)
+    }
+
+    // MARK: - Conversion helpers
+
+    private func makeSupplement(from create: SupplementCreate, id: String) -> Supplement {
+        Supplement(
+            id: id,
+            userId: "",
+            name: create.name,
+            scheduleType: create.scheduleType,
+            scheduleDays: create.scheduleDays,
+            scheduleStartDate: create.scheduleStartDate,
+            isActive: create.isActive ?? true,
+            sortOrder: create.sortOrder ?? 0,
+            timeOfDay: create.timeOfDay,
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            updatedAt: nil,
+            ingredients: []
+        )
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow(id: String) -> LocalSupplement? {
+        var descriptor = FetchDescriptor<LocalSupplement>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ supplement: Supplement) {
+        if let row = fetchRow(id: supplement.id) {
+            row.update(from: supplement)
+        } else {
+            context.insert(LocalSupplement(supplement: supplement))
+        }
+    }
+
+    private func deleteRow(id: String) {
+        if let row = fetchRow(id: id) {
+            context.delete(row)
+        }
+        // Logs for a removed supplement are orphaned — drop them too.
+        try? context.delete(model: LocalSupplementLog.self, where: #Predicate { $0.supplementId == id })
+    }
+
+    private func fetchLogs(date: String) -> [LocalSupplementLog] {
+        let descriptor = FetchDescriptor<LocalSupplementLog>(predicate: #Predicate { $0.date == date })
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func upsertLog(_ log: SupplementLog) {
+        let key = LocalSupplementLog.key(supplementId: log.supplementId, date: log.date)
+        var descriptor = FetchDescriptor<LocalSupplementLog>(predicate: #Predicate { $0.id == key })
+        descriptor.fetchLimit = 1
+        if let row = (try? context.fetch(descriptor))?.first {
+            row.update(from: log)
+        } else {
+            context.insert(LocalSupplementLog(log: log))
+        }
+    }
+
+    private func deleteLog(supplementId: String, date: String) {
+        let key = LocalSupplementLog.key(supplementId: supplementId, date: date)
+        try? context.delete(model: LocalSupplementLog.self, where: #Predicate { $0.id == key })
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/WeightRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/WeightRepository.swift
@@ -4,17 +4,22 @@ import SwiftData
 
 /// Local-first repository for weight entries. Reads come from SwiftData
 /// (sorted by entry date, newest first); `refresh()` upserts the server list
-/// by id and drops rows deleted elsewhere. Server-computed weight stats stay
-/// on the direct API in the views.
+/// by id and drops rows deleted elsewhere. Writes are SwiftData-first with
+/// the upload queued via the sync manager. Server-computed weight stats stay
+/// on the direct API in the views (hidden in Local mode).
 @MainActor
 @Observable
 final class WeightRepository {
     private let context: ModelContext
     private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
 
-    init(context: ModelContext, api: BissbilanzAPI) {
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
         self.context = context
         self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
     }
 
     // MARK: - Reads (local)
@@ -38,6 +43,7 @@ final class WeightRepository {
     // MARK: - Refresh (API → store)
 
     func refresh() async throws {
+        guard !appMode.isLocal else { return }
         let fetched = try await api.getWeightEntries()
         let serverIds = Set(fetched.map(\.id))
         for stale in entries() where !serverIds.contains(stale.id) && !LocalStore.isTempId(stale.id) {
@@ -49,18 +55,15 @@ final class WeightRepository {
         save()
     }
 
-    // MARK: - Writes (local first, then API)
+    // MARK: - Writes (local first + queued upload)
 
     @discardableResult
     func createEntry(_ create: WeightCreate) async throws -> WeightEntry {
         let temp = makeEntry(from: create, id: LocalStore.makeTempId())
         upsert(temp)
         save()
-        let server = try await api.createWeightEntry(create)
-        deleteRow(id: temp.id)
-        upsert(server)
-        save()
-        return server
+        syncManager.enqueue(.createWeight(body: create, localId: temp.id))
+        return temp
     }
 
     @discardableResult
@@ -73,20 +76,38 @@ final class WeightRepository {
             save()
             optimistic = updated
         }
-        if LocalStore.isTempId(id), let optimistic {
+        if LocalStore.isTempId(id) {
+            coalesceQueuedCreate(tempId: id, update: update)
+        } else {
+            syncManager.enqueue(.updateWeight(id: id, body: update))
+        }
+        if let optimistic {
             return optimistic
         }
-        let server = try await api.updateWeightEntry(id: id, update)
-        upsert(server)
-        save()
-        return server
+        throw APIError.notFound
     }
 
     func deleteEntry(id: String) async throws {
         deleteRow(id: id)
         save()
-        guard !LocalStore.isTempId(id) else { return }
-        try await api.deleteWeightEntry(id: id)
+        if LocalStore.isTempId(id) {
+            syncManager.removeQueued(table: "weight", affectedId: id)
+        } else {
+            syncManager.enqueue(.deleteWeight(id: id))
+        }
+    }
+
+    /// Rewrites the still-queued create for a temp-id weight entry so the
+    /// eventual upload carries the edited values.
+    private func coalesceQueuedCreate(tempId: String, update: WeightUpdate) {
+        for row in syncManager.queuedOperations(table: "weight", affectedId: tempId) {
+            guard let operation = row.operation(),
+                  case let .createWeight(body, localId) = operation
+            else { continue }
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let merged = (try? JSONPatch.merged(WeightCreate.self, base: body, patch: patch)) ?? body
+            syncManager.replace(row, with: .createWeight(body: merged, localId: localId))
+        }
     }
 
     // MARK: - Conversion helpers

--- a/mobile/iosApp/Bissbilanz/Persistence/WeightRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/WeightRepository.swift
@@ -32,6 +32,17 @@ final class WeightRepository {
         return rows.compactMap { $0.toWeightEntry() }
     }
 
+    /// One page of entries, newest first — backs the paginated history list.
+    func entries(offset: Int, limit: Int) -> [WeightEntry] {
+        var descriptor = FetchDescriptor<LocalWeightEntry>(sortBy: [
+            SortDescriptor(\.entryDate, order: .reverse),
+        ])
+        descriptor.fetchOffset = offset
+        descriptor.fetchLimit = limit
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toWeightEntry() }
+    }
+
     func latest() -> WeightEntry? {
         var descriptor = FetchDescriptor<LocalWeightEntry>(sortBy: [
             SortDescriptor(\.entryDate, order: .reverse),

--- a/mobile/iosApp/Bissbilanz/Persistence/WeightRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/WeightRepository.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for weight entries. Reads come from SwiftData
+/// (sorted by entry date, newest first); `refresh()` upserts the server list
+/// by id and drops rows deleted elsewhere. Server-computed weight stats stay
+/// on the direct API in the views.
+@MainActor
+@Observable
+final class WeightRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+
+    init(context: ModelContext, api: BissbilanzAPI) {
+        self.context = context
+        self.api = api
+    }
+
+    // MARK: - Reads (local)
+
+    func entries() -> [WeightEntry] {
+        let descriptor = FetchDescriptor<LocalWeightEntry>(sortBy: [
+            SortDescriptor(\.entryDate, order: .reverse),
+        ])
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toWeightEntry() }
+    }
+
+    func latest() -> WeightEntry? {
+        var descriptor = FetchDescriptor<LocalWeightEntry>(sortBy: [
+            SortDescriptor(\.entryDate, order: .reverse),
+        ])
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first?.toWeightEntry()
+    }
+
+    // MARK: - Refresh (API → store)
+
+    func refresh() async throws {
+        let fetched = try await api.getWeightEntries()
+        let serverIds = Set(fetched.map(\.id))
+        for stale in entries() where !serverIds.contains(stale.id) && !LocalStore.isTempId(stale.id) {
+            deleteRow(id: stale.id)
+        }
+        for entry in fetched {
+            upsert(entry)
+        }
+        save()
+    }
+
+    // MARK: - Writes (local first, then API)
+
+    @discardableResult
+    func createEntry(_ create: WeightCreate) async throws -> WeightEntry {
+        let temp = makeEntry(from: create, id: LocalStore.makeTempId())
+        upsert(temp)
+        save()
+        let server = try await api.createWeightEntry(create)
+        deleteRow(id: temp.id)
+        upsert(server)
+        save()
+        return server
+    }
+
+    @discardableResult
+    func updateEntry(id: String, _ update: WeightUpdate) async throws -> WeightEntry {
+        var optimistic: WeightEntry?
+        if let row = fetchRow(id: id), let existing = row.toWeightEntry() {
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let updated = (try? JSONPatch.merged(WeightEntry.self, base: existing, patch: patch)) ?? existing
+            row.update(from: updated)
+            save()
+            optimistic = updated
+        }
+        if LocalStore.isTempId(id), let optimistic {
+            return optimistic
+        }
+        let server = try await api.updateWeightEntry(id: id, update)
+        upsert(server)
+        save()
+        return server
+    }
+
+    func deleteEntry(id: String) async throws {
+        deleteRow(id: id)
+        save()
+        guard !LocalStore.isTempId(id) else { return }
+        try await api.deleteWeightEntry(id: id)
+    }
+
+    // MARK: - Conversion helpers
+
+    private func makeEntry(from create: WeightCreate, id: String) -> WeightEntry {
+        let now = ISO8601DateFormatter().string(from: Date())
+        return WeightEntry(
+            id: id,
+            userId: "",
+            weightKg: create.weightKg,
+            entryDate: create.entryDate,
+            loggedAt: now,
+            notes: create.notes,
+            createdAt: now,
+            updatedAt: nil
+        )
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow(id: String) -> LocalWeightEntry? {
+        var descriptor = FetchDescriptor<LocalWeightEntry>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ entry: WeightEntry) {
+        if let row = fetchRow(id: entry.id) {
+            row.update(from: entry)
+        } else {
+            context.insert(LocalWeightEntry(entry: entry))
+        }
+    }
+
+    private func deleteRow(id: String) {
+        if let row = fetchRow(id: id) {
+            context.delete(row)
+        }
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
+++ b/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
@@ -13,7 +13,10 @@ final class HealthKitService {
     static let writeWeightEnabledKey = "healthkit_write_weight_enabled"
 
     private let healthStore = HKHealthStore()
-    var isAvailable: Bool { HKHealthStore.isHealthDataAvailable() }
+    var isAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable()
+    }
+
     var isAuthorized = false
 
     private let readTypes: Set<HKObjectType> = {
@@ -79,7 +82,14 @@ final class HealthKitService {
         try await healthStore.save(sample)
     }
 
-    func saveNutrition(calories: Double, protein: Double, carbs: Double, fat: Double, fiber: Double, date: Date) async throws {
+    func saveNutrition(
+        calories: Double,
+        protein: Double,
+        carbs: Double,
+        fat: Double,
+        fiber: Double,
+        date: Date
+    ) async throws {
         var samples: [HKQuantitySample] = []
 
         let pairs: [(HKQuantityTypeIdentifier, Double, HKUnit)] = [
@@ -116,7 +126,12 @@ final class HealthKitService {
         let ownBundleId = Bundle.main.bundleIdentifier
 
         return try await withCheckedThrowingContinuation { continuation in
-            let query = HKSampleQuery(sampleType: type, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: [sortDescriptor]) { _, samples, error in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: [sortDescriptor]
+            ) { _, samples, error in
                 if let error {
                     continuation.resume(throwing: error)
                     return
@@ -124,7 +139,10 @@ final class HealthKitService {
                 let weights = (samples ?? [])
                     .compactMap { $0 as? HKQuantitySample }
                     .filter { $0.sourceRevision.source.bundleIdentifier != ownBundleId }
-                    .map { WeightSample(date: $0.startDate, weightKg: $0.quantity.doubleValue(for: .gramUnit(with: .kilo))) }
+                    .map { WeightSample(
+                        date: $0.startDate,
+                        weightKg: $0.quantity.doubleValue(for: .gramUnit(with: .kilo))
+                    ) }
                 continuation.resume(returning: weights)
             }
             self.healthStore.execute(query)
@@ -136,7 +154,12 @@ final class HealthKitService {
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
 
         return try await withCheckedThrowingContinuation { continuation in
-            let query = HKSampleQuery(sampleType: type, predicate: nil, limit: 1, sortDescriptors: [sortDescriptor]) { _, samples, error in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: nil,
+                limit: 1,
+                sortDescriptors: [sortDescriptor]
+            ) { _, samples, error in
                 if let error {
                     continuation.resume(throwing: error)
                     return

--- a/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct EntryEditSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(EntryRepository.self) private var entryRepository
     @Environment(\.dismiss) private var dismiss
 
     let entry: Entry
@@ -30,7 +30,7 @@ struct EntryEditSheet: View {
                 }
 
                 Section(L10n.servings) {
-                    Stepper(value: $servings, in: 0.25...50, step: 0.25) {
+                    Stepper(value: $servings, in: 0.25 ... 50, step: 0.25) {
                         Text("\(servings, specifier: "%.2g")x")
                             .fontWeight(.medium)
                     }
@@ -59,7 +59,10 @@ struct EntryEditSheet: View {
                     .fontWeight(.semibold)
                 }
             }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -71,7 +74,7 @@ struct EntryEditSheet: View {
         isSaving = true
         let update = EntryUpdate(mealType: mealType, servings: servings)
         do {
-            let updated = try await api.updateEntry(id: entry.id, update)
+            let updated = try await entryRepository.updateEntry(id: entry.id, update)
             onSaved(updated)
             dismiss()
         } catch {

--- a/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct FoodEditSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(FoodRepository.self) private var foodRepository
     @Environment(\.dismiss) private var dismiss
 
     let existingFood: Food?
@@ -24,8 +24,8 @@ struct FoodEditSheet: View {
     let initialBarcode: String?
 
     init(food: Food? = nil, barcode: String? = nil, onSaved: @escaping (Food) -> Void = { _ in }) {
-        self.existingFood = food
-        self.initialBarcode = barcode
+        existingFood = food
+        initialBarcode = barcode
         self.onSaved = onSaved
     }
 
@@ -141,11 +141,10 @@ struct FoodEditSheet: View {
         )
 
         do {
-            let saved: Food
-            if let existing = existingFood {
-                saved = try await api.updateFood(id: existing.id, foodData)
+            let saved: Food = if let existing = existingFood {
+                try await foodRepository.updateFood(id: existing.id, foodData)
             } else {
-                saved = try await api.createFood(foodData)
+                try await foodRepository.createFood(foodData)
             }
             onSaved(saved)
             dismiss()

--- a/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct QuickEntrySheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(EntryRepository.self) private var entryRepository
     @Environment(\.dismiss) private var dismiss
 
     let date: String
@@ -57,7 +57,10 @@ struct QuickEntrySheet: View {
                     .fontWeight(.semibold)
                 }
             }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -93,7 +96,7 @@ struct QuickEntrySheet: View {
             quickFiber: Double(fiber)
         )
         do {
-            _ = try await api.createEntry(entry)
+            try await entryRepository.createEntry(entry)
             onSaved()
             dismiss()
         } catch {

--- a/mobile/iosApp/Bissbilanz/Sheets/RecipeEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/RecipeEditSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RecipeEditSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(RecipeRepository.self) private var recipeRepository
     @Environment(\.dismiss) private var dismiss
 
     let existingRecipe: Recipe?
@@ -23,7 +23,7 @@ struct RecipeEditSheet: View {
     }
 
     init(recipe: Recipe? = nil, onSaved: @escaping (Recipe) -> Void = { _ in }) {
-        self.existingRecipe = recipe
+        existingRecipe = recipe
         self.onSaved = onSaved
     }
 
@@ -96,7 +96,11 @@ struct RecipeEditSheet: View {
             }
             .sheet(isPresented: $showFoodPicker) {
                 FoodPickerSheet { food in
-                    ingredients.append(IngredientRow(food: food, quantity: "\(food.servingSize)", unit: food.servingUnit))
+                    ingredients.append(IngredientRow(
+                        food: food,
+                        quantity: "\(food.servingSize)",
+                        unit: food.servingUnit
+                    ))
                 }
             }
             .onAppear { prefill() }
@@ -137,7 +141,7 @@ struct RecipeEditSheet: View {
                     ingredients: ingredientInputs,
                     isFavorite: isFavorite
                 )
-                saved = try await api.updateRecipe(id: existing.id, update)
+                saved = try await recipeRepository.updateRecipe(id: existing.id, update)
             } else {
                 let create = RecipeCreate(
                     name: name,
@@ -145,7 +149,7 @@ struct RecipeEditSheet: View {
                     ingredients: ingredientInputs,
                     isFavorite: isFavorite
                 )
-                saved = try await api.createRecipe(create)
+                saved = try await recipeRepository.createRecipe(create)
             }
             onSaved(saved)
             dismiss()
@@ -156,9 +160,9 @@ struct RecipeEditSheet: View {
     }
 }
 
-// Helper sheet for picking a food to add as ingredient
+/// Helper sheet for picking a food to add as ingredient
 struct FoodPickerSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(FoodRepository.self) private var foodRepository
     @Environment(\.dismiss) private var dismiss
 
     let onPicked: (Food) -> Void
@@ -172,7 +176,11 @@ struct FoodPickerSheet: View {
         NavigationStack {
             Group {
                 if query.count < 2 {
-                    ContentUnavailableView(L10n.search, systemImage: "magnifyingglass", description: Text("Type at least 2 characters"))
+                    ContentUnavailableView(
+                        L10n.search,
+                        systemImage: "magnifyingglass",
+                        description: Text("Type at least 2 characters")
+                    )
                 } else if isSearching {
                     LoadingView()
                 } else if results.isEmpty {
@@ -186,9 +194,11 @@ struct FoodPickerSheet: View {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(food.name)
                                     .foregroundStyle(.primary)
-                                Text("\(Int(food.calories)) cal \u{00B7} \(food.servingSize, specifier: "%.0f") \(food.servingUnit.displayName)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                Text(
+                                    "\(Int(food.calories)) cal \u{00B7} \(food.servingSize, specifier: "%.0f") \(food.servingUnit.displayName)"
+                                )
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                             }
                         }
                     }
@@ -215,9 +225,11 @@ struct FoodPickerSheet: View {
     }
 
     private func search(_ query: String) async {
-        guard query.count >= 2 else { results = []; return }
+        guard query.count >= 2 else { results = []
+            return
+        }
         isSearching = true
-        results = (try? await api.searchFoods(query: query)) ?? []
+        results = await foodRepository.searchFoods(query: query)
         isSearching = false
     }
 }

--- a/mobile/iosApp/Bissbilanz/Sheets/SupplementEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/SupplementEditSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SupplementEditSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(SupplementRepository.self) private var supplementRepository
     @Environment(\.dismiss) private var dismiss
 
     let existingSupplement: Supplement?
@@ -21,9 +21,9 @@ struct SupplementEditSheet: View {
         var name: String = ""
         var dosage: String = ""
         var dosageUnit: String = "mg"
-        // Original ingredientsText preserved verbatim when it can't be parsed as
-        // "<number> <unit>" — round-trips free-form labels without loss.
-        var originalText: String? = nil
+        /// Original ingredientsText preserved verbatim when it can't be parsed as
+        /// "<number> <unit>" — round-trips free-form labels without loss.
+        var originalText: String?
     }
 
     private let dosageUnits = ["mg", "g", "\u{00B5}g", "IU", "ml", "drops"]
@@ -31,7 +31,7 @@ struct SupplementEditSheet: View {
     private let weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
     init(supplement: Supplement? = nil, onSaved: @escaping (Supplement) -> Void = { _ in }) {
-        self.existingSupplement = supplement
+        existingSupplement = supplement
         self.onSaved = onSaved
     }
 
@@ -52,7 +52,7 @@ struct SupplementEditSheet: View {
 
                     if scheduleType == .weekly || scheduleType == .specificDays {
                         HStack {
-                            ForEach(0..<7, id: \.self) { day in
+                            ForEach(0 ..< 7, id: \.self) { day in
                                 Button {
                                     if scheduleDays.contains(day) {
                                         scheduleDays.remove(day)
@@ -144,9 +144,9 @@ struct SupplementEditSheet: View {
         }
     }
 
-    // Parses "42 mg" out of an existing ingredientsText. Returns (dosage, unit,
-    // original) where `original` is non-nil when we couldn't fully parse the
-    // text so the caller keeps the raw string around for round-trip safety.
+    /// Parses "42 mg" out of an existing ingredientsText. Returns (dosage, unit,
+    /// original) where `original` is non-nil when we couldn't fully parse the
+    /// text so the caller keeps the raw string around for round-trip safety.
     private func parseDosage(_ text: String?) -> (Double?, String, String?) {
         guard let text = text?.trimmingCharacters(in: .whitespaces), !text.isEmpty else {
             return (nil, "mg", nil)
@@ -189,11 +189,10 @@ struct SupplementEditSheet: View {
 
         let ingredientInputs = ingredientRows.enumerated().map { idx, row -> SupplementIngredientInput in
             let dose = Double(row.dosage) ?? 0
-            let label: String
-            if dose > 0 {
-                label = "\(row.dosage) \(row.dosageUnit)"
+            let label: String = if dose > 0 {
+                "\(row.dosage) \(row.dosageUnit)"
             } else {
-                label = row.originalText ?? ""
+                row.originalText ?? ""
             }
             return SupplementIngredientInput(
                 foodId: nil,
@@ -224,7 +223,7 @@ struct SupplementEditSheet: View {
                     timeOfDay: timeOfDay,
                     ingredients: ingredientInputs
                 )
-                saved = try await api.updateSupplement(id: existing.id, update)
+                saved = try await supplementRepository.updateSupplement(id: existing.id, update)
             } else {
                 let create = SupplementCreate(
                     name: name,
@@ -234,7 +233,7 @@ struct SupplementEditSheet: View {
                     timeOfDay: timeOfDay,
                     ingredients: ingredientInputs
                 )
-                saved = try await api.createSupplement(create)
+                saved = try await supplementRepository.createSupplement(create)
             }
             onSaved(saved)
             dismiss()

--- a/mobile/iosApp/Bissbilanz/Sync/AppMode.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/AppMode.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Observation
+
+/// How the app stores and syncs data.
+///
+/// - `local`: anonymous, no backend. The SwiftData store is the primary store;
+///   nothing is ever enqueued for sync and refresh calls are no-ops.
+/// - `synced`: logged in. The backend is the source of truth; the local store is
+///   an offline cache and writes are queued for upload.
+enum AppMode: String {
+    case local
+    case synced
+}
+
+/// Holds the persisted app mode. A `nil` mode means the user has not chosen yet —
+/// this is also the state for existing logged-in installs after an upgrade, which
+/// must keep behaving exactly as before. Therefore anything other than
+/// `AppMode.local` (including `nil`) is treated as "sync allowed". Mirrors the
+/// Android `AppModeManager` (same UserDefaults key and semantics).
+@MainActor
+@Observable
+final class AppModeManager {
+    private(set) var mode: AppMode?
+
+    private let defaults: UserDefaults
+    private static let key = "app_mode"
+
+    var isLocal: Bool {
+        mode == .local
+    }
+
+    /// Loads the persisted mode immediately — repositories and the sync queue
+    /// consult it from their first call.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        mode = defaults.string(forKey: Self.key).flatMap(AppMode.init(rawValue:))
+    }
+
+    func setMode(_ mode: AppMode) {
+        defaults.set(mode.rawValue, forKey: Self.key)
+        self.mode = mode
+    }
+
+    /// Clears the persisted mode (used on logout) so the next start shows the
+    /// login screen with the mode choice again.
+    func clear() {
+        defaults.removeObject(forKey: Self.key)
+        mode = nil
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Sync/ConnectivityMonitor.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/ConnectivityMonitor.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Network
+import Observation
+
+/// Publishes network reachability on the main actor via `NWPathMonitor`
+/// running on a background queue. `start()` is called once at app startup;
+/// tests skip it and set `isOnline` directly.
+@MainActor
+@Observable
+final class ConnectivityMonitor {
+    /// Optimistic default so the first drain attempt isn't blocked before the
+    /// path monitor delivers its initial update.
+    var isOnline = true {
+        didSet {
+            if isOnline != oldValue {
+                onOnlineChange?(isOnline)
+            }
+        }
+    }
+
+    /// Invoked on the main actor whenever connectivity flips (used by the
+    /// sync manager to drain when connectivity is regained).
+    var onOnlineChange: ((Bool) -> Void)?
+
+    @ObservationIgnored private var monitor: NWPathMonitor?
+
+    func start() {
+        guard monitor == nil else { return }
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { path in
+            let online = path.status == .satisfied
+            Task { @MainActor in
+                self.isOnline = online
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "connectivity-monitor", qos: .utility))
+        self.monitor = monitor
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Sync/PendingSyncOperation.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/PendingSyncOperation.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftData
+
+/// One persisted row of the offline sync queue. Ordered FIFO by `seq`
+/// (monotonically increasing, assigned at enqueue time on the main actor);
+/// `createdAt` is informational. The `affectedTable`/`affectedId` columns make
+/// temp-id coalescing lookups cheap without decoding every payload.
+@Model
+final class PendingSyncOperation {
+    @Attribute(.unique) var id: UUID
+    var seq: Int
+    var createdAt: Date
+    var type: String
+    var payload: Data
+    var affectedTable: String?
+    var affectedId: String?
+    var retryCount: Int
+
+    init(seq: Int, operation: SyncOperation) {
+        id = UUID()
+        self.seq = seq
+        createdAt = Date()
+        type = operation.typeName
+        payload = LocalStoreCoding.encode(operation)
+        affectedTable = operation.affectedTable
+        affectedId = operation.affectedId
+        retryCount = 0
+    }
+
+    func operation() -> SyncOperation? {
+        LocalStoreCoding.decode(SyncOperation.self, from: payload)
+    }
+
+    /// Rewrites the payload in place (temp-id coalescing). The affected
+    /// table/id never change when coalescing — mirroring the Android queue.
+    func replaceOperation(_ operation: SyncOperation) {
+        type = operation.typeName
+        payload = LocalStoreCoding.encode(operation)
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Sync/PendingSyncOperation.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/PendingSyncOperation.swift
@@ -31,10 +31,14 @@ final class PendingSyncOperation {
         LocalStoreCoding.decode(SyncOperation.self, from: payload)
     }
 
-    /// Rewrites the payload in place (temp-id coalescing). The affected
-    /// table/id never change when coalescing — mirroring the Android queue.
+    /// Rewrites the payload in place (temp-id coalescing and reference
+    /// remapping after a create drained). The affected table/id are refreshed
+    /// so coalescing lookups keep working after an op is re-keyed from a
+    /// `temp_` id to its server id.
     func replaceOperation(_ operation: SyncOperation) {
         type = operation.typeName
         payload = LocalStoreCoding.encode(operation)
+        affectedTable = operation.affectedTable
+        affectedId = operation.affectedId
     }
 }

--- a/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
@@ -136,9 +136,13 @@ final class SyncManager {
             }
         }
 
-        for row in queuedRows() {
-            // Coalescing may have removed the row while an earlier op was in flight.
-            guard !row.isDeleted else { continue }
+        // Re-fetch the head each iteration instead of iterating a start-of-
+        // drain snapshot: operations enqueued while an upload is in flight
+        // (their `scheduleDrain` is swallowed by the `isDraining` guard) are
+        // picked up by this drain instead of waiting for the next trigger.
+        // Every iteration either removes the head row or returns, so the
+        // loop terminates.
+        while let row = queuedRows().first {
             guard let operation = row.operation() else {
                 // Unreadable payload — nothing useful can ever be uploaded.
                 remove(row)
@@ -151,7 +155,7 @@ final class SyncManager {
                 }
                 processed += 1
             } catch {
-                switch Self.classify(error) {
+                switch Self.classify(error, isOnline: connectivity.isOnline) {
                 case .unauthorized:
                     errors.append("Session expired. Please log in again to sync pending changes.")
                     return processed
@@ -160,6 +164,13 @@ final class SyncManager {
                     remove(row)
                     processed += 1
                     errors.append("Failed to sync \(operation.summary): HTTP \(status)")
+
+                case .offline:
+                    // Plain connectivity failure (e.g. the optimistic
+                    // `isOnline` default before the path monitor reports an
+                    // offline launch) — never burn the retry budget on it,
+                    // just stop and wait for connectivity to come back.
+                    return processed
 
                 case .retryable:
                     row.retryCount += 1
@@ -178,13 +189,39 @@ final class SyncManager {
         return processed
     }
 
+    /// Rewrites still-queued operation payloads (and their affected table/id
+    /// columns) that reference a resolved `temp_` id, so chained offline
+    /// creates upload with the server id (the queue-side counterpart of
+    /// `LocalRemap`, which rewrites the local rows).
+    func remapQueuedReferences(from oldId: String, to newId: String) {
+        guard oldId != newId else { return }
+        var changed = false
+        for row in queuedRows() {
+            guard let operation = row.operation(),
+                  let remapped = operation.remappingReferences(from: oldId, to: newId)
+            else { continue }
+            row.replaceOperation(remapped)
+            changed = true
+        }
+        if changed {
+            save()
+        }
+    }
+
     // MARK: - Execution
 
     private func execute(_ operation: SyncOperation) async throws {
         switch operation {
         case let .createFood(body, localId):
             let server = try await api.createFood(body)
+            guard LocalRemap.foodRow(id: localId, in: context) != nil else {
+                // Deleted while the create was in flight — don't resurrect
+                // the row; remove the freshly created server record instead.
+                enqueue(.deleteFood(id: server.id))
+                return
+            }
             LocalRemap.replaceFood(id: localId, with: server, in: context)
+            remapQueuedReferences(from: localId, to: server.id)
 
         case let .updateFood(id, body):
             _ = try await api.updateFood(id: id, body)
@@ -197,11 +234,15 @@ final class SyncManager {
 
         case let .createEntry(body, localId):
             let server = try await api.createEntry(body)
+            guard let local = LocalRemap.entryRow(id: localId, in: context)?.toEntry() else {
+                enqueue(.deleteEntry(id: server.id))
+                return
+            }
             // POST responses are raw DB rows without resolved macros — merge
             // the display fields from the optimistic local row.
-            let local = LocalRemap.entryRow(id: localId, in: context)?.toEntry()
-            let merged = local.map { EntryRepository.merge(server: server, local: $0) } ?? server
+            let merged = EntryRepository.merge(server: server, local: local)
             LocalRemap.replaceEntry(id: localId, with: merged, date: merged.date ?? body.date, in: context)
+            remapQueuedReferences(from: localId, to: server.id)
 
         case let .updateEntry(id, body):
             _ = try await api.updateEntry(id: id, body)
@@ -211,7 +252,12 @@ final class SyncManager {
 
         case let .createRecipe(body, localId):
             let server = try await api.createRecipe(body)
+            guard LocalRemap.recipeRow(id: localId, in: context) != nil else {
+                enqueue(.deleteRecipe(id: server.id))
+                return
+            }
             LocalRemap.replaceRecipe(id: localId, with: server, in: context)
+            remapQueuedReferences(from: localId, to: server.id)
 
         case let .updateRecipe(id, body):
             _ = try await api.updateRecipe(id: id, body)
@@ -224,7 +270,12 @@ final class SyncManager {
 
         case let .createWeight(body, localId):
             let server = try await api.createWeightEntry(body)
+            guard LocalRemap.weightRow(id: localId, in: context) != nil else {
+                enqueue(.deleteWeight(id: server.id))
+                return
+            }
             LocalRemap.replaceWeight(id: localId, with: server, in: context)
+            remapQueuedReferences(from: localId, to: server.id)
 
         case let .updateWeight(id, body):
             _ = try await api.updateWeightEntry(id: id, body)
@@ -234,7 +285,12 @@ final class SyncManager {
 
         case let .createSupplement(body, localId):
             let server = try await api.createSupplement(body)
+            guard LocalRemap.supplementRow(id: localId, in: context) != nil else {
+                enqueue(.deleteSupplement(id: server.id))
+                return
+            }
             LocalRemap.replaceSupplement(id: localId, with: server, rekeyLogIds: false, in: context)
+            remapQueuedReferences(from: localId, to: server.id)
 
         case let .updateSupplement(id, body):
             _ = try await api.updateSupplement(id: id, body)
@@ -264,11 +320,14 @@ final class SyncManager {
     private enum FailureKind {
         case unauthorized
         case clientError(Int)
+        case offline
         case retryable
     }
 
-    private static func classify(_ error: Error) -> FailureKind {
-        guard let apiError = error as? APIError else { return .retryable }
+    private static func classify(_ error: Error, isOnline: Bool) -> FailureKind {
+        guard let apiError = error as? APIError else {
+            return isConnectivityError(error, isOnline: isOnline) ? .offline : .retryable
+        }
         switch apiError {
         case .unauthorized:
             return .unauthorized
@@ -278,8 +337,25 @@ final class SyncManager {
             return .clientError(404)
         case let .serverError(status, _):
             return status < 500 ? .clientError(status) : .retryable
-        case .networkError, .decodingError:
+        case let .networkError(underlying):
+            return isConnectivityError(underlying, isOnline: isOnline) ? .offline : .retryable
+        case .decodingError:
             return .retryable
+        }
+    }
+
+    /// Obvious "the device has no connection" URLErrors. `.timedOut` only
+    /// counts while the connectivity monitor reports offline — online
+    /// timeouts may be a struggling server and should consume retries.
+    private static func isConnectivityError(_ error: Error, isOnline: Bool) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .notConnectedToInternet, .networkConnectionLost, .cannotFindHost:
+            return true
+        case .timedOut:
+            return !isOnline
+        default:
+            return false
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
@@ -1,0 +1,304 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Persistent offline write queue + drainer, mirroring the Android
+/// `SyncQueue`/`SyncManager` pair on the main actor.
+///
+/// Repositories enqueue writes in Synced mode (in Local mode `enqueue` is a
+/// no-op — the local store is the primary store and the login migrator uploads
+/// it wholesale). The queue drains FIFO whenever something is enqueued,
+/// connectivity is regained, or the app foregrounds. Per-operation outcomes:
+/// - success → row removed; for creates the local `temp_` row is replaced with
+///   the server record (shared `LocalRemap` helpers, same code the migrator uses).
+/// - 4xx (except 401) → the server rejected the payload; the row is dropped and
+///   an error is recorded.
+/// - 401 → `performRequest` already refreshed and retried once, so a final 401
+///   means the session is dead: draining stops, the queue is kept.
+/// - 5xx / network errors → retryCount increments and draining stops; after
+///   `maxRetries` failed attempts the row is dropped with an error.
+@MainActor
+@Observable
+final class SyncManager {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let connectivity: ConnectivityMonitor
+
+    private(set) var isSyncing = false
+    private(set) var pendingCount = 0
+    private(set) var errors: [String] = []
+    private(set) var lastSyncedAt: Date?
+
+    @ObservationIgnored private var isDraining = false
+
+    /// Test seam: when false, `scheduleDrain` becomes a no-op so tests
+    /// control drain timing explicitly via `drainPendingQueue`.
+    @ObservationIgnored var autoDrain = true
+
+    static let maxRetries = 3
+
+    init(
+        context: ModelContext,
+        api: BissbilanzAPI,
+        appMode: AppModeManager,
+        connectivity: ConnectivityMonitor
+    ) {
+        self.context = context
+        self.api = api
+        self.appMode = appMode
+        self.connectivity = connectivity
+        pendingCount = queuedRows().count
+        connectivity.onOnlineChange = { [weak self] online in
+            if online {
+                self?.scheduleDrain()
+            }
+        }
+    }
+
+    // MARK: - Queue
+
+    /// Persists an operation for upload. In Local mode the local store is the
+    /// primary store, so nothing is queued — the login migrator uploads the
+    /// store state when switching to Synced; queued ops would double-apply.
+    func enqueue(_ operation: SyncOperation) {
+        guard !appMode.isLocal else { return }
+        context.insert(PendingSyncOperation(seq: nextSeq(), operation: operation))
+        save()
+        pendingCount = queuedRows().count
+        scheduleDrain()
+    }
+
+    /// Queued rows touching (table, id) in FIFO order — the coalescing lookup.
+    func queuedOperations(table: String, affectedId: String) -> [PendingSyncOperation] {
+        let descriptor = FetchDescriptor<PendingSyncOperation>(
+            predicate: #Predicate { $0.affectedTable == table && $0.affectedId == affectedId },
+            sortBy: [SortDescriptor(\.seq)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    /// Rewrites a queued operation in place (temp-id coalescing).
+    func replace(_ row: PendingSyncOperation, with operation: SyncOperation) {
+        row.replaceOperation(operation)
+        save()
+    }
+
+    func remove(_ row: PendingSyncOperation) {
+        context.delete(row)
+        save()
+        pendingCount = queuedRows().count
+    }
+
+    /// Drops every queued operation touching (table, id) — used when a
+    /// `temp_` row is deleted before its create drained (this also removes
+    /// queued supplement-logs for a temp supplement, which share the table/id).
+    func removeQueued(table: String, affectedId: String) {
+        for row in queuedOperations(table: table, affectedId: affectedId) {
+            context.delete(row)
+        }
+        save()
+        pendingCount = queuedRows().count
+    }
+
+    func clearQueue() {
+        try? context.delete(model: PendingSyncOperation.self)
+        save()
+        pendingCount = 0
+    }
+
+    // MARK: - Draining
+
+    /// Fire-and-forget drain trigger (enqueue, connectivity regained, app
+    /// foreground). The drain itself is reentrancy-guarded.
+    func scheduleDrain() {
+        guard autoDrain else { return }
+        Task {
+            await drainPendingQueue()
+        }
+    }
+
+    /// Uploads queued operations FIFO. Returns the number of operations
+    /// removed from the queue (successes and permanent drops).
+    @discardableResult
+    func drainPendingQueue() async -> Int {
+        guard !appMode.isLocal, !isDraining, connectivity.isOnline else { return 0 }
+        isDraining = true
+        isSyncing = true
+        errors = []
+        var processed = 0
+        defer {
+            isSyncing = false
+            isDraining = false
+            pendingCount = queuedRows().count
+            if processed > 0 {
+                lastSyncedAt = Date()
+            }
+        }
+
+        for row in queuedRows() {
+            // Coalescing may have removed the row while an earlier op was in flight.
+            guard !row.isDeleted else { continue }
+            guard let operation = row.operation() else {
+                // Unreadable payload — nothing useful can ever be uploaded.
+                remove(row)
+                continue
+            }
+            do {
+                try await execute(operation)
+                if !row.isDeleted {
+                    remove(row)
+                }
+                processed += 1
+            } catch {
+                switch Self.classify(error) {
+                case .unauthorized:
+                    errors.append("Session expired. Please log in again to sync pending changes.")
+                    return processed
+
+                case let .clientError(status):
+                    remove(row)
+                    processed += 1
+                    errors.append("Failed to sync \(operation.summary): HTTP \(status)")
+
+                case .retryable:
+                    row.retryCount += 1
+                    if row.retryCount >= Self.maxRetries {
+                        remove(row)
+                        processed += 1
+                        errors.append("Gave up syncing \(operation.summary) after \(Self.maxRetries) retries.")
+                    } else {
+                        save()
+                        return processed
+                    }
+                }
+            }
+            pendingCount = queuedRows().count
+        }
+        return processed
+    }
+
+    // MARK: - Execution
+
+    private func execute(_ operation: SyncOperation) async throws {
+        switch operation {
+        case let .createFood(body, localId):
+            let server = try await api.createFood(body)
+            LocalRemap.replaceFood(id: localId, with: server, in: context)
+
+        case let .updateFood(id, body):
+            _ = try await api.updateFood(id: id, body)
+
+        case let .deleteFood(id):
+            try await api.deleteFood(id: id)
+
+        case let .toggleFavorite(id, isFavorite):
+            _ = try await api.toggleFavorite(foodId: id, isFavorite: isFavorite)
+
+        case let .createEntry(body, localId):
+            let server = try await api.createEntry(body)
+            // POST responses are raw DB rows without resolved macros — merge
+            // the display fields from the optimistic local row.
+            let local = LocalRemap.entryRow(id: localId, in: context)?.toEntry()
+            let merged = local.map { EntryRepository.merge(server: server, local: $0) } ?? server
+            LocalRemap.replaceEntry(id: localId, with: merged, date: merged.date ?? body.date, in: context)
+
+        case let .updateEntry(id, body):
+            _ = try await api.updateEntry(id: id, body)
+
+        case let .deleteEntry(id):
+            try await api.deleteEntry(id: id)
+
+        case let .createRecipe(body, localId):
+            let server = try await api.createRecipe(body)
+            LocalRemap.replaceRecipe(id: localId, with: server, in: context)
+
+        case let .updateRecipe(id, body):
+            _ = try await api.updateRecipe(id: id, body)
+
+        case let .deleteRecipe(id):
+            try await api.deleteRecipe(id: id)
+
+        case let .setGoals(body):
+            _ = try await api.setGoals(body)
+
+        case let .createWeight(body, localId):
+            let server = try await api.createWeightEntry(body)
+            LocalRemap.replaceWeight(id: localId, with: server, in: context)
+
+        case let .updateWeight(id, body):
+            _ = try await api.updateWeightEntry(id: id, body)
+
+        case let .deleteWeight(id):
+            try await api.deleteWeightEntry(id: id)
+
+        case let .createSupplement(body, localId):
+            let server = try await api.createSupplement(body)
+            LocalRemap.replaceSupplement(id: localId, with: server, rekeyLogIds: false, in: context)
+
+        case let .updateSupplement(id, body):
+            _ = try await api.updateSupplement(id: id, body)
+
+        case let .deleteSupplement(id):
+            try await api.deleteSupplement(id: id)
+
+        case let .logSupplement(supplementId, date):
+            _ = try await api.logSupplement(id: supplementId, date: date)
+
+        case let .unlogSupplement(supplementId, date):
+            try await api.unlogSupplement(id: supplementId, date: date)
+
+        case let .setDayProperties(date, isFastingDay):
+            _ = try await api.setDayProperties(date: date, isFastingDay: isFastingDay)
+
+        case let .deleteDayProperties(date):
+            try await api.deleteDayProperties(date: date)
+
+        case let .updatePreferences(body):
+            _ = try await api.updatePreferences(body)
+        }
+    }
+
+    // MARK: - Error classification
+
+    private enum FailureKind {
+        case unauthorized
+        case clientError(Int)
+        case retryable
+    }
+
+    private static func classify(_ error: Error) -> FailureKind {
+        guard let apiError = error as? APIError else { return .retryable }
+        switch apiError {
+        case .unauthorized:
+            return .unauthorized
+        case .badRequest:
+            return .clientError(400)
+        case .notFound:
+            return .clientError(404)
+        case let .serverError(status, _):
+            return status < 500 ? .clientError(status) : .retryable
+        case .networkError, .decodingError:
+            return .retryable
+        }
+    }
+
+    // MARK: - Store helpers
+
+    /// All queued rows in FIFO order.
+    func queuedRows() -> [PendingSyncOperation] {
+        let descriptor = FetchDescriptor<PendingSyncOperation>(sortBy: [SortDescriptor(\.seq)])
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func nextSeq() -> Int {
+        var descriptor = FetchDescriptor<PendingSyncOperation>(sortBy: [SortDescriptor(\.seq, order: .reverse)])
+        descriptor.fetchLimit = 1
+        let highest = (try? context.fetch(descriptor))?.first?.seq ?? 0
+        return highest + 1
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Sync/SyncOperation.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/SyncOperation.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// One queued offline write, mirroring the Android `SyncOperation` hierarchy.
+/// Creates carry the optimistic `temp_` row id (`localId`) so the drained
+/// server record can replace the local row, and so edits/deletes of a not-yet-
+/// uploaded row can coalesce with (or cancel) the queued create.
+enum SyncOperation: Codable {
+    case createFood(body: FoodCreate, localId: String)
+    case updateFood(id: String, body: FoodCreate)
+    case deleteFood(id: String)
+    case toggleFavorite(id: String, isFavorite: Bool)
+    case createEntry(body: EntryCreate, localId: String)
+    case updateEntry(id: String, body: EntryUpdate)
+    case deleteEntry(id: String)
+    case createRecipe(body: RecipeCreate, localId: String)
+    case updateRecipe(id: String, body: RecipeUpdate)
+    case deleteRecipe(id: String)
+    case setGoals(body: Goals)
+    case createWeight(body: WeightCreate, localId: String)
+    case updateWeight(id: String, body: WeightUpdate)
+    case deleteWeight(id: String)
+    case createSupplement(body: SupplementCreate, localId: String)
+    case updateSupplement(id: String, body: SupplementUpdate)
+    case deleteSupplement(id: String)
+    case logSupplement(supplementId: String, date: String)
+    case unlogSupplement(supplementId: String, date: String)
+    case setDayProperties(date: String, isFastingDay: Bool)
+    case deleteDayProperties(date: String)
+    case updatePreferences(body: PreferencesUpdate)
+
+    /// Stable discriminator stored on the queue row (debugging/inspection).
+    var typeName: String {
+        switch self {
+        case .createFood: "create_food"
+        case .updateFood: "update_food"
+        case .deleteFood: "delete_food"
+        case .toggleFavorite: "toggle_favorite"
+        case .createEntry: "create_entry"
+        case .updateEntry: "update_entry"
+        case .deleteEntry: "delete_entry"
+        case .createRecipe: "create_recipe"
+        case .updateRecipe: "update_recipe"
+        case .deleteRecipe: "delete_recipe"
+        case .setGoals: "set_goals"
+        case .createWeight: "create_weight"
+        case .updateWeight: "update_weight"
+        case .deleteWeight: "delete_weight"
+        case .createSupplement: "create_supplement"
+        case .updateSupplement: "update_supplement"
+        case .deleteSupplement: "delete_supplement"
+        case .logSupplement: "log_supplement"
+        case .unlogSupplement: "unlog_supplement"
+        case .setDayProperties: "set_day_properties"
+        case .deleteDayProperties: "delete_day_properties"
+        case .updatePreferences: "update_preferences"
+        }
+    }
+
+    var affectedTable: String? {
+        switch self {
+        case .createFood, .updateFood, .deleteFood, .toggleFavorite: "foods"
+        case .createEntry, .updateEntry, .deleteEntry: "entries"
+        case .createRecipe, .updateRecipe, .deleteRecipe: "recipes"
+        case .setGoals: "goals"
+        case .createWeight, .updateWeight, .deleteWeight: "weight"
+        case .createSupplement, .updateSupplement, .deleteSupplement,
+             .logSupplement, .unlogSupplement: "supplements"
+        case .setDayProperties, .deleteDayProperties: "day_properties"
+        case .updatePreferences: "preferences"
+        }
+    }
+
+    var affectedId: String? {
+        switch self {
+        case let .createFood(_, localId), let .createEntry(_, localId),
+             let .createRecipe(_, localId), let .createWeight(_, localId),
+             let .createSupplement(_, localId):
+            localId
+        case let .updateFood(id, _), let .deleteFood(id), let .toggleFavorite(id, _),
+             let .updateEntry(id, _), let .deleteEntry(id),
+             let .updateRecipe(id, _), let .deleteRecipe(id),
+             let .updateWeight(id, _), let .deleteWeight(id),
+             let .updateSupplement(id, _), let .deleteSupplement(id):
+            id
+        case let .logSupplement(supplementId, _), let .unlogSupplement(supplementId, _):
+            supplementId
+        case let .setDayProperties(date, _), let .deleteDayProperties(date):
+            date
+        case .setGoals, .updatePreferences:
+            nil
+        }
+    }
+
+    /// Human-readable summary used in sync error messages (Android parity).
+    var summary: String {
+        switch self {
+        case .createFood: "create food"
+        case let .updateFood(id, _): "update food \(id)"
+        case let .deleteFood(id): "delete food \(id)"
+        case let .toggleFavorite(id, _): "toggle favorite \(id)"
+        case .createEntry: "create entry"
+        case let .updateEntry(id, _): "update entry \(id)"
+        case let .deleteEntry(id): "delete entry \(id)"
+        case .createRecipe: "create recipe"
+        case let .updateRecipe(id, _): "update recipe \(id)"
+        case let .deleteRecipe(id): "delete recipe \(id)"
+        case .setGoals: "set goals"
+        case .createWeight: "create weight entry"
+        case let .updateWeight(id, _): "update weight entry \(id)"
+        case let .deleteWeight(id): "delete weight entry \(id)"
+        case .createSupplement: "create supplement"
+        case let .updateSupplement(id, _): "update supplement \(id)"
+        case let .deleteSupplement(id): "delete supplement \(id)"
+        case let .logSupplement(id, _): "log supplement \(id)"
+        case let .unlogSupplement(id, _): "unlog supplement \(id)"
+        case let .setDayProperties(date, _): "set day properties \(date)"
+        case let .deleteDayProperties(date): "delete day properties \(date)"
+        case .updatePreferences: "update preferences"
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Sync/SyncOperation.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/SyncOperation.swift
@@ -91,6 +91,132 @@ enum SyncOperation: Codable {
         }
     }
 
+    /// Returns a copy with every reference to `oldId` rewritten to `newId`,
+    /// or nil when the operation does not reference it. Used by the sync
+    /// manager after a queued create drains: later queued operations may
+    /// reference the resolved `temp_` id (an entry logging a temp food, a
+    /// recipe ingredient, a queued supplement log, or an update/delete keyed
+    /// by the temp id) and must upload with the server id instead.
+    func remappingReferences(from oldId: String, to newId: String) -> SyncOperation? {
+        guard oldId != newId else { return nil }
+        switch self {
+        case let .updateFood(id, body) where id == oldId:
+            return .updateFood(id: newId, body: body)
+
+        case let .deleteFood(id) where id == oldId:
+            return .deleteFood(id: newId)
+
+        case let .toggleFavorite(id, isFavorite) where id == oldId:
+            return .toggleFavorite(id: newId, isFavorite: isFavorite)
+
+        case let .createEntry(body, localId) where body.foodId == oldId || body.recipeId == oldId:
+            var patched = body
+            if patched.foodId == oldId { patched.foodId = newId }
+            if patched.recipeId == oldId { patched.recipeId = newId }
+            return .createEntry(body: patched, localId: localId)
+
+        case let .updateEntry(id, body) where id == oldId:
+            return .updateEntry(id: newId, body: body)
+
+        case let .deleteEntry(id) where id == oldId:
+            return .deleteEntry(id: newId)
+
+        case let .createRecipe(body, localId):
+            guard let ingredients = Self.remapRecipeIngredients(body.ingredients, from: oldId, to: newId) else {
+                return nil
+            }
+            let patched = RecipeCreate(
+                name: body.name,
+                totalServings: body.totalServings,
+                ingredients: ingredients,
+                isFavorite: body.isFavorite,
+                imageUrl: body.imageUrl
+            )
+            return .createRecipe(body: patched, localId: localId)
+
+        case let .updateRecipe(id, body):
+            let ingredients = body.ingredients.flatMap {
+                Self.remapRecipeIngredients($0, from: oldId, to: newId)
+            }
+            guard id == oldId || ingredients != nil else { return nil }
+            var patched = body
+            if let ingredients { patched.ingredients = ingredients }
+            return .updateRecipe(id: id == oldId ? newId : id, body: patched)
+
+        case let .deleteRecipe(id) where id == oldId:
+            return .deleteRecipe(id: newId)
+
+        case let .updateWeight(id, body) where id == oldId:
+            return .updateWeight(id: newId, body: body)
+
+        case let .deleteWeight(id) where id == oldId:
+            return .deleteWeight(id: newId)
+
+        case let .createSupplement(body, localId):
+            guard let ingredients = Self.remapSupplementIngredients(body.ingredients, from: oldId, to: newId)
+            else { return nil }
+            let patched = SupplementCreate(
+                name: body.name,
+                scheduleType: body.scheduleType,
+                scheduleDays: body.scheduleDays,
+                scheduleStartDate: body.scheduleStartDate,
+                isActive: body.isActive,
+                sortOrder: body.sortOrder,
+                timeOfDay: body.timeOfDay,
+                ingredients: ingredients
+            )
+            return .createSupplement(body: patched, localId: localId)
+
+        case let .updateSupplement(id, body):
+            let ingredients = body.ingredients.flatMap {
+                Self.remapSupplementIngredients($0, from: oldId, to: newId)
+            }
+            guard id == oldId || ingredients != nil else { return nil }
+            var patched = body
+            if let ingredients { patched.ingredients = ingredients }
+            return .updateSupplement(id: id == oldId ? newId : id, body: patched)
+
+        case let .deleteSupplement(id) where id == oldId:
+            return .deleteSupplement(id: newId)
+
+        case let .logSupplement(supplementId, date) where supplementId == oldId:
+            return .logSupplement(supplementId: newId, date: date)
+
+        case let .unlogSupplement(supplementId, date) where supplementId == oldId:
+            return .unlogSupplement(supplementId: newId, date: date)
+
+        default:
+            return nil
+        }
+    }
+
+    /// Rewritten ingredient list, or nil when nothing referenced the old id.
+    private static func remapRecipeIngredients(
+        _ ingredients: [RecipeIngredientInput],
+        from oldId: String,
+        to newId: String
+    ) -> [RecipeIngredientInput]? {
+        guard ingredients.contains(where: { $0.foodId == oldId }) else { return nil }
+        return ingredients.map { input in
+            guard input.foodId == oldId else { return input }
+            return RecipeIngredientInput(foodId: newId, quantity: input.quantity, servingUnit: input.servingUnit)
+        }
+    }
+
+    private static func remapSupplementIngredients(
+        _ ingredients: [SupplementIngredientInput],
+        from oldId: String,
+        to newId: String
+    ) -> [SupplementIngredientInput]? {
+        guard ingredients.contains(where: { $0.foodId == oldId }) else { return nil }
+        return ingredients.map { input in
+            guard input.foodId == oldId else { return input }
+            var patched = input
+            patched.foodId = newId
+            return patched
+        }
+    }
+
     /// Human-readable summary used in sync error messages (Android parity).
     var summary: String {
         switch self {

--- a/mobile/iosApp/Bissbilanz/Utilities/DateFormatting.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/DateFormatting.swift
@@ -25,7 +25,12 @@ enum DateFormatting {
     }
 
     static func date(from isoString: String) -> Date? {
-        isoFormatter.date(from: isoString)
+        // ICU parsing is lenient about punctuation (e.g. "2026/03/12" matches
+        // "yyyy-MM-dd"); round-trip to accept canonical ISO strings only.
+        guard let date = isoFormatter.date(from: isoString),
+              isoFormatter.string(from: date) == isoString
+        else { return nil }
+        return date
     }
 
     static func displayString(from date: Date) -> String {

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -777,6 +777,22 @@ enum L10n {
         )
     }
 
+    static var sessionExpiredTitle: String {
+        localized("session_expired_title", en: "Session expired", de: "Sitzung abgelaufen")
+    }
+
+    static var sessionExpiredMessage: String {
+        localized(
+            "session_expired_message",
+            en: "Your data is safe on this device. Sign in again to keep syncing.",
+            de: "Deine Daten sind auf diesem Gerät gespeichert. Melde dich erneut an, um weiter zu synchronisieren."
+        )
+    }
+
+    static var notNow: String {
+        localized("not_now", en: "Not now", de: "Nicht jetzt")
+    }
+
     // MARK: - Local mode / Account
 
     static var localModeStatus: String {

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -616,8 +616,16 @@ enum L10n {
     static var signOutConfirmation: String {
         localized(
             "sign_out_confirmation",
-            en: "You will need to sign in again to use the app.",
-            de: "Du musst dich erneut anmelden, um die App zu nutzen."
+            en: "Data stored on this device will be removed, including changes that have not been synced yet. You will need to sign in again to use the app.",
+            de: "Auf diesem Gerät gespeicherte Daten werden entfernt, einschliesslich noch nicht synchronisierter Änderungen. Du musst dich erneut anmelden, um die App zu nutzen."
+        )
+    }
+
+    static func pendingSyncCount(_ count: Int) -> String {
+        localized(
+            "pending_sync_count",
+            en: count == 1 ? "1 change waiting to sync" : "\(count) changes waiting to sync",
+            de: count == 1 ? "1 Änderung wartet auf Synchronisierung" : "\(count) Änderungen warten auf Synchronisierung"
         )
     }
 

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -753,6 +753,145 @@ enum L10n {
         localized("sign_in", en: "Sign in", de: "Anmelden")
     }
 
+    static var continueWithoutAccount: String {
+        localized(
+            "continue_without_account",
+            en: "Continue without account",
+            de: "Ohne Konto fortfahren"
+        )
+    }
+
+    static var localModeExplainer: String {
+        localized(
+            "local_mode_explainer",
+            en: "Your data stays on this device. Sign in later anytime to sync.",
+            de: "Deine Daten bleiben auf diesem Gerät. Du kannst dich jederzeit später anmelden, um zu synchronisieren."
+        )
+    }
+
+    // MARK: - Local mode / Account
+
+    static var localModeStatus: String {
+        localized(
+            "local_mode_status",
+            en: "Local mode — data only on this device",
+            de: "Lokaler Modus — Daten nur auf diesem Gerät"
+        )
+    }
+
+    static var signInToSync: String {
+        localized("sign_in_to_sync", en: "Sign in to sync", de: "Anmelden zum Synchronisieren")
+    }
+
+    // MARK: - Migration
+
+    static var migrationAccountHasData: String {
+        localized(
+            "migration_account_has_data",
+            en: "Your account already has data",
+            de: "Dein Konto enthält bereits Daten"
+        )
+    }
+
+    static var migrationChoiceDescription: String {
+        localized(
+            "migration_choice_description",
+            en: "You can upload the data stored on this device to your account, "
+                + "or discard it and continue with your account data only.",
+            de: "Du kannst die auf diesem Gerät gespeicherten Daten in dein Konto hochladen "
+                + "oder sie verwerfen und nur mit deinen Kontodaten fortfahren."
+        )
+    }
+
+    static func migrationUploadItems(_ count: Int) -> String {
+        localized(
+            "migration_upload_items",
+            en: "Upload local data (\(count) items)",
+            de: "Lokale Daten hochladen (\(count) Einträge)"
+        )
+    }
+
+    static var migrationStartFresh: String {
+        localized(
+            "migration_start_fresh",
+            en: "Start fresh (discard local data)",
+            de: "Neu beginnen (lokale Daten verwerfen)"
+        )
+    }
+
+    static var migrationDiscardTitle: String {
+        localized(
+            "migration_discard_title",
+            en: "Discard local data?",
+            de: "Lokale Daten verwerfen?"
+        )
+    }
+
+    static var migrationDiscardMessage: String {
+        localized(
+            "migration_discard_message",
+            en: "All foods, recipes, log entries and other data stored on this device "
+                + "will be permanently deleted. The data in your account is kept.",
+            de: "Alle Lebensmittel, Rezepte, Einträge und sonstigen Daten auf diesem Gerät "
+                + "werden dauerhaft gelöscht. Die Daten in deinem Konto bleiben erhalten."
+        )
+    }
+
+    static var discard: String {
+        localized("discard", en: "Discard", de: "Verwerfen")
+    }
+
+    static var migrationUploading: String {
+        localized("migration_uploading", en: "Uploading your data", de: "Deine Daten werden hochgeladen")
+    }
+
+    static var migrationFailedTitle: String {
+        localized("migration_failed_title", en: "Upload failed", de: "Hochladen fehlgeschlagen")
+    }
+
+    static var migrationFailureSafe: String {
+        localized(
+            "migration_failure_safe",
+            en: "Your local data is safe — already uploaded items are not lost and the "
+                + "upload continues where it stopped.",
+            de: "Deine lokalen Daten sind sicher — bereits hochgeladene Einträge gehen nicht "
+                + "verloren und das Hochladen wird dort fortgesetzt, wo es aufgehört hat."
+        )
+    }
+
+    static func migrationStepLabel(_ step: MigrationStep) -> String {
+        switch step {
+        case .prepare:
+            localized("migration_step_prepare", en: "Preparing", de: "Vorbereiten")
+        case .foods:
+            localized("migration_step_foods", en: "Uploading foods", de: "Lebensmittel hochladen")
+        case .recipes:
+            localized("migration_step_recipes", en: "Uploading recipes", de: "Rezepte hochladen")
+        case .entries:
+            localized("migration_step_entries", en: "Uploading entries", de: "Einträge hochladen")
+        case .weights:
+            localized("migration_step_weights", en: "Uploading weight entries", de: "Gewichtseinträge hochladen")
+        case .supplements:
+            localized("migration_step_supplements", en: "Uploading supplements", de: "Supplements hochladen")
+        case .supplementLogs:
+            localized(
+                "migration_step_supplement_logs",
+                en: "Uploading supplement logs",
+                de: "Supplement-Einnahmen hochladen"
+            )
+        case .goals:
+            localized("migration_step_goals", en: "Uploading goals", de: "Ziele hochladen")
+        case .preferences:
+            localized("migration_step_preferences", en: "Uploading preferences", de: "Einstellungen hochladen")
+        case .dayProperties:
+            localized(
+                "migration_step_day_properties",
+                en: "Uploading day properties",
+                de: "Tageseigenschaften hochladen"
+            )
+        }
+    }
+
     // MARK: - Day Properties
 
     static var fastingDay: String {

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -952,6 +952,22 @@ enum L10n {
         localized("delta_7d", en: "7d Change", de: "7-Tage-Änderung")
     }
 
+    static var trendRising: String {
+        localized("trend_rising", en: "Rising", de: "Steigend")
+    }
+
+    static var trendFalling: String {
+        localized("trend_falling", en: "Falling", de: "Fallend")
+    }
+
+    static var trendSteady: String {
+        localized("trend_steady", en: "Steady", de: "Stabil")
+    }
+
+    static func deltaPerWeek(_ formatted: String) -> String {
+        localized("delta_per_week", en: "\(formatted) / 7d", de: "\(formatted) / 7T")
+    }
+
     static var projected: String {
         localized("projected", en: "Projected", de: "Prognose")
     }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -952,6 +952,10 @@ enum L10n {
         localized("delta_7d", en: "7d Change", de: "7-Tage-Änderung")
     }
 
+    static var showAll: String {
+        localized("show_all", en: "Show all", de: "Alle anzeigen")
+    }
+
     static var trendRising: String {
         localized("trend_rising", en: "Rising", de: "Steigend")
     }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -6,8 +6,8 @@ enum AppLocale: String, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .en: return "English"
-        case .de: return "Deutsch"
+        case .en: "English"
+        case .de: "Deutsch"
         }
     }
 }
@@ -17,287 +17,977 @@ enum AppLocale: String, CaseIterable {
 enum L10n {
     // MARK: - General
 
-    static var appName: String { localized("app_name", en: "Bissbilanz", de: "Bissbilanz") }
-    static var save: String { localized("save", en: "Save", de: "Speichern") }
-    static var cancel: String { localized("cancel", en: "Cancel", de: "Abbrechen") }
-    static var delete: String { localized("delete", en: "Delete", de: "Löschen") }
-    static var edit: String { localized("edit", en: "Edit", de: "Bearbeiten") }
-    static var close: String { localized("close", en: "Close", de: "Schließen") }
-    static var add: String { localized("add", en: "Add", de: "Hinzufügen") }
-    static var create: String { localized("create", en: "Create", de: "Erstellen") }
-    static var search: String { localized("search", en: "Search", de: "Suchen") }
-    static var loading: String { localized("loading", en: "Loading...", de: "Laden...") }
-    static var retry: String { localized("retry", en: "Retry", de: "Erneut versuchen") }
-    static var done: String { localized("done", en: "Done", de: "Fertig") }
-    static var today: String { localized("today", en: "Today", de: "Heute") }
-    static var log: String { localized("log", en: "Log", de: "Eintragen") }
-    static var error: String { localized("error", en: "Error", de: "Fehler") }
-    static var ok: String { localized("ok", en: "OK", de: "OK") }
+    static var appName: String {
+        localized("app_name", en: "Bissbilanz", de: "Bissbilanz")
+    }
+
+    static var save: String {
+        localized("save", en: "Save", de: "Speichern")
+    }
+
+    static var cancel: String {
+        localized("cancel", en: "Cancel", de: "Abbrechen")
+    }
+
+    static var delete: String {
+        localized("delete", en: "Delete", de: "Löschen")
+    }
+
+    static var edit: String {
+        localized("edit", en: "Edit", de: "Bearbeiten")
+    }
+
+    static var close: String {
+        localized("close", en: "Close", de: "Schließen")
+    }
+
+    static var add: String {
+        localized("add", en: "Add", de: "Hinzufügen")
+    }
+
+    static var create: String {
+        localized("create", en: "Create", de: "Erstellen")
+    }
+
+    static var search: String {
+        localized("search", en: "Search", de: "Suchen")
+    }
+
+    static var loading: String {
+        localized("loading", en: "Loading...", de: "Laden...")
+    }
+
+    static var retry: String {
+        localized("retry", en: "Retry", de: "Erneut versuchen")
+    }
+
+    static var done: String {
+        localized("done", en: "Done", de: "Fertig")
+    }
+
+    static var today: String {
+        localized("today", en: "Today", de: "Heute")
+    }
+
+    static var log: String {
+        localized("log", en: "Log", de: "Eintragen")
+    }
+
+    static var error: String {
+        localized("error", en: "Error", de: "Fehler")
+    }
+
+    static var ok: String {
+        localized("ok", en: "OK", de: "OK")
+    }
 
     // MARK: - Tabs
 
-    static var home: String { localized("home", en: "Home", de: "Startseite") }
-    static var foods: String { localized("foods", en: "Foods", de: "Lebensmittel") }
-    static var favorites: String { localized("favorites", en: "Favorites", de: "Favoriten") }
-    static var insights: String { localized("insights", en: "Insights", de: "Einblicke") }
-    static var settings: String { localized("settings", en: "Settings", de: "Einstellungen") }
+    static var home: String {
+        localized("home", en: "Home", de: "Startseite")
+    }
+
+    static var foods: String {
+        localized("foods", en: "Foods", de: "Lebensmittel")
+    }
+
+    static var favorites: String {
+        localized("favorites", en: "Favorites", de: "Favoriten")
+    }
+
+    static var insights: String {
+        localized("insights", en: "Insights", de: "Einblicke")
+    }
+
+    static var settings: String {
+        localized("settings", en: "Settings", de: "Einstellungen")
+    }
 
     // MARK: - Meals
 
-    static var breakfast: String { localized("breakfast", en: "Breakfast", de: "Frühstück") }
-    static var lunch: String { localized("lunch", en: "Lunch", de: "Mittagessen") }
-    static var dinner: String { localized("dinner", en: "Dinner", de: "Abendessen") }
-    static var snacks: String { localized("snacks", en: "Snacks", de: "Snacks") }
+    static var breakfast: String {
+        localized("breakfast", en: "Breakfast", de: "Frühstück")
+    }
+
+    static var lunch: String {
+        localized("lunch", en: "Lunch", de: "Mittagessen")
+    }
+
+    static var dinner: String {
+        localized("dinner", en: "Dinner", de: "Abendessen")
+    }
+
+    static var snacks: String {
+        localized("snacks", en: "Snacks", de: "Snacks")
+    }
 
     static func mealName(_ key: String) -> String {
         switch key.lowercased() {
-        case "breakfast": return breakfast
-        case "lunch": return lunch
-        case "dinner": return dinner
-        case "snacks", "snack": return snacks
-        default: return key.capitalized
+        case "breakfast": breakfast
+        case "lunch": lunch
+        case "dinner": dinner
+        case "snacks", "snack": snacks
+        default: key.capitalized
         }
     }
 
     // MARK: - Macros
 
-    static var calories: String { localized("calories", en: "Calories", de: "Kalorien") }
-    static var protein: String { localized("protein", en: "Protein", de: "Eiweiß") }
-    static var carbs: String { localized("carbs", en: "Carbs", de: "Kohlenhydrate") }
-    static var fat: String { localized("fat", en: "Fat", de: "Fett") }
-    static var fiber: String { localized("fiber", en: "Fiber", de: "Ballaststoffe") }
+    static var calories: String {
+        localized("calories", en: "Calories", de: "Kalorien")
+    }
+
+    static var protein: String {
+        localized("protein", en: "Protein", de: "Eiweiß")
+    }
+
+    static var carbs: String {
+        localized("carbs", en: "Carbs", de: "Kohlenhydrate")
+    }
+
+    static var fat: String {
+        localized("fat", en: "Fat", de: "Fett")
+    }
+
+    static var fiber: String {
+        localized("fiber", en: "Fiber", de: "Ballaststoffe")
+    }
 
     // MARK: - Dashboard
 
-    static var noEntriesYet: String { localized("no_entries_yet", en: "No entries yet today.", de: "Noch keine Einträge heute.") }
-    static var tapToAdd: String { localized("tap_to_add", en: "Tap + to add food.", de: "Tippe + um Essen hinzuzufügen.") }
-    static var goToToday: String { localized("go_to_today", en: "Go to Today", de: "Zu Heute") }
-    static var copyYesterday: String { localized("copy_yesterday", en: "Copy Yesterday", de: "Gestern kopieren") }
+    static var noEntriesYet: String {
+        localized(
+            "no_entries_yet",
+            en: "No entries yet today.",
+            de: "Noch keine Einträge heute."
+        )
+    }
+
+    static var tapToAdd: String {
+        localized("tap_to_add", en: "Tap + to add food.", de: "Tippe + um Essen hinzuzufügen.")
+    }
+
+    static var goToToday: String {
+        localized("go_to_today", en: "Go to Today", de: "Zu Heute")
+    }
+
+    static var copyYesterday: String {
+        localized("copy_yesterday", en: "Copy Yesterday", de: "Gestern kopieren")
+    }
 
     // MARK: - Foods
 
-    static var searchFoods: String { localized("search_foods", en: "Search foods...", de: "Lebensmittel suchen...") }
-    static var recent: String { localized("recent", en: "Recent", de: "Kürzlich") }
-    static var noResults: String { localized("no_results", en: "No results", de: "Keine Ergebnisse") }
-    static var noRecentFoods: String { localized("no_recent_foods", en: "Foods you log will appear here", de: "Eingetragene Lebensmittel erscheinen hier") }
-    static var createFood: String { localized("create_food", en: "Create Food", de: "Lebensmittel erstellen") }
-    static var editFood: String { localized("edit_food", en: "Edit Food", de: "Lebensmittel bearbeiten") }
-    static var servingSize: String { localized("serving_size", en: "Serving Size", de: "Portionsgröße") }
-    static var brand: String { localized("brand", en: "Brand", de: "Marke") }
-    static var barcode: String { localized("barcode", en: "Barcode", de: "Barcode") }
+    static var searchFoods: String {
+        localized("search_foods", en: "Search foods...", de: "Lebensmittel suchen...")
+    }
+
+    static var recent: String {
+        localized("recent", en: "Recent", de: "Kürzlich")
+    }
+
+    static var noResults: String {
+        localized("no_results", en: "No results", de: "Keine Ergebnisse")
+    }
+
+    static var noRecentFoods: String {
+        localized(
+            "no_recent_foods",
+            en: "Foods you log will appear here",
+            de: "Eingetragene Lebensmittel erscheinen hier"
+        )
+    }
+
+    static var createFood: String {
+        localized("create_food", en: "Create Food", de: "Lebensmittel erstellen")
+    }
+
+    static var editFood: String {
+        localized("edit_food", en: "Edit Food", de: "Lebensmittel bearbeiten")
+    }
+
+    static var servingSize: String {
+        localized("serving_size", en: "Serving Size", de: "Portionsgröße")
+    }
+
+    static var brand: String {
+        localized("brand", en: "Brand", de: "Marke")
+    }
+
+    static var barcode: String {
+        localized("barcode", en: "Barcode", de: "Barcode")
+    }
 
     // MARK: - Nutrition
 
-    static var mainMacros: String { localized("main_macros", en: "Main Macros", de: "Hauptnährstoffe") }
-    static var fatBreakdown: String { localized("fat_breakdown", en: "Fat Breakdown", de: "Fettaufschlüsselung") }
-    static var sugarsCarbs: String { localized("sugars_carbs", en: "Sugars & Carbs", de: "Zucker & Kohlenhydrate") }
-    static var minerals: String { localized("minerals", en: "Minerals", de: "Mineralstoffe") }
-    static var vitamins: String { localized("vitamins", en: "Vitamins", de: "Vitamine") }
-    static var other: String { localized("other", en: "Other", de: "Sonstige") }
-    static var nutrition: String { localized("nutrition", en: "Nutrition", de: "Nährwerte") }
-    static var quality: String { localized("quality", en: "Quality", de: "Qualität") }
-    static var ingredients: String { localized("ingredients", en: "Ingredients", de: "Zutaten") }
-    static var nutriScore: String { localized("nutri_score", en: "Nutri-Score", de: "Nutri-Score") }
-    static var novaGroup: String { localized("nova_group", en: "NOVA Group", de: "NOVA-Gruppe") }
-    static var logged: String { localized("logged", en: "logged", de: "eingetragen") }
-    static var failedToLog: String { localized("failed_to_log", en: "Failed to log", de: "Eintragung fehlgeschlagen") }
+    static var mainMacros: String {
+        localized("main_macros", en: "Main Macros", de: "Hauptnährstoffe")
+    }
+
+    static var fatBreakdown: String {
+        localized("fat_breakdown", en: "Fat Breakdown", de: "Fettaufschlüsselung")
+    }
+
+    static var sugarsCarbs: String {
+        localized("sugars_carbs", en: "Sugars & Carbs", de: "Zucker & Kohlenhydrate")
+    }
+
+    static var minerals: String {
+        localized("minerals", en: "Minerals", de: "Mineralstoffe")
+    }
+
+    static var vitamins: String {
+        localized("vitamins", en: "Vitamins", de: "Vitamine")
+    }
+
+    static var other: String {
+        localized("other", en: "Other", de: "Sonstige")
+    }
+
+    static var nutrition: String {
+        localized("nutrition", en: "Nutrition", de: "Nährwerte")
+    }
+
+    static var quality: String {
+        localized("quality", en: "Quality", de: "Qualität")
+    }
+
+    static var ingredients: String {
+        localized("ingredients", en: "Ingredients", de: "Zutaten")
+    }
+
+    static var nutriScore: String {
+        localized("nutri_score", en: "Nutri-Score", de: "Nutri-Score")
+    }
+
+    static var novaGroup: String {
+        localized("nova_group", en: "NOVA Group", de: "NOVA-Gruppe")
+    }
+
+    static var logged: String {
+        localized("logged", en: "logged", de: "eingetragen")
+    }
+
+    static var failedToLog: String {
+        localized("failed_to_log", en: "Failed to log", de: "Eintragung fehlgeschlagen")
+    }
 
     // MARK: - Entries
 
-    static var logFood: String { localized("log_food", en: "Log Food", de: "Essen eintragen") }
-    static var servings: String { localized("servings", en: "Servings", de: "Portionen") }
-    static var meal: String { localized("meal", en: "Meal", de: "Mahlzeit") }
-    static var quickEntry: String { localized("quick_entry", en: "Quick Entry", de: "Schnelleintrag") }
-    static var editEntry: String { localized("edit_entry", en: "Edit Entry", de: "Eintrag bearbeiten") }
-    static var logRecipe: String { localized("log_recipe", en: "Log Recipe", de: "Rezept eintragen") }
-    static var noEntries: String { localized("no_entries", en: "No entries", de: "Keine Einträge") }
-    static var noFavorites: String { localized("no_favorites", en: "No favorites", de: "Keine Favoriten") }
-    static var markFavoritesHint: String { localized("mark_favorites_hint", en: "Mark foods as favorites to see them here", de: "Markiere Lebensmittel als Favoriten") }
-    static var markRecipeFavoritesHint: String { localized("mark_recipe_favorites_hint", en: "Mark recipes as favorites to see them here", de: "Markiere Rezepte als Favoriten") }
-    static var addFood: String { localized("add_food", en: "Add Food", de: "Essen hinzufügen") }
+    static var logFood: String {
+        localized("log_food", en: "Log Food", de: "Essen eintragen")
+    }
+
+    static var servings: String {
+        localized("servings", en: "Servings", de: "Portionen")
+    }
+
+    static var meal: String {
+        localized("meal", en: "Meal", de: "Mahlzeit")
+    }
+
+    static var quickEntry: String {
+        localized("quick_entry", en: "Quick Entry", de: "Schnelleintrag")
+    }
+
+    static var editEntry: String {
+        localized("edit_entry", en: "Edit Entry", de: "Eintrag bearbeiten")
+    }
+
+    static var logRecipe: String {
+        localized("log_recipe", en: "Log Recipe", de: "Rezept eintragen")
+    }
+
+    static var noEntries: String {
+        localized("no_entries", en: "No entries", de: "Keine Einträge")
+    }
+
+    static var noFavorites: String {
+        localized("no_favorites", en: "No favorites", de: "Keine Favoriten")
+    }
+
+    static var markFavoritesHint: String {
+        localized(
+            "mark_favorites_hint",
+            en: "Mark foods as favorites to see them here",
+            de: "Markiere Lebensmittel als Favoriten"
+        )
+    }
+
+    static var markRecipeFavoritesHint: String {
+        localized(
+            "mark_recipe_favorites_hint",
+            en: "Mark recipes as favorites to see them here",
+            de: "Markiere Rezepte als Favoriten"
+        )
+    }
+
+    static var addFood: String {
+        localized("add_food", en: "Add Food", de: "Essen hinzufügen")
+    }
 
     // MARK: - Recipes
 
-    static var recipes: String { localized("recipes", en: "Recipes", de: "Rezepte") }
-    static var createRecipe: String { localized("create_recipe", en: "Create Recipe", de: "Rezept erstellen") }
-    static var editRecipe: String { localized("edit_recipe", en: "Edit Recipe", de: "Rezept bearbeiten") }
-    static var totalServings: String { localized("total_servings", en: "Total Servings", de: "Gesamtportionen") }
-    static var perServing: String { localized("per_serving", en: "Per Serving", de: "Pro Portion") }
-    static var totals: String { localized("totals", en: "Totals", de: "Gesamt") }
-    static var addIngredient: String { localized("add_ingredient", en: "Add Ingredient", de: "Zutat hinzufügen") }
+    static var recipes: String {
+        localized("recipes", en: "Recipes", de: "Rezepte")
+    }
+
+    static var createRecipe: String {
+        localized("create_recipe", en: "Create Recipe", de: "Rezept erstellen")
+    }
+
+    static var editRecipe: String {
+        localized("edit_recipe", en: "Edit Recipe", de: "Rezept bearbeiten")
+    }
+
+    static var totalServings: String {
+        localized("total_servings", en: "Total Servings", de: "Gesamtportionen")
+    }
+
+    static var perServing: String {
+        localized("per_serving", en: "Per Serving", de: "Pro Portion")
+    }
+
+    static var totals: String {
+        localized("totals", en: "Totals", de: "Gesamt")
+    }
+
+    static var addIngredient: String {
+        localized("add_ingredient", en: "Add Ingredient", de: "Zutat hinzufügen")
+    }
 
     // MARK: - Goals
 
-    static var goals: String { localized("goals", en: "Goals", de: "Ziele") }
-    static var editGoals: String { localized("edit_goals", en: "Edit Goals", de: "Ziele bearbeiten") }
-    static var dailyGoals: String { localized("daily_goals", en: "Daily Goals", de: "Tagesziele") }
+    static var goals: String {
+        localized("goals", en: "Goals", de: "Ziele")
+    }
+
+    static var editGoals: String {
+        localized("edit_goals", en: "Edit Goals", de: "Ziele bearbeiten")
+    }
+
+    static var dailyGoals: String {
+        localized("daily_goals", en: "Daily Goals", de: "Tagesziele")
+    }
 
     // MARK: - Weight
 
-    static var weight: String { localized("weight", en: "Weight", de: "Gewicht") }
-    static var logWeight: String { localized("log_weight", en: "Log Weight", de: "Gewicht eintragen") }
-    static var current: String { localized("current", en: "Current", de: "Aktuell") }
-    static var change: String { localized("change", en: "Change", de: "Änderung") }
-    static var history: String { localized("history", en: "History", de: "Verlauf") }
-    static var trend: String { localized("trend", en: "Trend", de: "Trend") }
+    static var weight: String {
+        localized("weight", en: "Weight", de: "Gewicht")
+    }
+
+    static var logWeight: String {
+        localized("log_weight", en: "Log Weight", de: "Gewicht eintragen")
+    }
+
+    static var current: String {
+        localized("current", en: "Current", de: "Aktuell")
+    }
+
+    static var change: String {
+        localized("change", en: "Change", de: "Änderung")
+    }
+
+    static var history: String {
+        localized("history", en: "History", de: "Verlauf")
+    }
+
+    static var trend: String {
+        localized("trend", en: "Trend", de: "Trend")
+    }
 
     // MARK: - Supplements
 
-    static var supplements: String { localized("supplements", en: "Supplements", de: "Nahrungsergänzung") }
-    static var createSupplement: String { localized("create_supplement", en: "Create Supplement", de: "Supplement erstellen") }
-    static var editSupplement: String { localized("edit_supplement", en: "Edit Supplement", de: "Supplement bearbeiten") }
-    static var daily: String { localized("daily", en: "Daily", de: "Täglich") }
-    static var everyOtherDay: String { localized("every_other_day", en: "Every other day", de: "Jeden zweiten Tag") }
-    static var weekly: String { localized("weekly", en: "Weekly", de: "Wöchentlich") }
-    static var custom: String { localized("custom", en: "Custom", de: "Benutzerdefiniert") }
-    static var morning: String { localized("morning", en: "Morning", de: "Morgens") }
-    static var noon: String { localized("noon", en: "Noon", de: "Mittags") }
-    static var evening: String { localized("evening", en: "Evening", de: "Abends") }
-    static var anytime: String { localized("anytime", en: "Anytime", de: "Jederzeit") }
-    static var supplementHistory: String { localized("supplement_history", en: "Supplement History", de: "Supplement-Verlauf") }
-    static var adherence: String { localized("adherence", en: "Adherence", de: "Einhaltung") }
+    static var supplements: String {
+        localized("supplements", en: "Supplements", de: "Nahrungsergänzung")
+    }
+
+    static var createSupplement: String {
+        localized(
+            "create_supplement",
+            en: "Create Supplement",
+            de: "Supplement erstellen"
+        )
+    }
+
+    static var editSupplement: String {
+        localized("edit_supplement", en: "Edit Supplement", de: "Supplement bearbeiten")
+    }
+
+    static var daily: String {
+        localized("daily", en: "Daily", de: "Täglich")
+    }
+
+    static var everyOtherDay: String {
+        localized("every_other_day", en: "Every other day", de: "Jeden zweiten Tag")
+    }
+
+    static var weekly: String {
+        localized("weekly", en: "Weekly", de: "Wöchentlich")
+    }
+
+    static var custom: String {
+        localized("custom", en: "Custom", de: "Benutzerdefiniert")
+    }
+
+    static var morning: String {
+        localized("morning", en: "Morning", de: "Morgens")
+    }
+
+    static var noon: String {
+        localized("noon", en: "Noon", de: "Mittags")
+    }
+
+    static var evening: String {
+        localized("evening", en: "Evening", de: "Abends")
+    }
+
+    static var anytime: String {
+        localized("anytime", en: "Anytime", de: "Jederzeit")
+    }
+
+    static var supplementHistory: String {
+        localized(
+            "supplement_history",
+            en: "Supplement History",
+            de: "Supplement-Verlauf"
+        )
+    }
+
+    static var adherence: String {
+        localized("adherence", en: "Adherence", de: "Einhaltung")
+    }
 
     // MARK: - Insights
 
-    static var streaks: String { localized("streaks", en: "Streaks", de: "Serien") }
-    static var currentStreak: String { localized("current_streak", en: "Current", de: "Aktuell") }
-    static var longestStreak: String { localized("longest_streak", en: "Longest", de: "Längste") }
-    static var weeklyAvg: String { localized("weekly_avg", en: "Weekly Average", de: "Wochendurchschnitt") }
-    static var monthlyAvg: String { localized("monthly_avg", en: "Monthly Average", de: "Monatsdurchschnitt") }
-    static var topFoods: String { localized("top_foods", en: "Top Foods", de: "Top-Lebensmittel") }
-    static var mealBreakdown: String { localized("meal_breakdown", en: "Meal Breakdown", de: "Mahlzeitenverteilung") }
-    static var caloriesTrend: String { localized("calories_trend", en: "Calorie Trend", de: "Kalorientrend") }
-    static var macroTrends: String { localized("macro_trends", en: "Macro Trends", de: "Makro-Trends") }
-    static var goalAchievement: String { localized("goal_achievement", en: "Goal Achievement", de: "Zielerreichung") }
-    static var daysWithinGoal: String { localized("days_within_goal", en: "Days within goal range", de: "Tage im Zielbereich") }
-    static var dayPeriod: String { localized("day_period", en: "day period", de: "Tage Zeitraum") }
-    static var avgComparison: String { localized("avg_comparison", en: "Average Comparison", de: "Durchschnittsvergleich") }
-    static var quickActions: String { localized("quick_actions", en: "Quick Actions", de: "Schnellaktionen") }
-    static var favoriteLogging: String { localized("favorite_logging", en: "Favorite Logging", de: "Favoriten-Eintragung") }
-    static var autoAssignByTime: String { localized("auto_assign_by_time", en: "Auto-assign by time", de: "Automatisch nach Uhrzeit") }
-    static var alwaysAsk: String { localized("always_ask", en: "Always ask", de: "Immer nachfragen") }
-    static var quickLog: String { localized("quick_log", en: "Quick Log", de: "Schnelleintrag") }
-    static var additives: String { localized("additives", en: "Additives", de: "Zusatzstoffe") }
-    static var inactive: String { localized("inactive", en: "Inactive", de: "Inaktiv") }
+    static var streaks: String {
+        localized("streaks", en: "Streaks", de: "Serien")
+    }
+
+    static var currentStreak: String {
+        localized("current_streak", en: "Current", de: "Aktuell")
+    }
+
+    static var longestStreak: String {
+        localized("longest_streak", en: "Longest", de: "Längste")
+    }
+
+    static var weeklyAvg: String {
+        localized("weekly_avg", en: "Weekly Average", de: "Wochendurchschnitt")
+    }
+
+    static var monthlyAvg: String {
+        localized("monthly_avg", en: "Monthly Average", de: "Monatsdurchschnitt")
+    }
+
+    static var topFoods: String {
+        localized("top_foods", en: "Top Foods", de: "Top-Lebensmittel")
+    }
+
+    static var mealBreakdown: String {
+        localized("meal_breakdown", en: "Meal Breakdown", de: "Mahlzeitenverteilung")
+    }
+
+    static var caloriesTrend: String {
+        localized("calories_trend", en: "Calorie Trend", de: "Kalorientrend")
+    }
+
+    static var macroTrends: String {
+        localized("macro_trends", en: "Macro Trends", de: "Makro-Trends")
+    }
+
+    static var goalAchievement: String {
+        localized("goal_achievement", en: "Goal Achievement", de: "Zielerreichung")
+    }
+
+    static var daysWithinGoal: String {
+        localized(
+            "days_within_goal",
+            en: "Days within goal range",
+            de: "Tage im Zielbereich"
+        )
+    }
+
+    static var dayPeriod: String {
+        localized("day_period", en: "day period", de: "Tage Zeitraum")
+    }
+
+    static var avgComparison: String {
+        localized(
+            "avg_comparison",
+            en: "Average Comparison",
+            de: "Durchschnittsvergleich"
+        )
+    }
+
+    static var quickActions: String {
+        localized("quick_actions", en: "Quick Actions", de: "Schnellaktionen")
+    }
+
+    static var favoriteLogging: String {
+        localized(
+            "favorite_logging",
+            en: "Favorite Logging",
+            de: "Favoriten-Eintragung"
+        )
+    }
+
+    static var autoAssignByTime: String {
+        localized(
+            "auto_assign_by_time",
+            en: "Auto-assign by time",
+            de: "Automatisch nach Uhrzeit"
+        )
+    }
+
+    static var alwaysAsk: String {
+        localized("always_ask", en: "Always ask", de: "Immer nachfragen")
+    }
+
+    static var quickLog: String {
+        localized("quick_log", en: "Quick Log", de: "Schnelleintrag")
+    }
+
+    static var additives: String {
+        localized("additives", en: "Additives", de: "Zusatzstoffe")
+    }
+
+    static var inactive: String {
+        localized("inactive", en: "Inactive", de: "Inaktiv")
+    }
 
     // MARK: - Calendar
 
-    static var calendar: String { localized("calendar", en: "Calendar", de: "Kalender") }
-    static var daysLogged: String { localized("days_logged", en: "Days Logged", de: "Tage eingetragen") }
-    static var daysOnTarget: String { localized("days_on_target", en: "Days on Target", de: "Tage im Ziel") }
+    static var calendar: String {
+        localized("calendar", en: "Calendar", de: "Kalender")
+    }
+
+    static var daysLogged: String {
+        localized("days_logged", en: "Days Logged", de: "Tage eingetragen")
+    }
+
+    static var daysOnTarget: String {
+        localized("days_on_target", en: "Days on Target", de: "Tage im Ziel")
+    }
 
     // MARK: - Maintenance
 
-    static var maintenance: String { localized("maintenance", en: "Maintenance", de: "Erhaltung") }
-    static var maintenanceCalories: String { localized("maintenance_calories", en: "Maintenance Calories", de: "Erhaltungskalorien") }
-    static var calculate: String { localized("calculate", en: "Calculate", de: "Berechnen") }
-    static var period: String { localized("period", en: "Period", de: "Zeitraum") }
-    static var weeks: String { localized("weeks", en: "weeks", de: "Wochen") }
-    static var bodyComposition: String { localized("body_composition", en: "Body Composition", de: "Körperzusammensetzung") }
-    static var dataCoverage: String { localized("data_coverage", en: "Data Coverage", de: "Datenabdeckung") }
+    static var maintenance: String {
+        localized("maintenance", en: "Maintenance", de: "Erhaltung")
+    }
+
+    static var maintenanceCalories: String {
+        localized(
+            "maintenance_calories",
+            en: "Maintenance Calories",
+            de: "Erhaltungskalorien"
+        )
+    }
+
+    static var calculate: String {
+        localized("calculate", en: "Calculate", de: "Berechnen")
+    }
+
+    static var period: String {
+        localized("period", en: "Period", de: "Zeitraum")
+    }
+
+    static var weeks: String {
+        localized("weeks", en: "weeks", de: "Wochen")
+    }
+
+    static var bodyComposition: String {
+        localized(
+            "body_composition",
+            en: "Body Composition",
+            de: "Körperzusammensetzung"
+        )
+    }
+
+    static var dataCoverage: String {
+        localized("data_coverage", en: "Data Coverage", de: "Datenabdeckung")
+    }
 
     // MARK: - Settings
 
-    static var signOut: String { localized("sign_out", en: "Sign Out", de: "Abmelden") }
-    static var signOutConfirmation: String { localized("sign_out_confirmation", en: "You will need to sign in again to use the app.", de: "Du musst dich erneut anmelden, um die App zu nutzen.") }
-    static var account: String { localized("account", en: "Account", de: "Konto") }
-    static var about: String { localized("about", en: "About", de: "Über") }
-    static var version: String { localized("version", en: "Version", de: "Version") }
-    static var language: String { localized("language", en: "Language", de: "Sprache") }
-    static var customMealTypes: String { localized("custom_meal_types", en: "Custom Meal Types", de: "Eigene Mahlzeittypen") }
-    static var visibleNutrients: String { localized("visible_nutrients", en: "Visible Nutrients", de: "Sichtbare Nährstoffe") }
-    static var dashboardWidgets: String { localized("dashboard_widgets", en: "Dashboard Widgets", de: "Dashboard-Widgets") }
-    static var favoriteBehavior: String { localized("favorite_behavior", en: "Favorite Behavior", de: "Favoriten-Verhalten") }
-    static var healthKit: String { localized("health_kit", en: "Health Integration", de: "Health-Integration") }
-    static var healthWriteWeight: String { localized("health_write_weight", en: "Write weight to Apple Health", de: "Gewicht in Apple Health schreiben") }
-    static var healthSyncFooter: String { localized("health_sync_footer", en: "Weights from Apple Health are imported automatically. Enable writing only if you log weight here and want it in Apple Health — leave it off if your scale already syncs to Health.", de: "Gewichte aus Apple Health werden automatisch importiert. Aktiviere das Schreiben nur, wenn du dein Gewicht hier erfasst und es in Apple Health haben möchtest — lass es aus, wenn deine Waage bereits mit Health synchronisiert.") }
+    static var signOut: String {
+        localized("sign_out", en: "Sign Out", de: "Abmelden")
+    }
+
+    static var signOutConfirmation: String {
+        localized(
+            "sign_out_confirmation",
+            en: "You will need to sign in again to use the app.",
+            de: "Du musst dich erneut anmelden, um die App zu nutzen."
+        )
+    }
+
+    static var account: String {
+        localized("account", en: "Account", de: "Konto")
+    }
+
+    static var about: String {
+        localized("about", en: "About", de: "Über")
+    }
+
+    static var version: String {
+        localized("version", en: "Version", de: "Version")
+    }
+
+    static var language: String {
+        localized("language", en: "Language", de: "Sprache")
+    }
+
+    static var customMealTypes: String {
+        localized(
+            "custom_meal_types",
+            en: "Custom Meal Types",
+            de: "Eigene Mahlzeittypen"
+        )
+    }
+
+    static var visibleNutrients: String {
+        localized(
+            "visible_nutrients",
+            en: "Visible Nutrients",
+            de: "Sichtbare Nährstoffe"
+        )
+    }
+
+    static var dashboardWidgets: String {
+        localized(
+            "dashboard_widgets",
+            en: "Dashboard Widgets",
+            de: "Dashboard-Widgets"
+        )
+    }
+
+    static var favoriteBehavior: String {
+        localized(
+            "favorite_behavior",
+            en: "Favorite Behavior",
+            de: "Favoriten-Verhalten"
+        )
+    }
+
+    static var healthKit: String {
+        localized("health_kit", en: "Health Integration", de: "Health-Integration")
+    }
+
+    static var healthWriteWeight: String {
+        localized(
+            "health_write_weight",
+            en: "Write weight to Apple Health",
+            de: "Gewicht in Apple Health schreiben"
+        )
+    }
+
+    static var healthSyncFooter: String {
+        localized(
+            "health_sync_footer",
+            en: "Weights from Apple Health are imported automatically. Enable writing only if you log weight here and want it in Apple Health — leave it off if your scale already syncs to Health.",
+            de: "Gewichte aus Apple Health werden automatisch importiert. Aktiviere das Schreiben nur, wenn du dein Gewicht hier erfasst und es in Apple Health haben möchtest — lass es aus, wenn deine Waage bereits mit Health synchronisiert."
+        )
+    }
 
     // MARK: - Scanner
 
-    static var scanBarcode: String { localized("scan_barcode", en: "Scan Barcode", de: "Barcode scannen") }
-    static var lookingUp: String { localized("looking_up", en: "Looking up barcode...", de: "Barcode wird gesucht...") }
-    static var notFound: String { localized("not_found", en: "No food found for this barcode", de: "Kein Lebensmittel für diesen Barcode gefunden") }
-    static var cameraRequired: String { localized("camera_required", en: "Camera access required", de: "Kamerazugriff erforderlich") }
-    static var openSettings: String { localized("open_settings", en: "Open Settings", de: "Einstellungen öffnen") }
-    static var enableCameraHint: String { localized("enable_camera_hint", en: "Enable camera access in Settings to scan barcodes.", de: "Aktiviere den Kamerazugriff in den Einstellungen, um Barcodes zu scannen.") }
-    static var createFoodForBarcode: String { localized("create_food_for_barcode", en: "Create food for this barcode", de: "Lebensmittel für diesen Barcode erstellen") }
-    static var torch: String { localized("torch", en: "Torch", de: "Taschenlampe") }
+    static var scanBarcode: String {
+        localized("scan_barcode", en: "Scan Barcode", de: "Barcode scannen")
+    }
+
+    static var lookingUp: String {
+        localized("looking_up", en: "Looking up barcode...", de: "Barcode wird gesucht...")
+    }
+
+    static var notFound: String {
+        localized(
+            "not_found",
+            en: "No food found for this barcode",
+            de: "Kein Lebensmittel für diesen Barcode gefunden"
+        )
+    }
+
+    static var cameraRequired: String {
+        localized(
+            "camera_required",
+            en: "Camera access required",
+            de: "Kamerazugriff erforderlich"
+        )
+    }
+
+    static var openSettings: String {
+        localized("open_settings", en: "Open Settings", de: "Einstellungen öffnen")
+    }
+
+    static var enableCameraHint: String {
+        localized(
+            "enable_camera_hint",
+            en: "Enable camera access in Settings to scan barcodes.",
+            de: "Aktiviere den Kamerazugriff in den Einstellungen, um Barcodes zu scannen."
+        )
+    }
+
+    static var createFoodForBarcode: String {
+        localized(
+            "create_food_for_barcode",
+            en: "Create food for this barcode",
+            de: "Lebensmittel für diesen Barcode erstellen"
+        )
+    }
+
+    static var torch: String {
+        localized("torch", en: "Torch", de: "Taschenlampe")
+    }
 
     // MARK: - Login
 
-    static var trackNutrition: String { localized("track_nutrition", en: "Track your nutrition", de: "Verfolge deine Ernährung") }
-    static var signIn: String { localized("sign_in", en: "Sign in", de: "Anmelden") }
+    static var trackNutrition: String {
+        localized(
+            "track_nutrition",
+            en: "Track your nutrition",
+            de: "Verfolge deine Ernährung"
+        )
+    }
+
+    static var signIn: String {
+        localized("sign_in", en: "Sign in", de: "Anmelden")
+    }
 
     // MARK: - Day Properties
 
-    static var fastingDay: String { localized("fasting_day", en: "Fasting Day", de: "Fastentag") }
-    static var fastingDayToggle: String { localized("fasting_day_toggle", en: "Mark as fasting day", de: "Als Fastentag markieren") }
-    static var fastingDayDescription: String { localized("fasting_day_description", en: "Include this 0-calorie day in statistics and predictions", de: "Diesen 0-Kalorien-Tag in Statistiken und Prognosen einbeziehen") }
+    static var fastingDay: String {
+        localized("fasting_day", en: "Fasting Day", de: "Fastentag")
+    }
+
+    static var fastingDayToggle: String {
+        localized(
+            "fasting_day_toggle",
+            en: "Mark as fasting day",
+            de: "Als Fastentag markieren"
+        )
+    }
+
+    static var fastingDayDescription: String {
+        localized(
+            "fasting_day_description",
+            en: "Include this 0-calorie day in statistics and predictions",
+            de: "Diesen 0-Kalorien-Tag in Statistiken und Prognosen einbeziehen"
+        )
+    }
 
     // MARK: - Weight (additional)
 
-    static var latestWeight: String { localized("latest_weight", en: "Latest", de: "Aktuell") }
-    static var trendWeight: String { localized("trend_weight", en: "Trend", de: "Trend") }
-    static var delta7d: String { localized("delta_7d", en: "7d Change", de: "7-Tage-Änderung") }
-    static var projected: String { localized("projected", en: "Projected", de: "Prognose") }
-    static var projection14d: String { localized("projection_14d", en: "14d", de: "14T") }
-    static var projection30d: String { localized("projection_30d", en: "30d", de: "30T") }
-    static var projection60d: String { localized("projection_60d", en: "60d", de: "60T") }
-    static var movingAverage7d: String { localized("moving_average_7d", en: "7d avg", de: "7T Ø") }
-    static var notes: String { localized("notes", en: "Notes", de: "Notizen") }
+    static var latestWeight: String {
+        localized("latest_weight", en: "Latest", de: "Aktuell")
+    }
+
+    static var trendWeight: String {
+        localized("trend_weight", en: "Trend", de: "Trend")
+    }
+
+    static var delta7d: String {
+        localized("delta_7d", en: "7d Change", de: "7-Tage-Änderung")
+    }
+
+    static var projected: String {
+        localized("projected", en: "Projected", de: "Prognose")
+    }
+
+    static var projection14d: String {
+        localized("projection_14d", en: "14d", de: "14T")
+    }
+
+    static var projection30d: String {
+        localized("projection_30d", en: "30d", de: "30T")
+    }
+
+    static var projection60d: String {
+        localized("projection_60d", en: "60d", de: "60T")
+    }
+
+    static var movingAverage7d: String {
+        localized("moving_average_7d", en: "7d avg", de: "7T Ø")
+    }
+
+    static var notes: String {
+        localized("notes", en: "Notes", de: "Notizen")
+    }
 
     // MARK: - Insights (additional)
 
-    static var calendarHeatmap: String { localized("calendar_heatmap", en: "Calendar", de: "Kalender") }
-    static var macroBalance: String { localized("macro_balance", en: "Macro Balance", de: "Makro-Balance") }
-    static var onTarget: String { localized("on_target", en: "On Target", de: "Im Ziel") }
-    static var hasEntries: String { localized("has_entries", en: "Has Entries", de: "Einträge vorhanden") }
-    static var noData: String { localized("no_data", en: "No data", de: "Keine Daten") }
-    static var average: String { localized("average", en: "Avg", de: "Ø") }
-    static var avgCalories: String { localized("avg_calories", en: "Avg Calories", de: "Ø Kalorien") }
+    static var calendarHeatmap: String {
+        localized("calendar_heatmap", en: "Calendar", de: "Kalender")
+    }
+
+    static var macroBalance: String {
+        localized("macro_balance", en: "Macro Balance", de: "Makro-Balance")
+    }
+
+    static var onTarget: String {
+        localized("on_target", en: "On Target", de: "Im Ziel")
+    }
+
+    static var hasEntries: String {
+        localized("has_entries", en: "Has Entries", de: "Einträge vorhanden")
+    }
+
+    static var noData: String {
+        localized("no_data", en: "No data", de: "Keine Daten")
+    }
+
+    static var average: String {
+        localized("average", en: "Avg", de: "Ø")
+    }
+
+    static var avgCalories: String {
+        localized("avg_calories", en: "Avg Calories", de: "Ø Kalorien")
+    }
 
     // MARK: - HealthKit (additional)
 
-    static var permissionsGranted: String { localized("permissions_granted", en: "Permissions granted", de: "Berechtigungen erteilt") }
-    static var grantPermissions: String { localized("grant_permissions", en: "Grant Permissions", de: "Berechtigungen erteilen") }
+    static var permissionsGranted: String {
+        localized(
+            "permissions_granted",
+            en: "Permissions granted",
+            de: "Berechtigungen erteilt"
+        )
+    }
+
+    static var grantPermissions: String {
+        localized(
+            "grant_permissions",
+            en: "Grant Permissions",
+            de: "Berechtigungen erteilen"
+        )
+    }
 
     // MARK: - Visible Nutrients (additional)
 
-    static var selectAll: String { localized("select_all", en: "Select All", de: "Alle auswählen") }
-    static var deselectAll: String { localized("deselect_all", en: "Deselect All", de: "Alle abwählen") }
-    static var fatBreakdownCategory: String { localized("fat_breakdown_category", en: "Fat Breakdown", de: "Fettaufschlüsselung") }
-    static var sugarsAndCarbs: String { localized("sugars_and_carbs", en: "Sugars & Carbs", de: "Zucker & Kohlenhydrate") }
+    static var selectAll: String {
+        localized("select_all", en: "Select All", de: "Alle auswählen")
+    }
+
+    static var deselectAll: String {
+        localized("deselect_all", en: "Deselect All", de: "Alle abwählen")
+    }
+
+    static var fatBreakdownCategory: String {
+        localized(
+            "fat_breakdown_category",
+            en: "Fat Breakdown",
+            de: "Fettaufschlüsselung"
+        )
+    }
+
+    static var sugarsAndCarbs: String {
+        localized("sugars_and_carbs", en: "Sugars & Carbs", de: "Zucker & Kohlenhydrate")
+    }
 
     // MARK: - Maintenance (additional)
 
-    static var avgDailyIntake: String { localized("avg_daily_intake", en: "Avg Daily Intake", de: "Ø Tagesaufnahme") }
-    static var dailyDeficitSurplus: String { localized("daily_deficit_surplus", en: "Daily Surplus/Deficit", de: "Täglicher Überschuss/Defizit") }
-    static var weightChange: String { localized("weight_change", en: "Weight Change", de: "Gewichtsänderung") }
-    static var fatChange: String { localized("fat_change", en: "Fat Change", de: "Fettänderung") }
-    static var muscleChange: String { localized("muscle_change", en: "Muscle Change", de: "Muskeländerung") }
-    static var totalDays: String { localized("total_days", en: "Total Days", de: "Gesamttage") }
-    static var weightEntries: String { localized("weight_entries", en: "Weight Entries", de: "Gewichtseinträge") }
-    static var foodEntryDays: String { localized("food_entry_days", en: "Food Entry Days", de: "Tage mit Einträgen") }
-    static var coverage: String { localized("coverage", en: "Coverage", de: "Abdeckung") }
-    static var startWeight: String { localized("start_weight", en: "Start Weight", de: "Startgewicht") }
-    static var endWeight: String { localized("end_weight", en: "End Weight", de: "Endgewicht") }
-    static var lowCoverageWarning: String { localized("low_coverage_warning", en: "Low data coverage may affect accuracy", de: "Geringe Datenabdeckung kann die Genauigkeit beeinflussen") }
-    static var kcalPerDay: String { localized("kcal_per_day", en: "kcal/day", de: "kcal/Tag") }
-    static var fatLabel: String { localized("fat_label", en: "Fat", de: "Fett") }
-    static var muscleLabel: String { localized("muscle_label", en: "Muscle", de: "Muskel") }
+    static var avgDailyIntake: String {
+        localized("avg_daily_intake", en: "Avg Daily Intake", de: "Ø Tagesaufnahme")
+    }
+
+    static var dailyDeficitSurplus: String {
+        localized(
+            "daily_deficit_surplus",
+            en: "Daily Surplus/Deficit",
+            de: "Täglicher Überschuss/Defizit"
+        )
+    }
+
+    static var weightChange: String {
+        localized("weight_change", en: "Weight Change", de: "Gewichtsänderung")
+    }
+
+    static var fatChange: String {
+        localized("fat_change", en: "Fat Change", de: "Fettänderung")
+    }
+
+    static var muscleChange: String {
+        localized("muscle_change", en: "Muscle Change", de: "Muskeländerung")
+    }
+
+    static var totalDays: String {
+        localized("total_days", en: "Total Days", de: "Gesamttage")
+    }
+
+    static var weightEntries: String {
+        localized("weight_entries", en: "Weight Entries", de: "Gewichtseinträge")
+    }
+
+    static var foodEntryDays: String {
+        localized("food_entry_days", en: "Food Entry Days", de: "Tage mit Einträgen")
+    }
+
+    static var coverage: String {
+        localized("coverage", en: "Coverage", de: "Abdeckung")
+    }
+
+    static var startWeight: String {
+        localized("start_weight", en: "Start Weight", de: "Startgewicht")
+    }
+
+    static var endWeight: String {
+        localized("end_weight", en: "End Weight", de: "Endgewicht")
+    }
+
+    static var lowCoverageWarning: String {
+        localized(
+            "low_coverage_warning",
+            en: "Low data coverage may affect accuracy",
+            de: "Geringe Datenabdeckung kann die Genauigkeit beeinflussen"
+        )
+    }
+
+    static var kcalPerDay: String {
+        localized("kcal_per_day", en: "kcal/day", de: "kcal/Tag")
+    }
+
+    static var fatLabel: String {
+        localized("fat_label", en: "Fat", de: "Fett")
+    }
+
+    static var muscleLabel: String {
+        localized("muscle_label", en: "Muscle", de: "Muskel")
+    }
 
     // MARK: - Supplement History (additional)
 
-    static var taken: String { localized("taken", en: "Taken", de: "Eingenommen") }
-    static var noHistoryForPeriod: String { localized("no_history_for_period", en: "No history for this period", de: "Kein Verlauf für diesen Zeitraum") }
-    static var from: String { localized("from", en: "From", de: "Von") }
-    static var to: String { localized("to", en: "To", de: "Bis") }
-    static var dateRange: String { localized("date_range", en: "Date Range", de: "Zeitraum") }
+    static var taken: String {
+        localized("taken", en: "Taken", de: "Eingenommen")
+    }
+
+    static var noHistoryForPeriod: String {
+        localized(
+            "no_history_for_period",
+            en: "No history for this period",
+            de: "Kein Verlauf für diesen Zeitraum"
+        )
+    }
+
+    static var from: String {
+        localized("from", en: "From", de: "Von")
+    }
+
+    static var to: String {
+        localized("to", en: "To", de: "Bis")
+    }
+
+    static var dateRange: String {
+        localized("date_range", en: "Date Range", de: "Zeitraum")
+    }
 
     // MARK: - Navigation Tabs
 
-    static var navigationTabs: String { localized("navigation_tabs", en: "Navigation Tabs", de: "Navigationsleiste") }
-    static var selectTabs: String { localized("select_tabs", en: "Select up to 3 tabs", de: "Wähle bis zu 3 Tabs") }
+    static var navigationTabs: String {
+        localized("navigation_tabs", en: "Navigation Tabs", de: "Navigationsleiste")
+    }
+
+    static var selectTabs: String {
+        localized("select_tabs", en: "Select up to 3 tabs", de: "Wähle bis zu 3 Tabs")
+    }
 
     // MARK: - Entries (additional)
 
@@ -305,25 +995,55 @@ enum L10n {
         localized("entries_copied", en: "\(count) entries copied", de: "\(count) Einträge kopiert")
     }
 
-    static var failedToCopy: String { localized("failed_to_copy", en: "Failed to copy entries", de: "Einträge konnten nicht kopiert werden") }
+    static var failedToCopy: String {
+        localized(
+            "failed_to_copy",
+            en: "Failed to copy entries",
+            de: "Einträge konnten nicht kopiert werden"
+        )
+    }
+
     static func copyConfirmation(to date: String) -> String {
-        localized("copy_confirmation", en: "Copy all entries from yesterday to \(date)?", de: "Alle Einträge von gestern nach \(date) kopieren?")
+        localized(
+            "copy_confirmation",
+            en: "Copy all entries from yesterday to \(date)?",
+            de: "Alle Einträge von gestern nach \(date) kopieren?"
+        )
     }
 
     // MARK: - NOVA Groups
 
-    static var novaUnprocessed: String { localized("nova_unprocessed", en: "Unprocessed", de: "Unverarbeitet") }
-    static var novaProcessedIngredients: String { localized("nova_processed_ingredients", en: "Processed ingredients", de: "Verarbeitete Zutaten") }
-    static var novaProcessed: String { localized("nova_processed", en: "Processed", de: "Verarbeitet") }
-    static var novaUltraProcessed: String { localized("nova_ultra_processed", en: "Ultra-processed", de: "Hochverarbeitet") }
+    static var novaUnprocessed: String {
+        localized("nova_unprocessed", en: "Unprocessed", de: "Unverarbeitet")
+    }
+
+    static var novaProcessedIngredients: String {
+        localized(
+            "nova_processed_ingredients",
+            en: "Processed ingredients",
+            de: "Verarbeitete Zutaten"
+        )
+    }
+
+    static var novaProcessed: String {
+        localized("nova_processed", en: "Processed", de: "Verarbeitet")
+    }
+
+    static var novaUltraProcessed: String {
+        localized(
+            "nova_ultra_processed",
+            en: "Ultra-processed",
+            de: "Hochverarbeitet"
+        )
+    }
 
     static func novaGroupDescription(_ group: Int) -> String {
         switch group {
-        case 1: return novaUnprocessed
-        case 2: return novaProcessedIngredients
-        case 3: return novaProcessed
-        case 4: return novaUltraProcessed
-        default: return localized("nova_unknown", en: "Unknown", de: "Unbekannt")
+        case 1: novaUnprocessed
+        case 2: novaProcessedIngredients
+        case 3: novaProcessed
+        case 4: novaUltraProcessed
+        default: localized("nova_unknown", en: "Unknown", de: "Unbekannt")
         }
     }
 
@@ -331,14 +1051,14 @@ enum L10n {
 
     static var weekdayHeaders: [String] {
         switch currentLocale {
-        case .en: return ["M", "T", "W", "T", "F", "S", "S"]
-        case .de: return ["M", "D", "M", "D", "F", "S", "S"]
+        case .en: ["M", "T", "W", "T", "F", "S", "S"]
+        case .de: ["M", "D", "M", "D", "F", "S", "S"]
         }
     }
 
     // MARK: - Private
 
-    nonisolated(unsafe) private static var _storedLocale: String?
+    private nonisolated(unsafe) static var _storedLocale: String?
 
     private static var storedLocale: String {
         get {
@@ -361,9 +1081,10 @@ enum L10n {
 
     private static func localized(_ key: String, en: String, de: String) -> String {
         switch currentLocale {
-        case .en: return en
-        case .de: return de
+        case .en: en
+        case .de: de
         }
     }
 }
+
 // swiftlint:enable type_body_length

--- a/mobile/iosApp/Bissbilanz/Views/BarcodeScannerView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/BarcodeScannerView.swift
@@ -2,6 +2,8 @@ import AVFoundation
 import SwiftUI
 
 struct BarcodeScannerView: View {
+    @Environment(FoodRepository.self) private var foodRepository
+    // Open Food Facts lookups are proxied by the server — they stay on the direct API.
     @Environment(BissbilanzAPI.self) private var api
     @Environment(\.dismiss) private var dismiss
 
@@ -158,11 +160,11 @@ struct BarcodeScannerView: View {
 
         Task {
             do {
-                if let food = try await api.findFoodByBarcode(barcode) {
+                if let food = try await foodRepository.findByBarcode(barcode) {
                     foundFood = food
                 } else if let food = try await api.lookupBarcode(barcode) {
                     // Found in Open Food Facts - create locally
-                    let created = try await api.createFood(FoodCreate(
+                    let created = try await foodRepository.createFood(FoodCreate(
                         name: food.name,
                         brand: food.brand,
                         servingSize: food.servingSize,

--- a/mobile/iosApp/Bissbilanz/Views/BarcodeScannerView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/BarcodeScannerView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 
 struct BarcodeScannerView: View {
     @Environment(FoodRepository.self) private var foodRepository
-    // Open Food Facts lookups are proxied by the server — they stay on the direct API.
+    // Open Food Facts lookups are proxied by the server in Synced mode; Local
+    // mode queries Open Food Facts directly (there is no backend session).
     @Environment(BissbilanzAPI.self) private var api
+    @Environment(AppModeManager.self) private var appModeManager
     @Environment(\.dismiss) private var dismiss
 
     @State private var scannedBarcode: String?
@@ -162,7 +164,7 @@ struct BarcodeScannerView: View {
             do {
                 if let food = try await foodRepository.findByBarcode(barcode) {
                     foundFood = food
-                } else if let food = try await api.lookupBarcode(barcode) {
+                } else if let food = try await lookupOpenFoodFacts(barcode) {
                     // Found in Open Food Facts - create locally
                     let created = try await foodRepository.createFood(FoodCreate(
                         name: food.name,
@@ -192,6 +194,16 @@ struct BarcodeScannerView: View {
                 UINotificationFeedbackGenerator().notificationOccurred(.error)
             }
             isSearching = false
+        }
+    }
+
+    /// Local mode has no backend session — query Open Food Facts directly;
+    /// Synced mode keeps using the authenticated server proxy.
+    private func lookupOpenFoodFacts(_ barcode: String) async throws -> Food? {
+        if appModeManager.isLocal {
+            try await OpenFoodFactsClient().lookupBarcode(barcode)
+        } else {
+            try await api.lookupBarcode(barcode)
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/CalendarView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/CalendarView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct CalendarView: View {
     @Environment(BissbilanzAPI.self) private var api
+    @Environment(AppModeManager.self) private var appModeManager
+    @Environment(EntryRepository.self) private var entryRepository
+    @Environment(GoalsRepository.self) private var goalsRepository
 
     @State private var currentMonth = Date()
     @State private var calendarDays: [CalendarDay] = []
@@ -192,10 +195,20 @@ struct CalendarView: View {
 
     private func loadData() async {
         isLoading = true
-        do {
-            calendarDays = try await api.getCalendarStats(month: month, year: year)
-        } catch {
-            calendarDays = []
+        if appModeManager.isLocal {
+            // In Local mode the local store holds every entry, so the month
+            // is aggregated locally instead of asking the server.
+            calendarDays = entryRepository.calendarDays(
+                year: year,
+                month: month,
+                calorieGoal: goalsRepository.goals()?.calorieGoal
+            )
+        } else {
+            do {
+                calendarDays = try await api.getCalendarStats(month: month, year: year)
+            } catch {
+                calendarDays = []
+            }
         }
         isLoading = false
     }

--- a/mobile/iosApp/Bissbilanz/Views/CalendarView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/CalendarView.swift
@@ -7,14 +7,28 @@ struct CalendarView: View {
     @State private var calendarDays: [CalendarDay] = []
     @State private var isLoading = true
 
-    private var weekdayHeaders: [String] { L10n.weekdayHeaders }
+    private var weekdayHeaders: [String] {
+        L10n.weekdayHeaders
+    }
+
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
 
-    private var year: Int { Calendar.current.component(.year, from: currentMonth) }
-    private var month: Int { Calendar.current.component(.month, from: currentMonth) }
+    private var year: Int {
+        Calendar.current.component(.year, from: currentMonth)
+    }
 
-    private var daysLogged: Int { calendarDays.filter { $0.calories > 0 }.count }
-    private var daysOnTarget: Int { calendarDays.filter { $0.metGoal }.count }
+    private var month: Int {
+        Calendar.current.component(.month, from: currentMonth)
+    }
+
+    private var daysLogged: Int {
+        calendarDays.filter { $0.calories > 0 }.count
+    }
+
+    private var daysOnTarget: Int {
+        calendarDays.filter(\.metGoal).count
+    }
+
     private var avgCalories: Double {
         let logged = calendarDays.filter { $0.calories > 0 }
         guard !logged.isEmpty else { return 0 }
@@ -83,7 +97,7 @@ struct CalendarView: View {
                 let offset = currentMonth.weekdayOffset
                 let daysInMonth = currentMonth.daysInMonth
 
-                ForEach(0..<(offset + daysInMonth), id: \.self) { index in
+                ForEach(0 ..< (offset + daysInMonth), id: \.self) { index in
                     if index < offset {
                         Color.clear.frame(height: 52)
                     } else {

--- a/mobile/iosApp/Bissbilanz/Views/ContentView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/ContentView.swift
@@ -44,10 +44,13 @@ enum NavigableTab: String, CaseIterable, Identifiable {
 }
 
 struct ContentView: View {
+    @Environment(AppModeManager.self) private var appModeManager
     @AppStorage("selected_tabs") private var selectedTabsRaw: String = "foods,favorites,insights"
 
     private var selectedTabs: [NavigableTab] {
-        selectedTabsRaw.split(separator: ",").compactMap { NavigableTab(rawValue: String($0)) }
+        let tabs = selectedTabsRaw.split(separator: ",").compactMap { NavigableTab(rawValue: String($0)) }
+        // Insights are server-computed stats — the tab is hidden in Local mode.
+        return appModeManager.isLocal ? tabs.filter { $0 != .insights } : tabs
     }
 
     var body: some View {

--- a/mobile/iosApp/Bissbilanz/Views/ContentView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/ContentView.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import SwiftUI
 
 enum NavigableTab: String, CaseIterable, Identifiable {
@@ -45,7 +46,10 @@ enum NavigableTab: String, CaseIterable, Identifiable {
 
 struct ContentView: View {
     @Environment(AppModeManager.self) private var appModeManager
+    @Environment(AuthManager.self) private var authManager
     @AppStorage("selected_tabs") private var selectedTabsRaw: String = "foods,favorites,insights"
+    @State private var showSessionExpiredPrompt = false
+    @State private var reauthSession: ASWebAuthenticationSession?
 
     private var selectedTabs: [NavigableTab] {
         let tabs = selectedTabsRaw.split(separator: ",").compactMap { NavigableTab(rawValue: String($0)) }
@@ -71,6 +75,21 @@ struct ContentView: View {
                 .tabItem {
                     Label(L10n.settings, systemImage: "gear")
                 }
+        }
+        // Only users who signed in initially are prompted — Local mode is
+        // anonymous by choice and never sees this.
+        .onChange(of: authManager.authState, initial: true) { _, state in
+            if state == .expired, !appModeManager.isLocal {
+                showSessionExpiredPrompt = true
+            }
+        }
+        .alert(L10n.sessionExpiredTitle, isPresented: $showSessionExpiredPrompt) {
+            Button(L10n.signIn) {
+                reauthSession = SignInFlow.start(authManager: authManager)
+            }
+            Button(L10n.notNow, role: .cancel) {}
+        } message: {
+            Text(L10n.sessionExpiredMessage)
         }
     }
 }

--- a/mobile/iosApp/Bissbilanz/Views/ContentView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/ContentView.swift
@@ -7,25 +7,27 @@ enum NavigableTab: String, CaseIterable, Identifiable {
     case weight
     case supplements
 
-    var id: String { rawValue }
+    var id: String {
+        rawValue
+    }
 
     var label: String {
         switch self {
-        case .foods: return L10n.foods
-        case .favorites: return L10n.favorites
-        case .insights: return L10n.insights
-        case .weight: return L10n.weight
-        case .supplements: return L10n.supplements
+        case .foods: L10n.foods
+        case .favorites: L10n.favorites
+        case .insights: L10n.insights
+        case .weight: L10n.weight
+        case .supplements: L10n.supplements
         }
     }
 
     var icon: String {
         switch self {
-        case .foods: return "fork.knife"
-        case .favorites: return "star"
-        case .insights: return "chart.bar"
-        case .weight: return "scalemass"
-        case .supplements: return "pills"
+        case .foods: "fork.knife"
+        case .favorites: "star"
+        case .insights: "chart.bar"
+        case .weight: "scalemass"
+        case .supplements: "pills"
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct DashboardView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(EntryRepository.self) private var entryRepository
+    @Environment(GoalsRepository.self) private var goalsRepository
+    @Environment(PreferencesRepository.self) private var preferencesRepository
+    @Environment(SupplementRepository.self) private var supplementRepository
+    @Environment(WeightRepository.self) private var weightRepository
 
     @State private var entries: [Entry] = []
     @State private var goals: Goals = .defaults
@@ -19,13 +23,29 @@ struct DashboardView: View {
     @State private var supplementChecklist: [SupplementChecklist] = []
     @State private var latestWeight: WeightEntry?
 
-    private var dateString: String { selectedDate.isoDateString }
+    private var dateString: String {
+        selectedDate.isoDateString
+    }
 
-    private var totalCalories: Double { entries.reduce(0) { $0 + $1.totalCalories } }
-    private var totalProtein: Double { entries.reduce(0) { $0 + $1.totalProtein } }
-    private var totalCarbs: Double { entries.reduce(0) { $0 + $1.totalCarbs } }
-    private var totalFat: Double { entries.reduce(0) { $0 + $1.totalFat } }
-    private var totalFiber: Double { entries.reduce(0) { $0 + $1.totalFiber } }
+    private var totalCalories: Double {
+        entries.reduce(0) { $0 + $1.totalCalories }
+    }
+
+    private var totalProtein: Double {
+        entries.reduce(0) { $0 + $1.totalProtein }
+    }
+
+    private var totalCarbs: Double {
+        entries.reduce(0) { $0 + $1.totalCarbs }
+    }
+
+    private var totalFat: Double {
+        entries.reduce(0) { $0 + $1.totalFat }
+    }
+
+    private var totalFiber: Double {
+        entries.reduce(0) { $0 + $1.totalFiber }
+    }
 
     private var mealGroups: [(String, [Entry])] {
         let grouped = Dictionary(grouping: entries, by: \.mealType)
@@ -71,11 +91,11 @@ struct DashboardView: View {
                         weightWidget(weight)
                     }
 
-                    if preferences.showSupplementsWidget && !supplementChecklist.isEmpty {
+                    if preferences.showSupplementsWidget, !supplementChecklist.isEmpty {
                         supplementsWidget
                     }
 
-                    if mealGroups.isEmpty && !isLoading {
+                    if mealGroups.isEmpty, !isLoading {
                         emptyState
                     } else {
                         ForEach(mealGroups, id: \.0) { meal, mealEntries in
@@ -170,11 +190,35 @@ struct DashboardView: View {
 
     private var macroRings: some View {
         HStack(spacing: 16) {
-            MacroRingView(label: "Cal", current: totalCalories, goal: goals.calorieGoal, color: MacroColors.calories, showGoal: true)
-            MacroRingView(label: "P", current: totalProtein, goal: goals.proteinGoal, color: MacroColors.protein, showGoal: true)
-            MacroRingView(label: "C", current: totalCarbs, goal: goals.carbGoal, color: MacroColors.carbs, showGoal: true)
+            MacroRingView(
+                label: "Cal",
+                current: totalCalories,
+                goal: goals.calorieGoal,
+                color: MacroColors.calories,
+                showGoal: true
+            )
+            MacroRingView(
+                label: "P",
+                current: totalProtein,
+                goal: goals.proteinGoal,
+                color: MacroColors.protein,
+                showGoal: true
+            )
+            MacroRingView(
+                label: "C",
+                current: totalCarbs,
+                goal: goals.carbGoal,
+                color: MacroColors.carbs,
+                showGoal: true
+            )
             MacroRingView(label: "F", current: totalFat, goal: goals.fatGoal, color: MacroColors.fat, showGoal: true)
-            MacroRingView(label: "Fb", current: totalFiber, goal: goals.fiberGoal, color: MacroColors.fiber, showGoal: true)
+            MacroRingView(
+                label: "Fb",
+                current: totalFiber,
+                goal: goals.fiberGoal,
+                color: MacroColors.fiber,
+                showGoal: true
+            )
         }
     }
 
@@ -215,7 +259,8 @@ struct DashboardView: View {
             }
             Spacer()
             if let dateStr = entry.loggedAt ?? entry.createdAt,
-               let date = DateFormatting.date(from: String(dateStr.prefix(10))) {
+               let date = DateFormatting.date(from: String(dateStr.prefix(10)))
+            {
                 Text(DateFormatting.displayString(from: date))
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
@@ -333,32 +378,42 @@ struct DashboardView: View {
 
     // MARK: - Data Loading
 
+    /// Instant render from the local store; `loadData` refreshes from the API on top.
+    private func loadFromStore() {
+        entries = entryRepository.entries(date: dateString)
+        goals = goalsRepository.goals() ?? .defaults
+        preferences = preferencesRepository.preferences() ?? .defaults
+        isFastingDay = entryRepository.isFastingDay(date: dateString)
+        supplementChecklist = supplementRepository.localChecklist(date: dateString)
+        latestWeight = weightRepository.latest()
+    }
+
     private func loadData() async {
+        loadFromStore()
         isLoading = true
         defer { isLoading = false }
 
-        async let entriesTask = api.getEntries(date: dateString)
-        async let goalsTask = api.getGoals()
-        async let prefsTask = api.getPreferences()
-        async let dayPropsTask = api.getDayProperties(date: dateString)
-        async let supplementsTask = api.getSupplementChecklist(date: dateString)
-        async let weightTask = api.getLatestWeight()
+        async let entriesTask: Void? = try? entryRepository.refresh(date: dateString)
+        async let goalsTask: Void? = try? goalsRepository.refresh()
+        async let prefsTask: Void? = try? preferencesRepository.refresh()
+        async let dayPropsTask: Void? = try? entryRepository.refreshDayProperties(date: dateString)
+        async let supplementsTask = try? supplementRepository.refreshChecklist(date: dateString)
+        async let weightTask: Void? = try? weightRepository.refresh()
 
-        do { entries = try await entriesTask } catch { entries = [] }
-        do { goals = try await goalsTask ?? .defaults } catch { goals = .defaults }
-        do { preferences = try await prefsTask } catch { preferences = .defaults }
-        do { isFastingDay = try await dayPropsTask?.isFastingDay ?? false } catch { isFastingDay = false }
-        do { supplementChecklist = try await supplementsTask } catch { supplementChecklist = [] }
-        do { latestWeight = try await weightTask } catch { latestWeight = nil }
+        _ = await (entriesTask, goalsTask, prefsTask, dayPropsTask, weightTask)
+        let checklist = await supplementsTask
+
+        loadFromStore()
+        if let checklist { supplementChecklist = checklist }
     }
 
     private func copyYesterday() async {
         let yesterday = selectedDate.adding(days: -1).isoDateString
         do {
-            let copied = try await api.copyEntries(fromDate: yesterday, toDate: dateString)
-            entries.append(contentsOf: copied)
+            let count = try await entryRepository.copyEntries(fromDate: yesterday, toDate: dateString)
+            entries = entryRepository.entries(date: dateString)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
-            toastMessage = L10n.entriesCopied(copied.count)
+            toastMessage = L10n.entriesCopied(count)
         } catch {
             UINotificationFeedbackGenerator().notificationOccurred(.error)
             toastMessage = L10n.failedToCopy
@@ -369,28 +424,29 @@ struct DashboardView: View {
         let newValue = !isFastingDay
         do {
             if newValue {
-                _ = try await api.setDayProperties(date: dateString, isFastingDay: true)
+                try await entryRepository.setDayProperties(date: dateString, isFastingDay: true)
             } else {
-                try await api.deleteDayProperties(date: dateString)
+                try await entryRepository.deleteDayProperties(date: dateString)
             }
-            isFastingDay = newValue
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         } catch {
             toastMessage = L10n.error
         }
+        isFastingDay = entryRepository.isFastingDay(date: dateString)
     }
 
     private func toggleSupplement(_ item: SupplementChecklist) async {
         do {
             if item.taken {
-                try await api.unlogSupplement(id: item.supplement.id, date: dateString)
+                try await supplementRepository.unlogSupplement(id: item.supplement.id, date: dateString)
             } else {
-                _ = try await api.logSupplement(id: item.supplement.id, date: dateString)
+                try await supplementRepository.logSupplement(id: item.supplement.id, date: dateString)
             }
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            supplementChecklist = (try? await api.getSupplementChecklist(date: dateString)) ?? supplementChecklist
         } catch {
             toastMessage = L10n.error
         }
+        supplementChecklist = await (try? supplementRepository.refreshChecklist(date: dateString))
+            ?? supplementRepository.localChecklist(date: dateString)
     }
 }

--- a/mobile/iosApp/Bissbilanz/Views/DayLogView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DayLogView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct DayLogView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(EntryRepository.self) private var entryRepository
     let date: String
 
     @State private var entries: [Entry] = []
@@ -202,23 +202,26 @@ struct DayLogView: View {
     }
 
     private func loadEntries(showSpinner: Bool = false) async {
-        if showSpinner { isLoading = true }
+        entries = entryRepository.entries(date: date)
+        if showSpinner { isLoading = entries.isEmpty }
         error = nil
         do {
-            entries = try await api.getEntries(date: date)
+            try await entryRepository.refresh(date: date)
+            entries = entryRepository.entries(date: date)
         } catch {
-            self.error = error
+            // Local data still renders — only block the screen when there is none.
+            if entries.isEmpty { self.error = error }
         }
         isLoading = false
     }
 
     private func deleteEntry(_ entry: Entry) async {
         do {
-            try await api.deleteEntry(id: entry.id)
-            entries.removeAll { $0.id == entry.id }
+            try await entryRepository.deleteEntry(id: entry.id)
         } catch {
             errorMessage = error.localizedDescription
         }
+        entries = entryRepository.entries(date: date)
     }
 
     private func copyYesterday() async {
@@ -226,9 +229,8 @@ struct DayLogView: View {
         let viewedDate = DateFormatting.date(from: date) ?? Date()
         let yesterday = viewedDate.adding(days: -1).isoDateString
         do {
-            // Copy responses are raw DB rows without resolved macros — reload instead
-            _ = try await api.copyEntries(fromDate: yesterday, toDate: date)
-            await loadEntries()
+            try await entryRepository.copyEntries(fromDate: yesterday, toDate: date)
+            entries = entryRepository.entries(date: date)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/mobile/iosApp/Bissbilanz/Views/FavoritesView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FavoritesView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
 struct FavoritesView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(FoodRepository.self) private var foodRepository
+    @Environment(RecipeRepository.self) private var recipeRepository
+    @Environment(EntryRepository.self) private var entryRepository
 
     @State private var favoriteFoods: [Food] = []
     @State private var favoriteRecipes: [Recipe] = []
@@ -122,9 +124,9 @@ struct FavoritesView: View {
     private func mealForCurrentTime() -> String {
         let hour = Calendar.current.component(.hour, from: Date())
         switch hour {
-        case 5..<11: return "breakfast"
-        case 11..<14: return "lunch"
-        case 14..<17: return "snacks"
+        case 5 ..< 11: return "breakfast"
+        case 11 ..< 14: return "lunch"
+        case 14 ..< 17: return "snacks"
         default: return "dinner"
         }
     }
@@ -138,7 +140,7 @@ struct FavoritesView: View {
             date: DateFormatting.today
         )
         do {
-            _ = try await api.createEntry(entry)
+            try await entryRepository.createEntry(entry, food: food)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             toastMessage = "\(food.name) \(L10n.logged)"
         } catch {
@@ -156,7 +158,7 @@ struct FavoritesView: View {
             date: DateFormatting.today
         )
         do {
-            _ = try await api.createEntry(entry)
+            try await entryRepository.createEntry(entry, recipe: recipe)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             toastMessage = "\(recipe.name) \(L10n.logged)"
         } catch {
@@ -166,15 +168,12 @@ struct FavoritesView: View {
     }
 
     private func loadFavorites() async {
-        isLoading = true
-        do {
-            let response = try await api.getFavorites()
-            favoriteFoods = response.foods
-            favoriteRecipes = response.recipes ?? []
-        } catch {
-            favoriteFoods = []
-            favoriteRecipes = []
-        }
+        favoriteFoods = foodRepository.favorites()
+        favoriteRecipes = recipeRepository.favoriteRecipes()
+        isLoading = favoriteFoods.isEmpty && favoriteRecipes.isEmpty
+        try? await foodRepository.refreshFavorites()
+        favoriteFoods = foodRepository.favorites()
+        favoriteRecipes = recipeRepository.favoriteRecipes()
         isLoading = false
     }
 }

--- a/mobile/iosApp/Bissbilanz/Views/FoodDetailView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodDetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct FoodDetailView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(FoodRepository.self) private var foodRepository
     @Environment(\.dismiss) private var dismiss
 
     let foodId: String
@@ -133,7 +133,9 @@ struct FoodDetailView: View {
             NutrientSection(title: L10n.vitamins, nutrients: food.vitaminNutrients)
             NutrientSection(title: L10n.other, nutrients: food.otherNutrients)
 
-            if food.nutriScore != nil || food.novaGroup != nil || !(food.additives?.isEmpty ?? true) || !(food.ingredientsText?.isEmpty ?? true) {
+            if food.nutriScore != nil || food
+                .novaGroup != nil || !(food.additives?.isEmpty ?? true) || !(food.ingredientsText?.isEmpty ?? true)
+            {
                 Section(L10n.quality) {
                     if let nutriScore = food.nutriScore {
                         VStack(alignment: .leading, spacing: 6) {
@@ -274,27 +276,31 @@ struct FoodDetailView: View {
         guard let food else { return }
         isTogglingFavorite = true
         do {
-            self.food = try await api.toggleFavorite(foodId: food.id, isFavorite: !food.isFavorite)
+            self.food = try await foodRepository.toggleFavorite(foodId: food.id, isFavorite: !food.isFavorite)
         } catch {
             errorMessage = error.localizedDescription
+            // The optimistic local flip persisted — keep the view in sync with it.
+            self.food = foodRepository.food(id: food.id) ?? food
         }
         isTogglingFavorite = false
     }
 
     private func loadFood() async {
-        isLoading = true
+        food = foodRepository.food(id: foodId)
+        isLoading = food == nil
         error = nil
         do {
-            food = try await api.getFood(id: foodId)
+            try await foodRepository.refreshFood(id: foodId)
+            food = foodRepository.food(id: foodId) ?? food
         } catch {
-            self.error = error
+            if food == nil { self.error = error }
         }
         isLoading = false
     }
 
     private func deleteFood() async {
         do {
-            try await api.deleteFood(id: foodId)
+            try await foodRepository.deleteFood(id: foodId)
             dismiss()
         } catch {
             errorMessage = error.localizedDescription

--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct FoodSearchView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(FoodRepository.self) private var foodRepository
+    @Environment(EntryRepository.self) private var entryRepository
     @Environment(\.dismiss) private var dismiss
 
     var date: String?
@@ -96,7 +97,11 @@ struct FoodSearchView: View {
             } else if isSearching {
                 LoadingView(message: L10n.loading)
             } else if searchResults.isEmpty {
-                ContentUnavailableView(L10n.noResults, systemImage: "magnifyingglass", description: Text("\(L10n.noResults): \"\(query)\""))
+                ContentUnavailableView(
+                    L10n.noResults,
+                    systemImage: "magnifyingglass",
+                    description: Text("\(L10n.noResults): \"\(query)\"")
+                )
             } else {
                 List(searchResults) { food in
                     foodRow(food)
@@ -193,37 +198,33 @@ struct FoodSearchView: View {
             return
         }
         isSearching = true
-        do {
-            searchResults = try await api.searchFoods(query: query)
-        } catch {
-            searchResults = []
-        }
+        searchResults = await foodRepository.searchFoods(query: query)
         isSearching = false
     }
 
     private func loadRecent() async {
-        do {
-            recentFoods = try await api.getRecentFoods()
-        } catch {
-            errorMessage = error.localizedDescription
-        }
+        recentFoods = foodRepository.localRecentFoods()
+        recentFoods = await foodRepository.refreshRecentFoods()
     }
 
     private func loadFavorites() async {
+        favoriteFoods = foodRepository.favorites()
         do {
-            let response = try await api.getFavorites()
-            favoriteFoods = response.foods
+            try await foodRepository.refreshFavorites()
+            favoriteFoods = foodRepository.favorites()
         } catch {
-            errorMessage = error.localizedDescription
+            if favoriteFoods.isEmpty {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
     private func mealForCurrentTime() -> String {
         let hour = Calendar.current.component(.hour, from: Date())
         switch hour {
-        case 5..<11: return "breakfast"
-        case 11..<14: return "lunch"
-        case 14..<17: return "snacks"
+        case 5 ..< 11: return "breakfast"
+        case 11 ..< 14: return "lunch"
+        case 14 ..< 17: return "snacks"
         default: return "dinner"
         }
     }
@@ -237,7 +238,7 @@ struct FoodSearchView: View {
             date: date
         )
         do {
-            _ = try await api.createEntry(entry)
+            try await entryRepository.createEntry(entry, food: food)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             toastMessage = "\(food.name) \(L10n.logged)"
         } catch {
@@ -248,7 +249,7 @@ struct FoodSearchView: View {
 }
 
 struct LogFoodSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(EntryRepository.self) private var entryRepository
     @Environment(\.dismiss) private var dismiss
 
     let food: Food
@@ -282,7 +283,7 @@ struct LogFoodSheet: View {
                         Text("\(food.servingSize, specifier: "%.0f") \(food.servingUnit.displayName)")
                             .foregroundStyle(.secondary)
                         Spacer()
-                        Stepper(value: $servings, in: 0.25...20, step: 0.25) {
+                        Stepper(value: $servings, in: 0.25 ... 20, step: 0.25) {
                             Text("\(servings, specifier: "%.2g")x")
                                 .fontWeight(.medium)
                         }
@@ -299,8 +300,18 @@ struct LogFoodSheet: View {
                 }
 
                 Section(L10n.nutrition) {
-                    NutrientRow(label: L10n.calories, value: food.calories * servings, unit: "kcal", color: MacroColors.calories)
-                    NutrientRow(label: L10n.protein, value: food.protein * servings, unit: "g", color: MacroColors.protein)
+                    NutrientRow(
+                        label: L10n.calories,
+                        value: food.calories * servings,
+                        unit: "kcal",
+                        color: MacroColors.calories
+                    )
+                    NutrientRow(
+                        label: L10n.protein,
+                        value: food.protein * servings,
+                        unit: "g",
+                        color: MacroColors.protein
+                    )
                     NutrientRow(label: L10n.carbs, value: food.carbs * servings, unit: "g", color: MacroColors.carbs)
                     NutrientRow(label: L10n.fat, value: food.fat * servings, unit: "g", color: MacroColors.fat)
                     NutrientRow(label: L10n.fiber, value: food.fiber * servings, unit: "g", color: MacroColors.fiber)
@@ -320,7 +331,10 @@ struct LogFoodSheet: View {
                     .fontWeight(.semibold)
                 }
             }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -337,7 +351,7 @@ struct LogFoodSheet: View {
             date: date
         )
         do {
-            _ = try await api.createEntry(entry)
+            try await entryRepository.createEntry(entry, food: food)
             dismiss()
         } catch {
             errorMessage = error.localizedDescription

--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -162,10 +162,30 @@ struct InsightsView: View {
                     Label(L10n.macroTrends, systemImage: "chart.xyaxis.line")
                         .font(.headline)
 
-                    macroTrendRow(L10n.protein, data: dailyStats.map { ($0.date, $0.protein) }, unit: "g", color: MacroColors.protein)
-                    macroTrendRow(L10n.carbs, data: dailyStats.map { ($0.date, $0.carbs) }, unit: "g", color: MacroColors.carbs)
-                    macroTrendRow(L10n.fat, data: dailyStats.map { ($0.date, $0.fat) }, unit: "g", color: MacroColors.fat)
-                    macroTrendRow(L10n.fiber, data: dailyStats.map { ($0.date, $0.fiber) }, unit: "g", color: MacroColors.fiber)
+                    macroTrendRow(
+                        L10n.protein,
+                        data: dailyStats.map { ($0.date, $0.protein) },
+                        unit: "g",
+                        color: MacroColors.protein
+                    )
+                    macroTrendRow(
+                        L10n.carbs,
+                        data: dailyStats.map { ($0.date, $0.carbs) },
+                        unit: "g",
+                        color: MacroColors.carbs
+                    )
+                    macroTrendRow(
+                        L10n.fat,
+                        data: dailyStats.map { ($0.date, $0.fat) },
+                        unit: "g",
+                        color: MacroColors.fat
+                    )
+                    macroTrendRow(
+                        L10n.fiber,
+                        data: dailyStats.map { ($0.date, $0.fiber) },
+                        unit: "g",
+                        color: MacroColors.fiber
+                    )
                 }
             }
         }
@@ -236,7 +256,8 @@ struct InsightsView: View {
     private var goalAchievementCard: some View {
         if let goals, !dailyStats.isEmpty {
             let totalDays = dailyStats.count
-            let calHit = dailyStats.filter { $0.calories <= goals.calorieGoal * 1.05 && $0.calories >= goals.calorieGoal * 0.9 }.count
+            let calHit = dailyStats
+                .filter { $0.calories <= goals.calorieGoal * 1.05 && $0.calories >= goals.calorieGoal * 0.9 }.count
             let proteinHit = dailyStats.filter { $0.protein >= goals.proteinGoal * 0.9 }.count
             let carbsHit = dailyStats.filter { $0.carbs <= goals.carbGoal * 1.1 }.count
             let fatHit = dailyStats.filter { $0.fat <= goals.fatGoal * 1.1 }.count
@@ -291,7 +312,6 @@ struct InsightsView: View {
 
     // MARK: - Calendar Heatmap
 
-    @ViewBuilder
     private var calendarHeatmapCard: some View {
         CardView {
             VStack(alignment: .leading, spacing: 8) {
@@ -334,10 +354,10 @@ struct InsightsView: View {
                 let dayMap = Dictionary(uniqueKeysWithValues: calendarDays.map { ($0.date, $0) })
 
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 2), count: 7), spacing: 2) {
-                    ForEach(0..<offset, id: \.self) { _ in
+                    ForEach(0 ..< offset, id: \.self) { _ in
                         Color.clear.frame(height: 28)
                     }
-                    ForEach(1...daysInMonth, id: \.self) { day in
+                    ForEach(1 ... daysInMonth, id: \.self) { day in
                         let date = Calendar.current.date(byAdding: .day, value: day - 1, to: startOfMonth)
                         let dateStr = date.map { DateFormatting.isoString(from: $0) } ?? ""
                         let calDay = dayMap[dateStr]
@@ -408,17 +428,47 @@ struct InsightsView: View {
 
                     Divider()
 
-                    comparisonRow(L10n.calories, weekly: weekly.calories, monthly: monthly.calories, unit: "kcal", color: MacroColors.calories)
-                    comparisonRow(L10n.protein, weekly: weekly.protein, monthly: monthly.protein, unit: "g", color: MacroColors.protein)
-                    comparisonRow(L10n.carbs, weekly: weekly.carbs, monthly: monthly.carbs, unit: "g", color: MacroColors.carbs)
+                    comparisonRow(
+                        L10n.calories,
+                        weekly: weekly.calories,
+                        monthly: monthly.calories,
+                        unit: "kcal",
+                        color: MacroColors.calories
+                    )
+                    comparisonRow(
+                        L10n.protein,
+                        weekly: weekly.protein,
+                        monthly: monthly.protein,
+                        unit: "g",
+                        color: MacroColors.protein
+                    )
+                    comparisonRow(
+                        L10n.carbs,
+                        weekly: weekly.carbs,
+                        monthly: monthly.carbs,
+                        unit: "g",
+                        color: MacroColors.carbs
+                    )
                     comparisonRow(L10n.fat, weekly: weekly.fat, monthly: monthly.fat, unit: "g", color: MacroColors.fat)
-                    comparisonRow(L10n.fiber, weekly: weekly.fiber, monthly: monthly.fiber, unit: "g", color: MacroColors.fiber)
+                    comparisonRow(
+                        L10n.fiber,
+                        weekly: weekly.fiber,
+                        monthly: monthly.fiber,
+                        unit: "g",
+                        color: MacroColors.fiber
+                    )
                 }
             }
         }
     }
 
-    private func comparisonRow(_ label: String, weekly: Double, monthly: Double, unit: String, color: Color) -> some View {
+    private func comparisonRow(
+        _ label: String,
+        weekly: Double,
+        monthly: Double,
+        unit: String,
+        color: Color
+    ) -> some View {
         let diff = weekly - monthly
         let diffPct = monthly > 0 ? (diff / monthly * 100) : 0
         let arrow = diff > 0 ? "\u{2191}" : (diff < 0 ? "\u{2193}" : "\u{2192}")
@@ -480,11 +530,11 @@ struct InsightsView: View {
 
     private func mealColor(_ mealType: String) -> Color {
         switch mealType.lowercased() {
-        case "breakfast": return .orange
-        case "lunch": return .blue
-        case "dinner": return .purple
-        case "snacks", "snack": return .green
-        default: return .gray
+        case "breakfast": .orange
+        case "lunch": .blue
+        case "dinner": .purple
+        case "snacks", "snack": .green
+        default: .gray
         }
     }
 
@@ -530,7 +580,10 @@ struct InsightsView: View {
 
     private func loadCalendar() async {
         let components = Calendar.current.dateComponents([.month, .year], from: calendarMonth)
-        calendarDays = (try? await api.getCalendarStats(month: components.month ?? 1, year: components.year ?? Calendar.current.component(.year, from: Date()))) ?? []
+        calendarDays = await (try? api.getCalendarStats(
+            month: components.month ?? 1,
+            year: components.year ?? Calendar.current.component(.year, from: Date())
+        )) ?? []
     }
 }
 

--- a/mobile/iosApp/Bissbilanz/Views/LoginView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/LoginView.swift
@@ -1,8 +1,33 @@
 import AuthenticationServices
 import SwiftUI
 
+/// Builds, configures and starts the OIDC web sign-in session. Shared between
+/// the login screen and the Settings "Sign in to sync" flow — the caller must
+/// retain the returned session until the callback fires.
+@MainActor
+enum SignInFlow {
+    static func start(authManager: AuthManager) -> ASWebAuthenticationSession? {
+        guard let url = authManager.buildLoginURL() else { return nil }
+
+        let session = ASWebAuthenticationSession(
+            url: url,
+            callbackURLScheme: "bissbilanz"
+        ) { callbackURL, error in
+            guard let callbackURL, error == nil else { return }
+            Task {
+                await authManager.handleCallback(url: callbackURL)
+            }
+        }
+        session.prefersEphemeralWebBrowserSession = false
+        session.presentationContextProvider = ASWebAuthenticationPresentationContextProvider.shared
+        session.start()
+        return session
+    }
+}
+
 struct LoginView: View {
     @Environment(AuthManager.self) private var authManager
+    @Environment(AppModeManager.self) private var appModeManager
     @State private var authSession: ASWebAuthenticationSession?
 
     var body: some View {
@@ -24,36 +49,36 @@ struct LoginView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Button {
-                signIn()
-            } label: {
-                Label(L10n.signIn, systemImage: "person.crop.circle")
-                    .frame(maxWidth: .infinity)
+            VStack(spacing: 16) {
+                Button {
+                    authSession = SignInFlow.start(authManager: authManager)
+                } label: {
+                    Label(L10n.signIn, systemImage: "person.crop.circle")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                VStack(spacing: 8) {
+                    Button {
+                        appModeManager.setMode(.local)
+                    } label: {
+                        Text(L10n.continueWithoutAccount)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+
+                    Text(L10n.localModeExplainer)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
 
             Spacer()
         }
         .padding(32)
-    }
-
-    private func signIn() {
-        guard let url = authManager.buildLoginURL() else { return }
-
-        let session = ASWebAuthenticationSession(
-            url: url,
-            callbackURLScheme: "bissbilanz"
-        ) { callbackURL, error in
-            guard let callbackURL, error == nil else { return }
-            Task {
-                await authManager.handleCallback(url: callbackURL)
-            }
-        }
-        session.prefersEphemeralWebBrowserSession = false
-        session.presentationContextProvider = ASWebAuthenticationPresentationContextProvider.shared
-        authSession = session
-        session.start()
     }
 }
 

--- a/mobile/iosApp/Bissbilanz/Views/MacroRadarView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/MacroRadarView.swift
@@ -17,7 +17,7 @@ struct MacroRadarView: View {
                 }
 
                 // Draw axes
-                for i in 0..<count {
+                for i in 0 ..< count {
                     let angle = angleFor(index: i, total: count)
                     let point = pointAt(center: center, radius: radius, angle: angle)
                     var path = Path()
@@ -28,7 +28,7 @@ struct MacroRadarView: View {
 
                 // Draw filled data polygon
                 var dataPath = Path()
-                for i in 0..<count {
+                for i in 0 ..< count {
                     let ratio = min(axes[i].1, 1.5)
                     let angle = angleFor(index: i, total: count)
                     let point = pointAt(center: center, radius: radius * ratio, angle: angle)
@@ -45,7 +45,7 @@ struct MacroRadarView: View {
             }
 
             // Draw labels
-            ForEach(0..<count, id: \.self) { i in
+            ForEach(0 ..< count, id: \.self) { i in
                 let angle = angleFor(index: i, total: count)
                 let labelRadius = radius + 16
                 let point = pointAt(center: center, radius: labelRadius, angle: angle)
@@ -75,7 +75,7 @@ struct MacroRadarView: View {
 
     private func polygonPath(center: CGPoint, radius: Double, sides: Int) -> Path {
         var path = Path()
-        for i in 0..<sides {
+        for i in 0 ..< sides {
             let angle = angleFor(index: i, total: sides)
             let point = pointAt(center: center, radius: radius, angle: angle)
             if i == 0 {

--- a/mobile/iosApp/Bissbilanz/Views/MaintenanceView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/MaintenanceView.swift
@@ -61,7 +61,7 @@ struct MaintenanceView: View {
                     Text(L10n.fatLabel)
                         .font(.caption)
                         .foregroundStyle(MacroColors.fat)
-                    Slider(value: $bodyFatRatio, in: 0...1, step: 0.05)
+                    Slider(value: $bodyFatRatio, in: 0 ... 1, step: 0.05)
                     Text(L10n.muscleLabel)
                         .font(.caption)
                         .foregroundStyle(MacroColors.protein)

--- a/mobile/iosApp/Bissbilanz/Views/MigrationView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/MigrationView.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+/// Shown when a user signs in while in Local mode: uploads the local data to
+/// the account (or lets the user discard it when the account already has
+/// data). Routing leaves this screen automatically once the app mode flips to
+/// Synced. Mirrors the Android `MigrationScreen`.
+struct MigrationView: View {
+    @Environment(LocalDataMigrator.self) private var migrator
+    @Environment(AppModeManager.self) private var appModeManager
+    @Environment(AuthManager.self) private var authManager
+
+    @State private var phase: Phase = .deciding
+    @State private var showDiscardConfirmation = false
+
+    private enum Phase: Equatable {
+        case deciding
+        case choice(localItemCount: Int)
+        case migrating
+        case preflightFailed(String)
+    }
+
+    var body: some View {
+        ZStack {
+            Color(.systemGroupedBackground)
+                .ignoresSafeArea()
+
+            content
+                .padding(24)
+        }
+        .task { await decide() }
+        .confirmationDialog(L10n.migrationDiscardTitle, isPresented: $showDiscardConfirmation) {
+            Button(L10n.discard, role: .destructive) {
+                migrator.discardLocalData()
+            }
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.migrationDiscardMessage)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch phase {
+        case .deciding:
+            ProgressView()
+
+        case let .choice(localItemCount):
+            choiceCard(localItemCount: localItemCount)
+
+        case let .preflightFailed(message):
+            failureCard(message: message)
+
+        case .migrating:
+            switch migrator.state {
+            case let .running(done, total, step):
+                progressCard(done: done, total: total, step: step)
+            case let .failed(message):
+                failureCard(message: message)
+            case .idle, .completed:
+                // Idle: migrate() is about to start. Completed: the mode flips
+                // to Synced and the root routing leaves this screen.
+                ProgressView()
+            }
+        }
+    }
+
+    // MARK: - Cards
+
+    private func choiceCard(localItemCount: Int) -> some View {
+        card {
+            Text(L10n.migrationAccountHasData)
+                .font(.title3)
+                .fontWeight(.bold)
+
+            Text(L10n.migrationChoiceDescription)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 8) {
+                Button {
+                    Task { await startUpload() }
+                } label: {
+                    Text(L10n.migrationUploadItems(localItemCount))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button {
+                    showDiscardConfirmation = true
+                } label: {
+                    Text(L10n.migrationStartFresh)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+            .padding(.top, 8)
+        }
+    }
+
+    private func progressCard(done: Int, total: Int, step: MigrationStep) -> some View {
+        card(alignment: .center) {
+            Text(L10n.migrationUploading)
+                .font(.title3)
+                .fontWeight(.bold)
+
+            ProgressView(value: total > 0 ? Double(done) / Double(total) : 0)
+                .progressViewStyle(.linear)
+
+            Text("\(L10n.migrationStepLabel(step)) (\(done)/\(total))…")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private func failureCard(message: String) -> some View {
+        card {
+            Text(L10n.migrationFailedTitle)
+                .font(.title3)
+                .fontWeight(.bold)
+
+            Text(L10n.migrationFailureSafe)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.red)
+
+            VStack(spacing: 8) {
+                Button {
+                    Task { await retry() }
+                } label: {
+                    Text(L10n.retry)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button {
+                    // Abandons the sign-in: the mode stays Local and routing
+                    // returns to the anonymous app.
+                    authManager.logout()
+                } label: {
+                    Text(L10n.continueWithoutAccount)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+            .padding(.top, 8)
+        }
+    }
+
+    private func card(
+        alignment: HorizontalAlignment = .leading,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: alignment, spacing: 12) {
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: alignment == .center ? .center : .leading)
+        .padding(24)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    // MARK: - Flow
+
+    /// Nothing local → flip straight to Synced; account already has data →
+    /// ask the user; otherwise start uploading immediately (Android parity).
+    private func decide() async {
+        phase = .deciding
+        let localItemCount = migrator.plan().total
+        if localItemCount == 0 {
+            appModeManager.setMode(.synced)
+            return
+        }
+        do {
+            if try await migrator.serverHasData() {
+                phase = .choice(localItemCount: localItemCount)
+            } else {
+                await startUpload()
+            }
+        } catch {
+            phase = .preflightFailed(error.localizedDescription)
+        }
+    }
+
+    private func startUpload() async {
+        phase = .migrating
+        await migrator.migrate()
+    }
+
+    private func retry() async {
+        if phase == .migrating {
+            await startUpload()
+        } else {
+            await decide()
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Views/MigrationView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/MigrationView.swift
@@ -140,8 +140,12 @@ struct MigrationView: View {
                 .controlSize(.large)
 
                 Button {
-                    // Abandons the sign-in: the mode stays Local and routing
-                    // returns to the anonymous app.
+                    // Abandons the sign-in: the mode stays Local, the local
+                    // data is kept and routing returns to the anonymous app.
+                    // The normalization marker must not survive the abandoned
+                    // run — a later sign-in (possibly a different account)
+                    // needs a fresh normalization pass.
+                    migrator.abandonMigration()
                     authManager.logout()
                 } label: {
                     Text(L10n.continueWithoutAccount)

--- a/mobile/iosApp/Bissbilanz/Views/RecipeDetailView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/RecipeDetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RecipeDetailView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(RecipeRepository.self) private var recipeRepository
     @Environment(\.dismiss) private var dismiss
 
     let recipeId: String
@@ -108,10 +108,20 @@ struct RecipeDetailView: View {
 
             Section(L10n.perServing) {
                 if let cal = recipe.calories {
-                    NutrientRow(label: L10n.calories, value: cal / recipe.totalServings, unit: "kcal", color: MacroColors.calories)
+                    NutrientRow(
+                        label: L10n.calories,
+                        value: cal / recipe.totalServings,
+                        unit: "kcal",
+                        color: MacroColors.calories
+                    )
                 }
                 if let p = recipe.protein {
-                    NutrientRow(label: L10n.protein, value: p / recipe.totalServings, unit: "g", color: MacroColors.protein)
+                    NutrientRow(
+                        label: L10n.protein,
+                        value: p / recipe.totalServings,
+                        unit: "g",
+                        color: MacroColors.protein
+                    )
                 }
                 if let c = recipe.carbs {
                     NutrientRow(label: L10n.carbs, value: c / recipe.totalServings, unit: "g", color: MacroColors.carbs)
@@ -120,7 +130,12 @@ struct RecipeDetailView: View {
                     NutrientRow(label: L10n.fat, value: f / recipe.totalServings, unit: "g", color: MacroColors.fat)
                 }
                 if let fb = recipe.fiber {
-                    NutrientRow(label: L10n.fiber, value: fb / recipe.totalServings, unit: "g", color: MacroColors.fiber)
+                    NutrientRow(
+                        label: L10n.fiber,
+                        value: fb / recipe.totalServings,
+                        unit: "g",
+                        color: MacroColors.fiber
+                    )
                 }
             }
 
@@ -163,19 +178,21 @@ struct RecipeDetailView: View {
     // MARK: - Actions
 
     private func loadRecipe() async {
-        isLoading = true
+        recipe = recipeRepository.recipe(id: recipeId)
+        isLoading = recipe == nil
         error = nil
         do {
-            recipe = try await api.getRecipe(id: recipeId)
+            try await recipeRepository.refreshRecipe(id: recipeId)
+            recipe = recipeRepository.recipe(id: recipeId) ?? recipe
         } catch {
-            self.error = error
+            if recipe == nil { self.error = error }
         }
         isLoading = false
     }
 
     private func deleteRecipe() async {
         do {
-            try await api.deleteRecipe(id: recipeId)
+            try await recipeRepository.deleteRecipe(id: recipeId)
             dismiss()
         } catch {
             errorMessage = error.localizedDescription

--- a/mobile/iosApp/Bissbilanz/Views/RecipeListView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/RecipeListView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RecipeListView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(RecipeRepository.self) private var recipeRepository
 
     @State private var recipes: [Recipe] = []
     @State private var isLoading = true
@@ -85,7 +85,10 @@ struct RecipeListView: View {
             }
             .refreshable { await loadRecipes() }
             .task { await loadRecipes() }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -125,20 +128,22 @@ struct RecipeListView: View {
 
     private func deleteRecipe(_ recipe: Recipe) async {
         do {
-            try await api.deleteRecipe(id: recipe.id)
-            recipes.removeAll { $0.id == recipe.id }
+            try await recipeRepository.deleteRecipe(id: recipe.id)
         } catch {
             errorMessage = error.localizedDescription
         }
+        recipes = recipeRepository.recipes()
     }
 
     private func loadRecipes() async {
-        isLoading = true
+        recipes = recipeRepository.recipes()
+        isLoading = recipes.isEmpty
         error = nil
         do {
-            recipes = try await api.getRecipes()
+            try await recipeRepository.refresh()
+            recipes = recipeRepository.recipes()
         } catch {
-            self.error = error
+            if recipes.isEmpty { self.error = error }
         }
         isLoading = false
     }
@@ -147,7 +152,7 @@ struct RecipeListView: View {
 // MARK: - Log Recipe Sheet
 
 struct LogRecipeSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(EntryRepository.self) private var entryRepository
     @Environment(\.dismiss) private var dismiss
 
     let recipe: Recipe
@@ -178,15 +183,35 @@ struct LogRecipeSheet: View {
 
                 if let cal = recipe.calories {
                     Section(L10n.perServing) {
-                        NutrientRow(label: L10n.calories, value: cal / recipe.totalServings, unit: "kcal", color: MacroColors.calories)
+                        NutrientRow(
+                            label: L10n.calories,
+                            value: cal / recipe.totalServings,
+                            unit: "kcal",
+                            color: MacroColors.calories
+                        )
                         if let p = recipe.protein {
-                            NutrientRow(label: L10n.protein, value: p / recipe.totalServings, unit: "g", color: MacroColors.protein)
+                            NutrientRow(
+                                label: L10n.protein,
+                                value: p / recipe.totalServings,
+                                unit: "g",
+                                color: MacroColors.protein
+                            )
                         }
                         if let c = recipe.carbs {
-                            NutrientRow(label: L10n.carbs, value: c / recipe.totalServings, unit: "g", color: MacroColors.carbs)
+                            NutrientRow(
+                                label: L10n.carbs,
+                                value: c / recipe.totalServings,
+                                unit: "g",
+                                color: MacroColors.carbs
+                            )
                         }
                         if let f = recipe.fat {
-                            NutrientRow(label: L10n.fat, value: f / recipe.totalServings, unit: "g", color: MacroColors.fat)
+                            NutrientRow(
+                                label: L10n.fat,
+                                value: f / recipe.totalServings,
+                                unit: "g",
+                                color: MacroColors.fat
+                            )
                         }
                     }
                 }
@@ -224,7 +249,10 @@ struct LogRecipeSheet: View {
                     .fontWeight(.semibold)
                 }
             }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -241,7 +269,7 @@ struct LogRecipeSheet: View {
             date: DateFormatting.isoString(from: date)
         )
         do {
-            _ = try await api.createEntry(entry)
+            try await entryRepository.createEntry(entry, recipe: recipe)
             onLogged()
             dismiss()
         } catch {

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -146,7 +146,7 @@ struct SettingsView: View {
                     }
                 }
 
-                // Quick actions
+                // Quick actions — standalone buttons, no card behind them
                 Section(L10n.quickActions) {
                     HStack(spacing: 12) {
                         Button {
@@ -165,7 +165,8 @@ struct SettingsView: View {
                         }
                         .buttonStyle(.bordered)
                     }
-                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets())
                 }
 
                 // Language section
@@ -266,6 +267,20 @@ struct SettingsView: View {
                             Label(L10n.signInToSync, systemImage: "person.crop.circle")
                         }
                     } else {
+                        if authManager.authState == .expired {
+                            HStack(alignment: .firstTextBaseline) {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .foregroundStyle(.orange)
+                                Text(L10n.sessionExpiredMessage)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Button {
+                                signInSession = SignInFlow.start(authManager: authManager)
+                            } label: {
+                                Label(L10n.signIn, systemImage: "person.crop.circle")
+                            }
+                        }
                         if syncManager.pendingCount > 0 {
                             HStack {
                                 Image(systemName: "arrow.triangle.2.circlepath")
@@ -537,6 +552,8 @@ struct VisibleNutrientsView: View {
                     .buttonStyle(.bordered)
                     .frame(maxWidth: .infinity)
                 }
+                .listRowBackground(Color.clear)
+                .listRowInsets(EdgeInsets())
             }
 
             ForEach(Self.nutrientCategories, id: \.0) { category, nutrients in

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @Environment(GoalsRepository.self) private var goalsRepository
+    @Environment(PreferencesRepository.self) private var preferencesRepository
+    // Meal types are server-only — they stay on the direct API.
     @Environment(BissbilanzAPI.self) private var api
     @Environment(AuthManager.self) private var authManager
 
@@ -15,7 +18,8 @@ struct SettingsView: View {
     @State private var errorMessage: String?
     private let healthKitService = HealthKitService.shared
     @State private var healthSyncEnabled: Bool = UserDefaults.standard.bool(forKey: HealthKitService.syncEnabledKey)
-    @State private var healthWriteWeightEnabled: Bool = UserDefaults.standard.bool(forKey: HealthKitService.writeWeightEnabledKey)
+    @State private var healthWriteWeightEnabled: Bool = UserDefaults.standard
+        .bool(forKey: HealthKitService.writeWeightEnabledKey)
     @AppStorage("selected_tabs") private var selectedTabsRaw: String = "foods,favorites,insights"
 
     private var selectedTabNames: String {
@@ -195,7 +199,10 @@ struct SettingsView: View {
                     Toggle(L10n.favorites, isOn: widgetBinding(\.showFavoritesWidget, key: "showFavoritesWidget"))
                     Toggle(L10n.supplements, isOn: widgetBinding(\.showSupplementsWidget, key: "showSupplementsWidget"))
                     Toggle(L10n.weight, isOn: widgetBinding(\.showWeightWidget, key: "showWeightWidget"))
-                    Toggle(L10n.mealBreakdown, isOn: widgetBinding(\.showMealBreakdownWidget, key: "showMealBreakdownWidget"))
+                    Toggle(
+                        L10n.mealBreakdown,
+                        isOn: widgetBinding(\.showMealBreakdownWidget, key: "showMealBreakdownWidget")
+                    )
                     Toggle(L10n.topFoods, isOn: widgetBinding(\.showTopFoodsWidget, key: "showTopFoodsWidget"))
                 }
 
@@ -207,9 +214,8 @@ struct SettingsView: View {
                             Task {
                                 var update = PreferencesUpdate()
                                 update.favoriteMealAssignmentMode = newValue
-                                if let updated = try? await api.updatePreferences(update) {
-                                    preferences = updated
-                                }
+                                preferences = await (try? preferencesRepository.update(update))
+                                    ?? (preferencesRepository.preferences() ?? .defaults)
                             }
                         }
                     )) {
@@ -271,7 +277,10 @@ struct SettingsView: View {
                 RecipeEditSheet()
             }
             .task { await loadData() }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -296,9 +305,8 @@ struct SettingsView: View {
                     case "showTopFoodsWidget": update.showTopFoodsWidget = newValue
                     default: break
                     }
-                    if let updated = try? await api.updatePreferences(update) {
-                        preferences = updated
-                    }
+                    preferences = await (try? preferencesRepository.update(update))
+                        ?? (preferencesRepository.preferences() ?? .defaults)
                 }
             }
         )
@@ -371,21 +379,27 @@ struct SettingsView: View {
             sugarGoal: goals.sugarGoal
         )
         do {
-            goals = try await api.setGoals(newGoals)
+            goals = try await goalsRepository.setGoals(newGoals)
         } catch {
             errorMessage = error.localizedDescription
+            // The optimistic local write persisted — keep the view in sync with it.
+            goals = goalsRepository.goals() ?? .defaults
         }
         isEditingGoals = false
     }
 
     private func loadData() async {
-        async let g = try? api.getGoals()
-        async let p = try? api.getPreferences()
+        goals = goalsRepository.goals() ?? .defaults
+        preferences = preferencesRepository.preferences() ?? .defaults
+
+        async let g: Void? = try? goalsRepository.refresh()
+        async let p: Void? = try? preferencesRepository.refresh()
         async let m = try? api.getMealTypes()
 
-        goals = await g ?? .defaults
-        preferences = await p ?? .defaults
+        _ = await (g, p)
         mealTypes = await m ?? []
+        goals = goalsRepository.goals() ?? .defaults
+        preferences = preferencesRepository.preferences() ?? .defaults
     }
 
     private func addMealType() async {
@@ -413,7 +427,7 @@ struct SettingsView: View {
 // MARK: - Visible Nutrients View
 
 struct VisibleNutrientsView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(PreferencesRepository.self) private var preferencesRepository
     @Binding var preferences: Preferences
 
     @State private var selectedNutrients: Set<String> = []
@@ -513,9 +527,8 @@ struct VisibleNutrientsView: View {
         isSaving = true
         var update = PreferencesUpdate()
         update.visibleNutrients = Array(selectedNutrients)
-        if let updated = try? await api.updatePreferences(update) {
-            preferences = updated
-        }
+        preferences = await (try? preferencesRepository.update(update))
+            ?? (preferencesRepository.preferences() ?? .defaults)
         isDirty = false
         isSaving = false
     }

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import SwiftUI
 
 struct SettingsView: View {
@@ -6,7 +7,9 @@ struct SettingsView: View {
     // Meal types are server-only — they stay on the direct API.
     @Environment(BissbilanzAPI.self) private var api
     @Environment(AuthManager.self) private var authManager
+    @Environment(AppModeManager.self) private var appModeManager
 
+    @State private var signInSession: ASWebAuthenticationSession?
     @State private var goals: Goals = .defaults
     @State private var preferences: Preferences = .defaults
     @State private var mealTypes: [MealType] = []
@@ -86,8 +89,11 @@ struct SettingsView: View {
                     NavigationLink { CalendarView() } label: {
                         Label(L10n.calendar, systemImage: "calendar")
                     }
-                    NavigationLink { MaintenanceView() } label: {
-                        Label(L10n.maintenance, systemImage: "function")
+                    // The maintenance calculator is server-computed — hidden in Local mode.
+                    if !appModeManager.isLocal {
+                        NavigationLink { MaintenanceView() } label: {
+                            Label(L10n.maintenance, systemImage: "function")
+                        }
                     }
                 }
 
@@ -172,24 +178,26 @@ struct SettingsView: View {
                     }
                 }
 
-                // Custom meal types
-                Section(L10n.customMealTypes) {
-                    ForEach(mealTypes) { mealType in
-                        Text(mealType.name)
-                            .swipeActions {
-                                Button(role: .destructive) {
-                                    Task { await deleteMealType(mealType) }
-                                } label: {
-                                    Label(L10n.delete, systemImage: "trash")
+                // Custom meal types (server-only, hidden in Local mode)
+                if !appModeManager.isLocal {
+                    Section(L10n.customMealTypes) {
+                        ForEach(mealTypes) { mealType in
+                            Text(mealType.name)
+                                .swipeActions {
+                                    Button(role: .destructive) {
+                                        Task { await deleteMealType(mealType) }
+                                    } label: {
+                                        Label(L10n.delete, systemImage: "trash")
+                                    }
                                 }
-                            }
-                    }
-                    HStack {
-                        TextField(L10n.customMealTypes, text: $newMealTypeName)
-                        Button(L10n.add) {
-                            Task { await addMealType() }
                         }
-                        .disabled(newMealTypeName.isEmpty)
+                        HStack {
+                            TextField(L10n.customMealTypes, text: $newMealTypeName)
+                            Button(L10n.add) {
+                                Task { await addMealType() }
+                            }
+                            .disabled(newMealTypeName.isEmpty)
+                        }
                     }
                 }
 
@@ -242,10 +250,25 @@ struct SettingsView: View {
 
                 // Account
                 Section(L10n.account) {
-                    Button(role: .destructive) {
-                        showLogoutConfirmation = true
-                    } label: {
-                        Label(L10n.signOut, systemImage: "rectangle.portrait.and.arrow.right")
+                    if appModeManager.isLocal {
+                        HStack {
+                            Image(systemName: "iphone")
+                                .foregroundStyle(.secondary)
+                            Text(L10n.localModeStatus)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        Button {
+                            signInSession = SignInFlow.start(authManager: authManager)
+                        } label: {
+                            Label(L10n.signInToSync, systemImage: "person.crop.circle")
+                        }
+                    } else {
+                        Button(role: .destructive) {
+                            showLogoutConfirmation = true
+                        } label: {
+                            Label(L10n.signOut, systemImage: "rectangle.portrait.and.arrow.right")
+                        }
                     }
                 }
 
@@ -263,6 +286,9 @@ struct SettingsView: View {
             .confirmationDialog(L10n.signOut + "?", isPresented: $showLogoutConfirmation) {
                 Button(L10n.signOut, role: .destructive) {
                     authManager.logout()
+                    // Reset the mode so the next start shows the login screen
+                    // with the mode choice again.
+                    appModeManager.clear()
                 }
             } message: {
                 Text(L10n.signOutConfirmation)
@@ -394,10 +420,12 @@ struct SettingsView: View {
 
         async let g: Void? = try? goalsRepository.refresh()
         async let p: Void? = try? preferencesRepository.refresh()
-        async let m = try? api.getMealTypes()
 
         _ = await (g, p)
-        mealTypes = await m ?? []
+        // Meal types are server-only — never fetched in Local mode.
+        if !appModeManager.isLocal {
+            mealTypes = await (try? api.getMealTypes()) ?? []
+        }
         goals = goalsRepository.goals() ?? .defaults
         preferences = preferencesRepository.preferences() ?? .defaults
     }

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -8,6 +8,8 @@ struct SettingsView: View {
     @Environment(BissbilanzAPI.self) private var api
     @Environment(AuthManager.self) private var authManager
     @Environment(AppModeManager.self) private var appModeManager
+    @Environment(SyncManager.self) private var syncManager
+    @Environment(LocalDataMigrator.self) private var migrator
 
     @State private var signInSession: ASWebAuthenticationSession?
     @State private var goals: Goals = .defaults
@@ -264,6 +266,24 @@ struct SettingsView: View {
                             Label(L10n.signInToSync, systemImage: "person.crop.circle")
                         }
                     } else {
+                        if syncManager.pendingCount > 0 {
+                            HStack {
+                                Image(systemName: "arrow.triangle.2.circlepath")
+                                    .foregroundStyle(.secondary)
+                                Text(L10n.pendingSyncCount(syncManager.pendingCount))
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        if let syncError = syncManager.errors.last {
+                            HStack(alignment: .firstTextBaseline) {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .foregroundStyle(.red)
+                                Text(syncError)
+                                    .font(.caption)
+                                    .foregroundStyle(.red)
+                            }
+                        }
                         Button(role: .destructive) {
                             showLogoutConfirmation = true
                         } label: {
@@ -285,6 +305,10 @@ struct SettingsView: View {
             .navigationTitle(L10n.settings)
             .confirmationDialog(L10n.signOut + "?", isPresented: $showLogoutConfirmation) {
                 Button(L10n.signOut, role: .destructive) {
+                    // The local store and pending queue belong to the
+                    // signed-out account — wipe them so nothing leaks into
+                    // the next session (Local mode or another account).
+                    migrator.wipeLocalData()
                     authManager.logout()
                     // Reset the mode so the next start shows the login screen
                     // with the mode choice again.

--- a/mobile/iosApp/Bissbilanz/Views/SupplementHistoryView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SupplementHistoryView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SupplementHistoryView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(SupplementRepository.self) private var supplementRepository
 
     @State private var history: [SupplementHistoryItem] = []
     @State private var isLoading = true
@@ -9,8 +9,8 @@ struct SupplementHistoryView: View {
     @State private var endDate = Date()
     @State private var showDatePicker = false
 
-    // history is a flat list of (supplementId, date) taken events. Group by date
-    // for display without losing the day-indexed layout of the old UI.
+    /// history is a flat list of (supplementId, date) taken events. Group by date
+    /// for display without losing the day-indexed layout of the old UI.
     private var historyByDate: [(date: String, items: [SupplementHistoryItem])] {
         let grouped = Dictionary(grouping: history, by: { $0.date })
         return grouped
@@ -18,14 +18,20 @@ struct SupplementHistoryView: View {
             .sorted { $0.date > $1.date }
     }
 
-    private var totalTaken: Int { history.count }
+    private var totalTaken: Int {
+        history.count
+    }
 
     var body: some View {
         Group {
             if isLoading {
                 LoadingView()
             } else if history.isEmpty {
-                ContentUnavailableView(L10n.supplementHistory, systemImage: "pills", description: Text(L10n.noHistoryForPeriod))
+                ContentUnavailableView(
+                    L10n.supplementHistory,
+                    systemImage: "pills",
+                    description: Text(L10n.noHistoryForPeriod)
+                )
             } else {
                 List {
                     Section {
@@ -93,16 +99,16 @@ struct SupplementHistoryView: View {
     }
 
     private func loadData() async {
-        isLoading = true
-        do {
-            history = try await api.getSupplementHistory(
-                startDate: startDate.isoDateString,
-                endDate: endDate.isoDateString
-            )
-        } catch {
-            // Surface in a real implementation; skeleton silently resets.
-            history = []
-        }
+        history = supplementRepository.localHistory(
+            startDate: startDate.isoDateString,
+            endDate: endDate.isoDateString
+        )
+        isLoading = history.isEmpty
+        // Server-computed history; the repository falls back to cached logs offline.
+        history = await supplementRepository.history(
+            startDate: startDate.isoDateString,
+            endDate: endDate.isoDateString
+        )
         isLoading = false
     }
 }

--- a/mobile/iosApp/Bissbilanz/Views/SupplementsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SupplementsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SupplementsView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(SupplementRepository.self) private var supplementRepository
 
     @State private var supplements: [Supplement] = []
     @State private var loggedIds: Set<String> = []
@@ -11,8 +11,14 @@ struct SupplementsView: View {
     @State private var expandedIds: Set<String> = []
     @State private var errorMessage: String?
 
-    private var takenCount: Int { loggedIds.count }
-    private var totalCount: Int { supplements.filter(\.isActive).count }
+    private var takenCount: Int {
+        loggedIds.count
+    }
+
+    private var totalCount: Int {
+        supplements.filter(\.isActive).count
+    }
+
     private var progress: Double {
         guard totalCount > 0 else { return 0 }
         return Double(takenCount) / Double(totalCount)
@@ -68,7 +74,10 @@ struct SupplementsView: View {
             }
             .refreshable { await loadData() }
             .task { await loadData() }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -99,8 +108,13 @@ struct SupplementsView: View {
 
     // MARK: - Supplements Sections
 
-    private var activeSupplements: [Supplement] { supplements.filter(\.isActive) }
-    private var inactiveSupplements: [Supplement] { supplements.filter { !$0.isActive } }
+    private var activeSupplements: [Supplement] {
+        supplements.filter(\.isActive)
+    }
+
+    private var inactiveSupplements: [Supplement] {
+        supplements.filter { !$0.isActive }
+    }
 
     private var supplementsSection: some View {
         Group {
@@ -252,20 +266,20 @@ struct SupplementsView: View {
 
     private func timeOfDayLabel(_ time: String) -> String {
         switch time.lowercased() {
-        case "morning": return L10n.morning
-        case "evening", "night": return L10n.evening
-        case "noon", "afternoon": return L10n.noon
-        case "anytime": return L10n.anytime
-        default: return time.capitalized
+        case "morning": L10n.morning
+        case "evening", "night": L10n.evening
+        case "noon", "afternoon": L10n.noon
+        case "anytime": L10n.anytime
+        default: time.capitalized
         }
     }
 
     private func timeIcon(_ time: String) -> String {
         switch time.lowercased() {
-        case "morning": return "sunrise"
-        case "evening", "night": return "moon"
-        case "noon", "afternoon": return "sun.max"
-        default: return "clock"
+        case "morning": "sunrise"
+        case "evening", "night": "moon"
+        case "noon", "afternoon": "sun.max"
+        default: "clock"
         }
     }
 
@@ -273,46 +287,43 @@ struct SupplementsView: View {
 
     private func toggleSupplement(_ supplement: Supplement, isTaken: Bool) async {
         let dateString = DateFormatting.today
-        if isTaken {
-            do {
-                try await api.unlogSupplement(id: supplement.id, date: dateString)
-                loggedIds.remove(supplement.id)
-            } catch {
-                errorMessage = error.localizedDescription
+        do {
+            if isTaken {
+                try await supplementRepository.unlogSupplement(id: supplement.id, date: dateString)
+            } else {
+                try await supplementRepository.logSupplement(id: supplement.id, date: dateString)
             }
-        } else {
-            do {
-                _ = try await api.logSupplement(id: supplement.id, date: dateString)
-                loggedIds.insert(supplement.id)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
+        } catch {
+            errorMessage = error.localizedDescription
         }
+        loggedIds = supplementRepository.loggedSupplementIds(date: dateString)
     }
 
     private func deleteSupplement(_ supplement: Supplement) async {
         do {
-            try await api.deleteSupplement(id: supplement.id)
-            supplements.removeAll { $0.id == supplement.id }
-            loggedIds.remove(supplement.id)
+            try await supplementRepository.deleteSupplement(id: supplement.id)
         } catch {
             errorMessage = error.localizedDescription
         }
+        supplements = supplementRepository.supplements()
+        loggedIds.remove(supplement.id)
     }
 
     private func loadData() async {
-        isLoading = true
         let dateString = DateFormatting.today
+        supplements = supplementRepository.supplements()
+        loggedIds = supplementRepository.loggedSupplementIds(date: dateString)
+        isLoading = supplements.isEmpty
         do {
-            supplements = try await api.getSupplements()
+            try await supplementRepository.refresh()
+            supplements = supplementRepository.supplements()
         } catch {
-            errorMessage = error.localizedDescription
+            if supplements.isEmpty {
+                errorMessage = error.localizedDescription
+            }
         }
-        do {
-            let checklist = try await api.getSupplementChecklist(date: dateString)
+        if let checklist = try? await supplementRepository.refreshChecklist(date: dateString) {
             loggedIds = Set(checklist.filter(\.taken).map(\.supplement.id))
-        } catch {
-            // Checklist fetch failed — keep loggedIds as-is rather than showing incorrect state
         }
         isLoading = false
     }

--- a/mobile/iosApp/Bissbilanz/Views/TabSelectionView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/TabSelectionView.swift
@@ -1,10 +1,16 @@
 import SwiftUI
 
 struct TabSelectionView: View {
+    @Environment(AppModeManager.self) private var appModeManager
     @AppStorage("selected_tabs") private var selectedTabsRaw: String = "foods,favorites,insights"
 
     private var selectedTabs: Set<NavigableTab> {
         Set(selectedTabsRaw.split(separator: ",").compactMap { NavigableTab(rawValue: String($0)) })
+    }
+
+    /// Insights are server-computed stats — not offered in Local mode.
+    private var availableTabs: [NavigableTab] {
+        appModeManager.isLocal ? NavigableTab.allCases.filter { $0 != .insights } : NavigableTab.allCases
     }
 
     var body: some View {
@@ -16,7 +22,7 @@ struct TabSelectionView: View {
             }
 
             Section {
-                ForEach(NavigableTab.allCases) { tab in
+                ForEach(availableTabs) { tab in
                     let isSelected = selectedTabs.contains(tab)
                     Button {
                         toggleTab(tab)

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 
 struct WeightView: View {
     @Environment(WeightRepository.self) private var weightRepository
-    /// Weight stats are server-computed — they stay on the direct API.
+    /// Weight stats are server-computed — they stay on the direct API and
+    /// are skipped in Local mode.
     @Environment(BissbilanzAPI.self) private var api
+    @Environment(AppModeManager.self) private var appModeManager
 
     @State private var entries: [WeightEntry] = []
     @State private var weightStats: WeightStatsResponse?
@@ -388,11 +390,10 @@ struct WeightView: View {
         entries = weightRepository.entries()
         if showSpinner { isLoading = entries.isEmpty }
 
-        async let refreshTask: Void? = try? weightRepository.refresh()
-        async let statsTask = try? api.getWeightStats()
-
-        _ = await refreshTask
-        weightStats = await statsTask
+        try? await weightRepository.refresh()
+        if !appModeManager.isLocal {
+            weightStats = try? await api.getWeightStats()
+        }
         entries = weightRepository.entries()
 
         isLoading = false
@@ -430,7 +431,9 @@ struct WeightView: View {
 
         if imported {
             entries = weightRepository.entries()
-            weightStats = await (try? api.getWeightStats()) ?? weightStats
+            if !appModeManager.isLocal {
+                weightStats = await (try? api.getWeightStats()) ?? weightStats
+            }
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -165,6 +165,8 @@ struct WeightView: View {
 
     // MARK: - Stats Chips
 
+    /// The chips are little cards themselves — the list row stays invisible
+    /// so they don't sit inside another container.
     private var statsChipsSection: some View {
         Section {
             ScrollView(.horizontal, showsIndicators: false) {
@@ -198,7 +200,8 @@ struct WeightView: View {
                 }
                 .padding(.horizontal, 4)
             }
-            .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -1,6 +1,82 @@
 import Charts
 import SwiftUI
 
+/// Direction of the recent weight development shown in the trend card.
+enum WeightTrend: Equatable {
+    case rising(Double)
+    case falling(Double)
+    case steady(Double?)
+
+    /// Weekly changes inside this band are daily fluctuation noise, not a trend.
+    static let steadyBandKg = 0.3
+
+    static func from(delta: Double?) -> WeightTrend {
+        guard let delta else { return .steady(nil) }
+        if delta > steadyBandKg { return .rising(delta) }
+        if delta < -steadyBandKg { return .falling(delta) }
+        return .steady(delta)
+    }
+
+    /// Local fallback for the server's `delta_7d` (Local mode / offline):
+    /// average of the entries in the 7 days up to the newest entry vs the
+    /// 7 days before that. Averaging smooths the day-to-day fluctuation a
+    /// point-to-point delta would amplify.
+    static func localDelta7d(entries: [WeightEntry]) -> Double? {
+        let dated = entries.compactMap { entry -> (date: Date, kg: Double)? in
+            guard let date = DateFormatting.date(from: entry.entryDate) else { return nil }
+            return (date, entry.weightKg)
+        }
+        guard let latest = dated.map(\.date).max() else { return nil }
+        var recent: [Double] = []
+        var previous: [Double] = []
+        for sample in dated {
+            let days = latest.timeIntervalSince(sample.date) / 86400
+            if days < 7 {
+                recent.append(sample.kg)
+            } else if days < 14 {
+                previous.append(sample.kg)
+            }
+        }
+        guard !recent.isEmpty, !previous.isEmpty else { return nil }
+        return recent.reduce(0, +) / Double(recent.count) - previous.reduce(0, +) / Double(previous.count)
+    }
+
+    var delta: Double? {
+        switch self {
+        case let .rising(delta), let .falling(delta):
+            delta
+        case let .steady(delta):
+            delta
+        }
+    }
+}
+
+extension WeightTrend {
+    var icon: String {
+        switch self {
+        case .rising: "arrow.up.right"
+        case .falling: "arrow.down.right"
+        case .steady: "arrow.right"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .rising: L10n.trendRising
+        case .falling: L10n.trendFalling
+        case .steady: L10n.trendSteady
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .rising: .red
+        case .falling: .green
+        case .steady: .secondary
+        }
+    }
+}
+
 struct WeightView: View {
     @Environment(WeightRepository.self) private var weightRepository
     /// Weight stats are server-computed — they stay on the direct API and
@@ -163,30 +239,30 @@ struct WeightView: View {
         }
     }
 
-    // MARK: - Stats Chips
+    // MARK: - Summary Cards
 
-    /// The chips are little cards themselves — the list row stays invisible
-    /// so they don't sit inside another container.
+    /// The trend card prefers the server's smoothed 7-day delta and falls
+    /// back to the local computation in Local mode or offline.
+    private var trend: WeightTrend {
+        WeightTrend.from(delta: weightStats?.delta7d ?? WeightTrend.localDelta7d(entries: entries))
+    }
+
+    /// Top row: latest weight and trend direction side by side as floating
+    /// cards (no list container). Server projections follow as chips.
     private var statsChipsSection: some View {
         Section {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 12) {
-                    if let latest = entries.first {
-                        statChip(L10n.latestWeight, value: String(format: "%.1f kg", latest.weightKg), color: .blue)
-                    }
+            HStack(spacing: 12) {
+                latestCard
+                trendCard
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
 
-                    if let stats = weightStats {
-                        if let trend = stats.trend {
-                            statChip(L10n.trendWeight, value: String(format: "%.1f kg", trend), color: .green)
-                        }
-                        if let delta = stats.delta7d {
-                            let prefix = delta >= 0 ? "+" : ""
-                            statChip(
-                                L10n.delta7d,
-                                value: "\(prefix)\(String(format: "%.1f", delta)) kg",
-                                color: delta >= 0 ? .red : .green
-                            )
-                        }
+            if let stats = weightStats,
+               stats.projected14d != nil || stats.projected30d != nil || stats.projected60d != nil
+            {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
                         if let p14 = stats.projected14d {
                             statChip(L10n.projection14d, value: String(format: "%.1f kg", p14), color: .purple)
                         }
@@ -197,12 +273,66 @@ struct WeightView: View {
                             statChip(L10n.projection60d, value: String(format: "%.1f kg", p60), color: .purple)
                         }
                     }
+                    .padding(.horizontal, 4)
                 }
-                .padding(.horizontal, 4)
+                .listRowBackground(Color.clear)
+                .listRowInsets(EdgeInsets())
             }
-            .listRowBackground(Color.clear)
-            .listRowInsets(EdgeInsets())
         }
+    }
+
+    private var latestCard: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.latestWeight)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(String(format: "%.1f kg", entries.first?.weightKg ?? 0))
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundStyle(.blue)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            Text(latestDateText)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.blue.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var latestDateText: String {
+        guard let latest = entries.first else { return "" }
+        if let date = DateFormatting.date(from: latest.entryDate) {
+            return DateFormatting.displayString(from: date)
+        }
+        return latest.entryDate
+    }
+
+    private var trendCard: some View {
+        let trend = trend
+        return VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.trendWeight)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Image(systemName: trend.icon)
+                Text(trend.label)
+            }
+            .font(.title2)
+            .fontWeight(.bold)
+            .foregroundStyle(trend.color)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            Text(trend.delta.map { L10n.deltaPerWeek(String(format: "%+.1f kg", $0)) } ?? "—")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(trend.color.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     private func statChip(_ label: String, value: String, color: Color) -> some View {

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -2,6 +2,8 @@ import Charts
 import SwiftUI
 
 struct WeightView: View {
+    @Environment(WeightRepository.self) private var weightRepository
+    /// Weight stats are server-computed — they stay on the direct API.
     @Environment(BissbilanzAPI.self) private var api
 
     @State private var entries: [WeightEntry] = []
@@ -20,14 +22,16 @@ struct WeightView: View {
         case quarter = 90
         case all = 0
 
-        var id: Int { rawValue }
+        var id: Int {
+            rawValue
+        }
 
         var label: String {
             switch self {
-            case .week: return "7d"
-            case .month: return "30d"
-            case .quarter: return "90d"
-            case .all: return L10n.history
+            case .week: "7d"
+            case .month: "30d"
+            case .quarter: "90d"
+            case .all: L10n.history
             }
         }
     }
@@ -35,7 +39,8 @@ struct WeightView: View {
     private var chartEntries: [WeightEntry] {
         let sorted = entries.sorted { entryA, entryB in
             guard let dateA = DateFormatting.date(from: entryA.entryDate),
-                  let dateB = DateFormatting.date(from: entryB.entryDate) else { return false }
+                  let dateB = DateFormatting.date(from: entryB.entryDate)
+            else { return false }
             return dateA < dateB
         }
         guard selectedRange > 0 else { return sorted }
@@ -54,7 +59,7 @@ struct WeightView: View {
         for (index, entry) in sorted.enumerated() {
             guard let date = DateFormatting.date(from: entry.entryDate) else { continue }
             let windowStart = max(0, index - 6)
-            let window = sorted[windowStart...index]
+            let window = sorted[windowStart ... index]
             let avg = window.map(\.weightKg).reduce(0, +) / Double(window.count)
             result.append((date: date, average: avg))
         }
@@ -85,7 +90,7 @@ struct WeightView: View {
         // Start from last actual data point
         let lastX = n - 1
         result.append((lastDate, slope * lastX + intercept))
-        for day in 1...projectionDays {
+        for day in 1 ... projectionDays {
             let futureDate = lastDate.adding(days: day)
             let futureWeight = slope * (lastX + Double(day)) + intercept
             result.append((futureDate, futureWeight))
@@ -97,10 +102,10 @@ struct WeightView: View {
         var weights = chartEntries.map(\.weightKg)
         weights.append(contentsOf: projectionData.map(\.weight))
         guard let minW = weights.min(), let maxW = weights.max() else {
-            return 0...100
+            return 0 ... 100
         }
         let padding = max((maxW - minW) * 0.15, 0.5)
-        return (minW - padding)...(maxW + padding)
+        return (minW - padding) ... (maxW + padding)
     }
 
     var body: some View {
@@ -145,7 +150,10 @@ struct WeightView: View {
             }
             .refreshable { await loadEntries() }
             .task { await loadEntries(showSpinner: true) }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -169,7 +177,11 @@ struct WeightView: View {
                         }
                         if let delta = stats.delta7d {
                             let prefix = delta >= 0 ? "+" : ""
-                            statChip(L10n.delta7d, value: "\(prefix)\(String(format: "%.1f", delta)) kg", color: delta >= 0 ? .red : .green)
+                            statChip(
+                                L10n.delta7d,
+                                value: "\(prefix)\(String(format: "%.1f", delta)) kg",
+                                color: delta >= 0 ? .red : .green
+                            )
                         }
                         if let p14 = stats.projected14d {
                             statChip(L10n.projection14d, value: String(format: "%.1f kg", p14), color: .purple)
@@ -369,17 +381,19 @@ struct WeightView: View {
 
     // MARK: - Data Loading
 
-    // showSpinner only on first load: flipping isLoading during pull-to-refresh
-    // swaps the List out for LoadingView, which kills the refresh gesture and
-    // leaves the spinner stuck.
+    /// showSpinner only on first load: flipping isLoading during pull-to-refresh
+    /// swaps the List out for LoadingView, which kills the refresh gesture and
+    /// leaves the spinner stuck.
     private func loadEntries(showSpinner: Bool = false) async {
-        if showSpinner { isLoading = true }
+        entries = weightRepository.entries()
+        if showSpinner { isLoading = entries.isEmpty }
 
-        async let entriesTask = try? api.getWeightEntries()
+        async let refreshTask: Void? = try? weightRepository.refresh()
         async let statsTask = try? api.getWeightStats()
 
-        entries = await entriesTask ?? []
+        _ = await refreshTask
         weightStats = await statsTask
+        entries = weightRepository.entries()
 
         isLoading = false
 
@@ -409,32 +423,32 @@ struct WeightView: View {
         for (day, sample) in latestPerDay where !existingDates.contains(day) {
             let kg = (sample.weightKg * 100).rounded() / 100
             let create = WeightCreate(weightKg: kg, entryDate: day, notes: nil)
-            if (try? await api.createWeightEntry(create)) != nil {
+            if await (try? weightRepository.createEntry(create)) != nil {
                 imported = true
             }
         }
 
         if imported {
-            entries = (try? await api.getWeightEntries()) ?? entries
-            weightStats = (try? await api.getWeightStats()) ?? weightStats
+            entries = weightRepository.entries()
+            weightStats = await (try? api.getWeightStats()) ?? weightStats
         }
     }
 
     private func deleteEntry(_ entry: WeightEntry) async {
         do {
-            try await api.deleteWeightEntry(id: entry.id)
-            entries.removeAll { $0.id == entry.id }
+            try await weightRepository.deleteEntry(id: entry.id)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         } catch {
             errorMessage = error.localizedDescription
         }
+        entries = weightRepository.entries()
     }
 }
 
 // MARK: - Add / Edit Weight Sheet
 
 struct AddWeightSheet: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(WeightRepository.self) private var weightRepository
     @Environment(\.dismiss) private var dismiss
 
     let existingEntry: WeightEntry?
@@ -486,7 +500,10 @@ struct AddWeightSheet: View {
                 }
             }
             .onAppear { prefill() }
-            .alert(L10n.error, isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
                 Button(L10n.ok, role: .cancel) {}
             } message: {
                 if let errorMessage { Text(errorMessage) }
@@ -498,7 +515,8 @@ struct AddWeightSheet: View {
         let defaults = UserDefaults.standard
         guard defaults.bool(forKey: HealthKitService.syncEnabledKey),
               defaults.bool(forKey: HealthKitService.writeWeightEnabledKey),
-              HealthKitService.shared.isAvailable else { return }
+              HealthKitService.shared.isAvailable
+        else { return }
         // Best effort — the user may have denied write permission in Health
         try? await HealthKitService.shared.saveWeight(kg, date: date)
     }
@@ -524,14 +542,14 @@ struct AddWeightSheet: View {
                     entryDate: dateStr,
                     notes: notes.isEmpty ? nil : notes
                 )
-                _ = try await api.updateWeightEntry(id: existing.id, update)
+                try await weightRepository.updateEntry(id: existing.id, update)
             } else {
                 let entry = WeightCreate(
                     weightKg: kg,
                     entryDate: dateStr,
                     notes: notes.isEmpty ? nil : notes
                 )
-                _ = try await api.createWeightEntry(entry)
+                try await weightRepository.createEntry(entry)
                 await writeToHealthIfEnabled(kg: kg)
             }
             UINotificationFeedbackGenerator().notificationOccurred(.success)

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -228,6 +228,9 @@ struct WeightView: View {
             }
             .refreshable { await loadEntries() }
             .task { await loadEntries(showSpinner: true) }
+            // Cheap local re-read when popping back from the history subpage,
+            // where entries can be edited or deleted.
+            .onAppear { entries = weightRepository.entries() }
             .alert(
                 L10n.error,
                 isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
@@ -473,41 +476,26 @@ struct WeightView: View {
 
     // MARK: - History Section
 
+    private static let historyPreviewCount = 5
+
     private var historySection: some View {
         Section(L10n.history) {
-            ForEach(entries) { entry in
-                Button {
+            ForEach(entries.prefix(Self.historyPreviewCount)) { entry in
+                WeightEntryRow(entry: entry) {
                     editingEntry = entry
+                } onDelete: {
+                    Task { await deleteEntry(entry) }
+                }
+            }
+            if entries.count > Self.historyPreviewCount {
+                NavigationLink {
+                    WeightHistoryView()
                 } label: {
                     HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            if let date = DateFormatting.date(from: entry.entryDate) {
-                                Text(DateFormatting.displayString(from: date))
-                                    .font(.body)
-                                    .foregroundStyle(.primary)
-                            } else {
-                                Text(entry.entryDate)
-                                    .font(.body)
-                                    .foregroundStyle(.primary)
-                            }
-                            if let notes = entry.notes, !notes.isEmpty {
-                                Text(notes)
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
-                                    .lineLimit(1)
-                            }
-                        }
+                        Text(L10n.showAll)
                         Spacer()
-                        Text("\(entry.weightKg, specifier: "%.1f") kg")
+                        Text("\(entries.count)")
                             .foregroundStyle(.secondary)
-                    }
-                }
-                .buttonStyle(.plain)
-                .swipeActions(edge: .trailing) {
-                    Button(role: .destructive) {
-                        Task { await deleteEntry(entry) }
-                    } label: {
-                        Label(L10n.delete, systemImage: "trash")
                     }
                 }
             }
@@ -578,6 +566,125 @@ struct WeightView: View {
             errorMessage = error.localizedDescription
         }
         entries = weightRepository.entries()
+    }
+}
+
+// MARK: - Entry Row
+
+/// One history row — shared by the preview list on the weight page and the
+/// full history subpage.
+struct WeightEntryRow: View {
+    let entry: WeightEntry
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        Button(action: onEdit) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    if let date = DateFormatting.date(from: entry.entryDate) {
+                        Text(DateFormatting.displayString(from: date))
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                    } else {
+                        Text(entry.entryDate)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                    }
+                    if let notes = entry.notes, !notes.isEmpty {
+                        Text(notes)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                Text("\(entry.weightKg, specifier: "%.1f") kg")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive, action: onDelete) {
+                Label(L10n.delete, systemImage: "trash")
+            }
+        }
+    }
+}
+
+// MARK: - Full History
+
+/// All weight entries, loaded page-wise from the local store as the list
+/// scrolls — List rows are lazy, so reaching the last loaded row triggers
+/// the next page fetch.
+struct WeightHistoryView: View {
+    @Environment(WeightRepository.self) private var weightRepository
+
+    @State private var entries: [WeightEntry] = []
+    @State private var hasMore = true
+    @State private var editingEntry: WeightEntry?
+    @State private var errorMessage: String?
+
+    private static let pageSize = 50
+
+    var body: some View {
+        List {
+            ForEach(entries) { entry in
+                WeightEntryRow(entry: entry) {
+                    editingEntry = entry
+                } onDelete: {
+                    Task { await deleteEntry(entry) }
+                }
+                .onAppear {
+                    if entry.id == entries.last?.id {
+                        loadNextPage()
+                    }
+                }
+            }
+        }
+        .navigationTitle(L10n.history)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            if entries.isEmpty { loadNextPage() }
+        }
+        .sheet(item: $editingEntry) { entry in
+            AddWeightSheet(existingEntry: entry) {
+                reloadLoadedWindow()
+            }
+        }
+        .alert(
+            L10n.error,
+            isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+        ) {
+            Button(L10n.ok, role: .cancel) {}
+        } message: {
+            if let errorMessage { Text(errorMessage) }
+        }
+    }
+
+    private func loadNextPage() {
+        guard hasMore else { return }
+        let page = weightRepository.entries(offset: entries.count, limit: Self.pageSize)
+        entries += page
+        hasMore = page.count == Self.pageSize
+    }
+
+    /// Re-reads everything loaded so far in one fetch — an edit can change an
+    /// entry's date and therefore its position in the ordering.
+    private func reloadLoadedWindow() {
+        let limit = max(entries.count, Self.pageSize)
+        entries = weightRepository.entries(offset: 0, limit: limit)
+        hasMore = entries.count == limit
+    }
+
+    private func deleteEntry(_ entry: WeightEntry) async {
+        do {
+            try await weightRepository.deleteEntry(id: entry.id)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            entries.removeAll { $0.id == entry.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/mobile/iosApp/BissbilanzTests/AppModeTests.swift
+++ b/mobile/iosApp/BissbilanzTests/AppModeTests.swift
@@ -1,0 +1,90 @@
+@testable import Bissbilanz
+import Foundation
+import Testing
+
+@Suite("App mode manager")
+@MainActor
+struct AppModeManagerTests {
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "appmode-test-\(UUID().uuidString)")!
+    }
+
+    @Test("Starts with no mode chosen")
+    func startsWithNilMode() {
+        let manager = AppModeManager(defaults: makeDefaults())
+        #expect(manager.mode == nil)
+        #expect(manager.isLocal == false)
+    }
+
+    @Test("setMode persists across instances")
+    func setModePersists() {
+        let defaults = makeDefaults()
+        AppModeManager(defaults: defaults).setMode(.local)
+
+        let reloaded = AppModeManager(defaults: defaults)
+        #expect(reloaded.mode == .local)
+        #expect(reloaded.isLocal == true)
+    }
+
+    @Test("Switching to synced persists too")
+    func switchingToSyncedPersists() {
+        let defaults = makeDefaults()
+        let manager = AppModeManager(defaults: defaults)
+        manager.setMode(.local)
+        manager.setMode(.synced)
+
+        #expect(manager.isLocal == false)
+        #expect(AppModeManager(defaults: defaults).mode == .synced)
+    }
+
+    @Test("clear removes the persisted mode")
+    func clearRemovesMode() {
+        let defaults = makeDefaults()
+        let manager = AppModeManager(defaults: defaults)
+        manager.setMode(.local)
+        manager.clear()
+
+        #expect(manager.mode == nil)
+        #expect(AppModeManager(defaults: defaults).mode == nil)
+    }
+
+    @Test("Garbage in the store reads as no mode")
+    func garbageReadsAsNil() {
+        let defaults = makeDefaults()
+        defaults.set("bogus", forKey: "app_mode")
+        #expect(AppModeManager(defaults: defaults).mode == nil)
+    }
+}
+
+@Suite("Root destination routing")
+struct RootDestinationTests {
+    @Test(
+        "Routing table",
+        arguments: [
+            // Local mode is fully anonymous: the app shows without an account,
+            // and a successful login first migrates the local data.
+            (AuthState.unauthenticated, AppMode.local, RootDestination.app),
+            (AuthState.authenticated, AppMode.local, RootDestination.migration),
+            (AuthState.refreshing, AppMode.local, RootDestination.migration),
+            // Synced (and "not chosen" nil) requires an account.
+            (AuthState.unauthenticated, AppMode.synced, RootDestination.login),
+            (AuthState.authenticated, AppMode.synced, RootDestination.app),
+            (AuthState.refreshing, AppMode.synced, RootDestination.app),
+        ]
+    )
+    func routes(authState: AuthState, mode: AppMode, expected: RootDestination) {
+        #expect(resolveRootDestination(authState: authState, mode: mode) == expected)
+    }
+
+    @Test(
+        "nil mode (not chosen) is treated as sync-allowed",
+        arguments: [
+            (AuthState.unauthenticated, RootDestination.login),
+            (AuthState.authenticated, RootDestination.app),
+            (AuthState.refreshing, RootDestination.app),
+        ]
+    )
+    func nilModeRoutes(authState: AuthState, expected: RootDestination) {
+        #expect(resolveRootDestination(authState: authState, mode: nil) == expected)
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/AppModeTests.swift
+++ b/mobile/iosApp/BissbilanzTests/AppModeTests.swift
@@ -66,10 +66,13 @@ struct RootDestinationTests {
             (AuthState.unauthenticated, AppMode.local, RootDestination.app),
             (AuthState.authenticated, AppMode.local, RootDestination.migration),
             (AuthState.refreshing, AppMode.local, RootDestination.migration),
-            // Synced (and "not chosen" nil) requires an account.
-            (AuthState.unauthenticated, AppMode.synced, RootDestination.login),
+            // A Synced user stays in the app even when the session dies —
+            // re-sign-in happens via an in-app prompt, never the login screen.
+            (AuthState.unauthenticated, AppMode.synced, RootDestination.app),
             (AuthState.authenticated, AppMode.synced, RootDestination.app),
             (AuthState.refreshing, AppMode.synced, RootDestination.app),
+            (AuthState.expired, AppMode.synced, RootDestination.app),
+            (AuthState.expired, AppMode.local, RootDestination.app),
         ]
     )
     func routes(authState: AuthState, mode: AppMode, expected: RootDestination) {
@@ -77,11 +80,12 @@ struct RootDestinationTests {
     }
 
     @Test(
-        "nil mode (not chosen) is treated as sync-allowed",
+        "nil mode (not chosen) shows login only when unauthenticated",
         arguments: [
             (AuthState.unauthenticated, RootDestination.login),
             (AuthState.authenticated, RootDestination.app),
             (AuthState.refreshing, RootDestination.app),
+            (AuthState.expired, RootDestination.app),
         ]
     )
     func nilModeRoutes(authState: AuthState, expected: RootDestination) {

--- a/mobile/iosApp/BissbilanzTests/AuthManagerTests.swift
+++ b/mobile/iosApp/BissbilanzTests/AuthManagerTests.swift
@@ -9,10 +9,13 @@ struct AuthStateTests {
         let unauthenticated = AuthState.unauthenticated
         let authenticated = AuthState.authenticated
         let refreshing = AuthState.refreshing
+        let expired = AuthState.expired
 
         #expect(unauthenticated != authenticated)
         #expect(authenticated != refreshing)
         #expect(unauthenticated != refreshing)
+        #expect(expired != unauthenticated)
+        #expect(expired != authenticated)
     }
 }
 

--- a/mobile/iosApp/BissbilanzTests/AuthManagerTests.swift
+++ b/mobile/iosApp/BissbilanzTests/AuthManagerTests.swift
@@ -1,7 +1,6 @@
+@testable import Bissbilanz
 import Foundation
 import Testing
-
-@testable import Bissbilanz
 
 @Suite("AuthState Tests")
 struct AuthStateTests {
@@ -17,7 +16,18 @@ struct AuthStateTests {
     }
 }
 
-@Suite("KeychainHelper Tests")
+/// The keychain rejects unsigned processes: with the project default
+/// `CODE_SIGNING_ALLOWED=NO`, `SecItemAdd` fails (missing entitlement) and
+/// every save silently no-ops. Probe once and skip the suite in unsigned runs;
+/// pass `CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-` to exercise it.
+private let keychainIsAvailable: Bool = {
+    let probeKey = "bissbilanz_test_probe_\(UUID().uuidString)"
+    KeychainHelper.save(key: probeKey, value: "probe")
+    defer { KeychainHelper.delete(key: probeKey) }
+    return KeychainHelper.load(key: probeKey) == "probe"
+}()
+
+@Suite("KeychainHelper Tests", .enabled(if: keychainIsAvailable, "Keychain requires a signed test host"))
 struct KeychainHelperTests {
     private let testKey = "bissbilanz_test_key_\(UUID().uuidString)"
 
@@ -95,37 +105,37 @@ struct KeychainHelperTests {
 struct AuthManagerLoginURLTests {
     @Test("Login URL contains base URL and state parameter")
     @MainActor
-    func loginURLFormat() {
+    func loginURLFormat() throws {
         let auth = AuthManager(baseURL: "https://test.example.com")
         let url = auth.buildLoginURL()
 
         #expect(url != nil)
-        #expect(url!.absoluteString.starts(with: "https://test.example.com/api/auth/mobile/login"))
-        #expect(url!.absoluteString.contains("state="))
+        #expect(try #require(url?.absoluteString.starts(with: "https://test.example.com/api/auth/mobile/login")))
+        #expect(try #require(url?.absoluteString.contains("state=")))
     }
 
     @Test("Login URL state parameter is UUID format")
     @MainActor
-    func loginURLStateFormat() {
+    func loginURLStateFormat() throws {
         let auth = AuthManager(baseURL: "https://test.example.com")
-        let url = auth.buildLoginURL()!
+        let url = try #require(auth.buildLoginURL())
 
-        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         let state = components.queryItems?.first(where: { $0.name == "state" })?.value
 
         #expect(state != nil)
-        #expect(UUID(uuidString: state!) != nil)
+        #expect(try UUID(uuidString: #require(state)) != nil)
     }
 
     @Test("Each login URL has unique state")
     @MainActor
-    func uniqueLoginState() {
+    func uniqueLoginState() throws {
         let auth = AuthManager(baseURL: "https://test.example.com")
-        let url1 = auth.buildLoginURL()!
-        let url2 = auth.buildLoginURL()!
+        let url1 = try #require(auth.buildLoginURL())
+        let url2 = try #require(auth.buildLoginURL())
 
-        let components1 = URLComponents(url: url1, resolvingAgainstBaseURL: false)!
-        let components2 = URLComponents(url: url2, resolvingAgainstBaseURL: false)!
+        let components1 = try #require(URLComponents(url: url1, resolvingAgainstBaseURL: false))
+        let components2 = try #require(URLComponents(url: url2, resolvingAgainstBaseURL: false))
         let state1 = components1.queryItems?.first(where: { $0.name == "state" })?.value
         let state2 = components2.queryItems?.first(where: { $0.name == "state" })?.value
 
@@ -137,43 +147,43 @@ struct AuthManagerLoginURLTests {
 struct AuthManagerCallbackTests {
     @Test("Callback URL without code returns false")
     @MainActor
-    func callbackWithoutCode() async {
+    func callbackWithoutCode() async throws {
         let auth = AuthManager(baseURL: "https://test.example.com")
         _ = auth.buildLoginURL()
 
-        let callbackURL = URL(string: "bissbilanz://callback?state=wrong")!
+        let callbackURL = try #require(URL(string: "bissbilanz://callback?state=wrong"))
         let result = await auth.handleCallback(url: callbackURL)
         #expect(result == false)
     }
 
     @Test("Callback URL with wrong state returns false")
     @MainActor
-    func callbackWrongState() async {
+    func callbackWrongState() async throws {
         let auth = AuthManager(baseURL: "https://test.example.com")
         _ = auth.buildLoginURL()
 
-        let callbackURL = URL(string: "bissbilanz://callback?code=abc123&state=wrong-state")!
+        let callbackURL = try #require(URL(string: "bissbilanz://callback?code=abc123&state=wrong-state"))
         let result = await auth.handleCallback(url: callbackURL)
         #expect(result == false)
     }
 
     @Test("Callback without prior login URL returns false")
     @MainActor
-    func callbackWithoutLogin() async {
+    func callbackWithoutLogin() async throws {
         let auth = AuthManager(baseURL: "https://test.example.com")
 
-        let callbackURL = URL(string: "bissbilanz://callback?code=abc123&state=some-state")!
+        let callbackURL = try #require(URL(string: "bissbilanz://callback?code=abc123&state=some-state"))
         let result = await auth.handleCallback(url: callbackURL)
         #expect(result == false)
     }
 
     @Test("Callback with empty components returns false")
     @MainActor
-    func callbackEmptyComponents() async {
+    func callbackEmptyComponents() async throws {
         let auth = AuthManager(baseURL: "https://test.example.com")
         _ = auth.buildLoginURL()
 
-        let callbackURL = URL(string: "bissbilanz://callback")!
+        let callbackURL = try #require(URL(string: "bissbilanz://callback"))
         let result = await auth.handleCallback(url: callbackURL)
         #expect(result == false)
     }
@@ -209,4 +219,3 @@ struct AuthManagerStateTests {
         #expect(auth.authState == .unauthenticated)
     }
 }
-

--- a/mobile/iosApp/BissbilanzTests/BissbilanzAPITests.swift
+++ b/mobile/iosApp/BissbilanzTests/BissbilanzAPITests.swift
@@ -1,7 +1,6 @@
+@testable import Bissbilanz
 import Foundation
 import Testing
-
-@testable import Bissbilanz
 
 @Suite("APIError Tests")
 struct APIErrorTests {
@@ -67,12 +66,12 @@ struct APIErrorTests {
 @Suite("API Request Building Tests")
 struct APIRequestBuildingTests {
     @Test("GET request with query params builds correct URL")
-    func getWithQueryParams() {
-        var components = URLComponents(string: "https://example.com/api/foods")!
+    func getWithQueryParams() throws {
+        var components = try #require(URLComponents(string: "https://example.com/api/foods"))
         components.queryItems = ["search": "apple", "limit": "10"].map {
             URLQueryItem(name: $0.key, value: $0.value)
         }
-        let url = components.url!
+        let url = try #require(components.url)
 
         #expect(url.absoluteString.contains("search=apple"))
         #expect(url.absoluteString.contains("limit=10"))
@@ -89,7 +88,7 @@ struct APIRequestBuildingTests {
         )
 
         let data = try JSONEncoder().encode(entry)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["foodId"] as? String == "food-1")
         #expect(json["mealType"] as? String == "lunch")
@@ -113,13 +112,13 @@ struct APIRequestBuildingTests {
         )
 
         let data = try JSONEncoder().encode(recipe)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["name"] as? String == "Oatmeal Bowl")
         #expect(json["totalServings"] as? Double == 2)
         #expect(json["isFavorite"] as? Bool == true)
 
-        let ingredients = json["ingredients"] as! [[String: Any]]
+        let ingredients = try #require(json["ingredients"] as? [[String: Any]])
         #expect(ingredients.count == 2)
         #expect(ingredients[0]["foodId"] as? String == "f1")
         #expect(ingredients[0]["quantity"] as? Double == 80)
@@ -148,19 +147,19 @@ struct APIRequestBuildingTests {
                     ),
                     servings: 1,
                     sortOrder: 0
-                )
+                ),
             ]
         )
 
         let data = try JSONEncoder().encode(supplement)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["name"] as? String == "Vitamin D")
         #expect(json["scheduleType"] as? String == "daily")
         #expect(json["timeOfDay"] as? String == "morning")
-        let ingredients = json["ingredients"] as! [[String: Any]]
+        let ingredients = try #require(json["ingredients"] as? [[String: Any]])
         #expect(ingredients.count == 1)
-        let food = ingredients[0]["food"] as! [String: Any]
+        let food = try #require(ingredients[0]["food"] as? [String: Any])
         #expect(food["name"] as? String == "Vitamin D3")
         #expect(food["ingredientsText"] as? String == "4000 IU")
     }
@@ -177,12 +176,12 @@ struct APIRequestBuildingTests {
                     food: nil,
                     servings: 1,
                     sortOrder: 0
-                )
+                ),
             ]
         )
 
         let data = try JSONEncoder().encode(supplement)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["scheduleType"] as? String == "specific_days")
         #expect(json["scheduleDays"] as? [Int] == [1, 3, 5])
@@ -193,7 +192,7 @@ struct APIRequestBuildingTests {
         let update = WeightUpdate(weightKg: 74.2)
 
         let data = try JSONEncoder().encode(update)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["weightKg"] as? Double == 74.2)
         #expect(json["entryDate"] == nil)
@@ -205,7 +204,7 @@ struct APIRequestBuildingTests {
         let update = EntryUpdate(mealType: "dinner", servings: 2.0)
 
         let data = try JSONEncoder().encode(update)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["mealType"] as? String == "dinner")
         #expect(json["servings"] as? Double == 2.0)
@@ -221,7 +220,7 @@ struct APIRequestBuildingTests {
         )
 
         let data = try JSONEncoder().encode(update)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["showWeightWidget"] as? Bool == false)
         #expect(json["visibleNutrients"] as? [String] == ["sugar", "sodium", "vitaminC"])
@@ -237,7 +236,7 @@ struct APIRequestBuildingTests {
         )
 
         let data = try JSONEncoder().encode(request)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["startDate"] as? String == "2026-01-01")
         #expect(json["endDate"] as? String == "2026-03-01")
@@ -249,7 +248,7 @@ struct APIRequestBuildingTests {
         let props = DayPropertiesSet(isFastingDay: true)
 
         let data = try JSONEncoder().encode(props)
-        let jsonStr = String(data: data, encoding: .utf8)!
+        let jsonStr = try #require(String(data: data, encoding: .utf8))
 
         #expect(jsonStr.contains("is_fasting_day"))
         #expect(!jsonStr.contains("isFastingDay"))

--- a/mobile/iosApp/BissbilanzTests/DateFormattingTests.swift
+++ b/mobile/iosApp/BissbilanzTests/DateFormattingTests.swift
@@ -1,25 +1,24 @@
+@testable import Bissbilanz
 import Foundation
 import Testing
-
-@testable import Bissbilanz
 
 @Suite("DateFormatting Tests")
 struct DateFormattingTests {
     @Test("ISO string format is yyyy-MM-dd")
-    func isoStringFormat() {
+    func isoStringFormat() throws {
         let components = DateComponents(year: 2026, month: 3, day: 12)
-        let date = Calendar.current.date(from: components)!
+        let date = try #require(Calendar.current.date(from: components))
 
         let result = DateFormatting.isoString(from: date)
         #expect(result == "2026-03-12")
     }
 
     @Test("Parse ISO string back to date")
-    func parseISOString() {
+    func parseISOString() throws {
         let date = DateFormatting.date(from: "2026-03-12")
         #expect(date != nil)
 
-        let components = Calendar.current.dateComponents([.year, .month, .day], from: date!)
+        let components = try Calendar.current.dateComponents([.year, .month, .day], from: #require(date))
         #expect(components.year == 2026)
         #expect(components.month == 3)
         #expect(components.day == 12)
@@ -33,20 +32,20 @@ struct DateFormattingTests {
     }
 
     @Test("Today returns current date in ISO format")
-    func todayFormat() {
+    func todayFormat() throws {
         let today = DateFormatting.today
         #expect(today.count == 10)
         #expect(today.contains("-"))
 
         let parsed = DateFormatting.date(from: today)
         #expect(parsed != nil)
-        #expect(Calendar.current.isDateInToday(parsed!))
+        #expect(try Calendar.current.isDateInToday(#require(parsed)))
     }
 
     @Test("Round-trip ISO formatting")
-    func roundTrip() {
+    func roundTrip() throws {
         let original = "2026-01-15"
-        let date = DateFormatting.date(from: original)!
+        let date = try #require(DateFormatting.date(from: original))
         let result = DateFormatting.isoString(from: date)
         #expect(result == original)
     }
@@ -55,16 +54,16 @@ struct DateFormattingTests {
 @Suite("Date Extension Tests")
 struct DateExtensionTests {
     @Test("isoDateString returns formatted string")
-    func isoDateString() {
+    func isoDateString() throws {
         let components = DateComponents(year: 2026, month: 6, day: 1)
-        let date = Calendar.current.date(from: components)!
+        let date = try #require(Calendar.current.date(from: components))
         #expect(date.isoDateString == "2026-06-01")
     }
 
     @Test("Adding days works correctly")
-    func addingDays() {
+    func addingDays() throws {
         let components = DateComponents(year: 2026, month: 3, day: 10)
-        let date = Calendar.current.date(from: components)!
+        let date = try #require(Calendar.current.date(from: components))
 
         let tomorrow = date.adding(days: 1)
         #expect(tomorrow.isoDateString == "2026-03-11")
@@ -77,9 +76,9 @@ struct DateExtensionTests {
     }
 
     @Test("Adding months works correctly")
-    func addingMonths() {
+    func addingMonths() throws {
         let components = DateComponents(year: 2026, month: 1, day: 15)
-        let date = Calendar.current.date(from: components)!
+        let date = try #require(Calendar.current.date(from: components))
 
         let nextMonth = date.adding(months: 1)
         let nextComponents = Calendar.current.dateComponents([.year, .month], from: nextMonth)
@@ -99,9 +98,9 @@ struct DateExtensionTests {
     }
 
     @Test("startOfMonth returns first day")
-    func startOfMonth() {
+    func startOfMonth() throws {
         let components = DateComponents(year: 2026, month: 3, day: 15)
-        let date = Calendar.current.date(from: components)!
+        let date = try #require(Calendar.current.date(from: components))
         let start = date.startOfMonth
 
         let startComponents = Calendar.current.dateComponents([.year, .month, .day], from: start)
@@ -111,23 +110,29 @@ struct DateExtensionTests {
     }
 
     @Test("daysInMonth returns correct count")
-    func daysInMonth() {
-        let feb2026 = Calendar.current.date(from: DateComponents(year: 2026, month: 2, day: 1))!
+    func daysInMonth() throws {
+        let feb2026 = try #require(Calendar.current.date(from: DateComponents(year: 2026, month: 2, day: 1)))
         #expect(feb2026.daysInMonth == 28)
 
-        let mar2026 = Calendar.current.date(from: DateComponents(year: 2026, month: 3, day: 1))!
+        let mar2026 = try #require(Calendar.current.date(from: DateComponents(year: 2026, month: 3, day: 1)))
         #expect(mar2026.daysInMonth == 31)
 
-        let apr2026 = Calendar.current.date(from: DateComponents(year: 2026, month: 4, day: 1))!
+        let apr2026 = try #require(Calendar.current.date(from: DateComponents(year: 2026, month: 4, day: 1)))
         #expect(apr2026.daysInMonth == 30)
     }
 }
 
-@Suite("Localization Tests")
+/// `L10n.currentLocale` is process-global (UserDefaults-backed), so every
+/// test that touches it lives in this single `.serialized` suite — spread
+/// across parallel suites they race and read each other's locale.
+@Suite("Localization Tests", .serialized)
 struct LocalizationTests {
     @Test("Meal names map correctly")
     func mealNames() {
+        let savedLocale = L10n.currentLocale
         L10n.currentLocale = .en
+        defer { L10n.currentLocale = savedLocale }
+
         #expect(L10n.mealName("breakfast") == "Breakfast")
         #expect(L10n.mealName("lunch") == "Lunch")
         #expect(L10n.mealName("dinner") == "Dinner")
@@ -157,6 +162,76 @@ struct LocalizationTests {
         #expect(L10n.protein == "Protein")
         #expect(L10n.settings == "Settings")
     }
+
+    @Test("Meal name handles case-insensitive input")
+    func mealNameCaseInsensitive() {
+        let savedLocale = L10n.currentLocale
+        L10n.currentLocale = .en
+        defer { L10n.currentLocale = savedLocale }
+
+        #expect(L10n.mealName("BREAKFAST") == "Breakfast")
+        #expect(L10n.mealName("Lunch") == "Lunch")
+        #expect(L10n.mealName("DINNER") == "Dinner")
+    }
+
+    @Test("Snack alias maps to Snacks")
+    func snackAlias() {
+        let savedLocale = L10n.currentLocale
+        L10n.currentLocale = .en
+        defer { L10n.currentLocale = savedLocale }
+
+        #expect(L10n.mealName("snack") == "Snacks")
+        #expect(L10n.mealName("snacks") == "Snacks")
+    }
+
+    @Test("Unknown meal type returns capitalized")
+    func unknownMealCapitalized() {
+        // `.capitalized` uppercases after hyphens too ("Pre-Workout").
+        #expect(L10n.mealName("pre-workout") == "Pre-Workout")
+        #expect(L10n.mealName("brunch") == "Brunch")
+    }
+
+    @Test("NOVA group descriptions")
+    func novaGroupDescriptions() {
+        let savedLocale = L10n.currentLocale
+        L10n.currentLocale = .en
+        defer { L10n.currentLocale = savedLocale }
+
+        #expect(L10n.novaGroupDescription(1) == "Unprocessed")
+        #expect(L10n.novaGroupDescription(2) == "Processed ingredients")
+        #expect(L10n.novaGroupDescription(3) == "Processed")
+        #expect(L10n.novaGroupDescription(4) == "Ultra-processed")
+        #expect(L10n.novaGroupDescription(0) == "Unknown")
+        #expect(L10n.novaGroupDescription(5) == "Unknown")
+    }
+
+    @Test("Weekday headers differ by locale")
+    func weekdayHeaders() {
+        let savedLocale = L10n.currentLocale
+        defer { L10n.currentLocale = savedLocale }
+
+        L10n.currentLocale = .en
+        let enHeaders = L10n.weekdayHeaders
+        #expect(enHeaders.count == 7)
+        #expect(enHeaders[0] == "M")
+        #expect(enHeaders[2] == "W") // Wednesday
+
+        L10n.currentLocale = .de
+        let deHeaders = L10n.weekdayHeaders
+        #expect(deHeaders[2] == "M") // Mittwoch
+    }
+
+    @Test("Entries copied interpolation")
+    func entriesCopiedMessage() {
+        let savedLocale = L10n.currentLocale
+        defer { L10n.currentLocale = savedLocale }
+
+        L10n.currentLocale = .en
+        #expect(L10n.entriesCopied(3) == "3 entries copied")
+
+        L10n.currentLocale = .de
+        #expect(L10n.entriesCopied(3) == "3 Einträge kopiert")
+    }
 }
 
 @Suite("JSON Encoding Tests")
@@ -176,7 +251,7 @@ struct JSONEncodingTests {
         )
 
         let data = try JSONEncoder().encode(food)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["name"] as? String == "Test")
         #expect(json["servingSize"] as? Double == 100)
@@ -195,7 +270,7 @@ struct JSONEncodingTests {
         )
 
         let data = try JSONEncoder().encode(entry)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["foodId"] as? String == "food-1")
         #expect(json["mealType"] as? String == "lunch")
@@ -247,7 +322,7 @@ struct JSONEncodingTests {
         )
 
         let data = try JSONEncoder().encode(weight)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["weightKg"] as? Double == 75.5)
         #expect(json["entryDate"] as? String == "2026-03-12")

--- a/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
+++ b/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
@@ -1,8 +1,7 @@
+@testable import Bissbilanz
 import Foundation
 import HealthKit
 import Testing
-
-@testable import Bissbilanz
 
 @Suite("HealthKit Type Configuration Tests")
 struct HealthKitTypeConfigTests {

--- a/mobile/iosApp/BissbilanzTests/LocalModelTests.swift
+++ b/mobile/iosApp/BissbilanzTests/LocalModelTests.swift
@@ -1,0 +1,284 @@
+@testable import Bissbilanz
+import Foundation
+import Testing
+
+/// JSON round-trips Local model ↔ Codable struct for every persisted entity.
+/// The local models keep typed columns plus a `jsonData` payload; these tests
+/// prove the payload is lossless and the typed columns mirror the struct.
+@Suite("Local model JSON round-trips")
+struct LocalModelTests {
+    @Test("LocalEntry round-trips and stamps the cache date")
+    func localEntryRoundTrip() throws {
+        let entry = try JSONPatch.decode(Entry.self, from: [
+            "id": "e1",
+            "mealType": "breakfast",
+            "servings": 1.5,
+            "foodId": "f1",
+            "foodName": "Oats",
+            "calories": 150,
+            "protein": 5,
+            "carbs": 27,
+            "fat": 2.5,
+            "fiber": 4,
+            "servingSize": 40,
+            "servingUnit": "g",
+            "eatenAt": "2026-06-01T08:00:00.000Z",
+        ])
+
+        let local = LocalEntry(entry: entry, date: "2026-06-01")
+        let restored = try #require(local.toEntry())
+
+        #expect(local.id == "e1")
+        #expect(local.date == "2026-06-01")
+        #expect(local.foodName == "Oats")
+        #expect(local.calories == 150)
+        #expect(restored.id == "e1")
+        #expect(restored.date == "2026-06-01") // injected — list responses omit it
+        #expect(restored.foodName == "Oats")
+        #expect(restored.servings == 1.5)
+        #expect(restored.servingUnit == .g)
+        #expect(restored.totalCalories == 225)
+    }
+
+    @Test("LocalFood round-trips including extended nutrients")
+    func localFoodRoundTrip() throws {
+        let food = try JSONPatch.decode(Food.self, from: [
+            "id": "f1",
+            "userId": "u1",
+            "name": "Apple",
+            "brand": "Organic",
+            "servingSize": 182,
+            "servingUnit": "g",
+            "calories": 95,
+            "protein": 0.5,
+            "carbs": 25.1,
+            "fat": 0.3,
+            "fiber": 4.4,
+            "sugar": 18.9,
+            "vitaminC": 8.4,
+            "barcode": "012345678901",
+            "isFavorite": true,
+            "nutriScore": "a",
+            "novaGroup": 1,
+            "additives": ["en:e300"],
+        ])
+
+        let local = LocalFood(food: food)
+        let restored = try #require(local.toFood())
+
+        #expect(local.id == "f1")
+        #expect(local.isFavorite == true)
+        #expect(local.barcode == "012345678901")
+        #expect(restored.name == "Apple")
+        #expect(restored.brand == "Organic")
+        #expect(restored.sugar == 18.9)
+        #expect(restored.vitaminC == 8.4)
+        #expect(restored.nutriScore == "a")
+        #expect(restored.novaGroup == 1)
+        #expect(restored.additives == ["en:e300"])
+    }
+
+    @Test("LocalRecipe round-trips including ingredients")
+    func localRecipeRoundTrip() throws {
+        let recipe = try JSONPatch.decode(Recipe.self, from: [
+            "id": "r1",
+            "userId": "u1",
+            "name": "Oatmeal Bowl",
+            "totalServings": 2,
+            "isFavorite": true,
+            "calories": 350,
+            "protein": 12,
+            "carbs": 55,
+            "fat": 8,
+            "fiber": 7,
+            "ingredients": [
+                [
+                    "id": "ri1",
+                    "recipeId": "r1",
+                    "foodId": "f1",
+                    "quantity": 80,
+                    "servingUnit": "g",
+                    "sortOrder": 0,
+                ],
+            ],
+        ])
+
+        let local = LocalRecipe(recipe: recipe)
+        let restored = try #require(local.toRecipe())
+
+        #expect(local.id == "r1")
+        #expect(local.isFavorite == true)
+        #expect(local.totalServings == 2)
+        #expect(restored.name == "Oatmeal Bowl")
+        #expect(restored.calories == 350)
+        #expect(restored.ingredients?.count == 1)
+        #expect(restored.ingredients?.first?.foodId == "f1")
+        #expect(restored.ingredients?.first?.quantity == 80)
+    }
+
+    @Test("LocalWeightEntry round-trips")
+    func localWeightEntryRoundTrip() throws {
+        let entry = try JSONPatch.decode(WeightEntry.self, from: [
+            "id": "w1",
+            "userId": "u1",
+            "weightKg": 74.6,
+            "entryDate": "2026-06-01",
+            "loggedAt": "2026-06-01T07:30:00Z",
+            "notes": "morning",
+        ])
+
+        let local = LocalWeightEntry(entry: entry)
+        let restored = try #require(local.toWeightEntry())
+
+        #expect(local.id == "w1")
+        #expect(local.entryDate == "2026-06-01")
+        #expect(local.weightKg == 74.6)
+        #expect(restored.weightKg == 74.6)
+        #expect(restored.notes == "morning")
+        #expect(restored.loggedAt == "2026-06-01T07:30:00Z")
+    }
+
+    @Test("LocalSupplement round-trips including ingredients")
+    func localSupplementRoundTrip() throws {
+        let supplement = try JSONPatch.decode(Supplement.self, from: [
+            "id": "s1",
+            "userId": "u1",
+            "name": "Vitamin D",
+            "scheduleType": "specific_days",
+            "scheduleDays": [1, 3, 5],
+            "isActive": true,
+            "sortOrder": 2,
+            "timeOfDay": "morning",
+            "ingredients": [
+                [
+                    "id": "i1",
+                    "supplementId": "s1",
+                    "foodId": "f1",
+                    "servings": 1,
+                    "sortOrder": 0,
+                    "food": [
+                        "id": "f1",
+                        "name": "Vitamin D3",
+                        "kind": "supplement",
+                        "servingSize": 1,
+                        "servingUnit": "piece",
+                        "calories": 0,
+                        "protein": 0,
+                        "carbs": 0,
+                        "fat": 0,
+                        "fiber": 0,
+                        "ingredientsText": "4000 IU",
+                    ],
+                ],
+            ],
+        ])
+
+        let local = LocalSupplement(supplement: supplement)
+        let restored = try #require(local.toSupplement())
+
+        #expect(local.id == "s1")
+        #expect(local.isActive == true)
+        #expect(local.sortOrder == 2)
+        #expect(restored.scheduleType == .specificDays)
+        #expect(restored.scheduleDays == [1, 3, 5])
+        #expect(restored.timeOfDay == "morning")
+        #expect(restored.ingredients.first?.food.ingredientsText == "4000 IU")
+    }
+
+    @Test("LocalSupplementLog round-trips and uses the natural key")
+    func localSupplementLogRoundTrip() throws {
+        let log = SupplementLog(
+            supplementId: "s1",
+            date: "2026-06-01",
+            takenAt: "2026-06-01T08:00:00Z",
+            entryIds: ["e1", "e2"]
+        )
+
+        let local = LocalSupplementLog(log: log)
+        let restored = try #require(local.toSupplementLog())
+
+        #expect(local.id == "s1-2026-06-01")
+        #expect(local.supplementId == "s1")
+        #expect(local.date == "2026-06-01")
+        #expect(local.takenAt == "2026-06-01T08:00:00Z")
+        #expect(restored.supplementId == "s1")
+        #expect(restored.entryIds == ["e1", "e2"])
+    }
+
+    @Test("LocalSupplementLog synthetic init defaults entryIds to empty")
+    func localSupplementLogSyntheticInit() throws {
+        let local = LocalSupplementLog(supplementId: "s1", date: "2026-06-01", takenAt: "2026-06-01T08:00:00Z")
+        let restored = try #require(local.toSupplementLog())
+
+        #expect(local.id == "s1-2026-06-01")
+        #expect(restored.takenAt == "2026-06-01T08:00:00Z")
+        #expect(restored.entryIds.isEmpty)
+    }
+
+    @Test("LocalGoals round-trips including optional goals")
+    func localGoalsRoundTrip() throws {
+        let goals = Goals(
+            calorieGoal: 2200,
+            proteinGoal: 160,
+            carbGoal: 240,
+            fatGoal: 70,
+            fiberGoal: 35,
+            sodiumGoal: 2300,
+            sugarGoal: nil
+        )
+
+        let local = LocalGoals(goals: goals)
+        let restored = try #require(local.toGoals())
+
+        #expect(local.id == LocalGoals.singletonId)
+        #expect(restored.calorieGoal == 2200)
+        #expect(restored.proteinGoal == 160)
+        #expect(restored.sodiumGoal == 2300)
+        #expect(restored.sugarGoal == nil)
+    }
+
+    @Test("LocalPreferences round-trips")
+    func localPreferencesRoundTrip() throws {
+        let preferences = Preferences(
+            showChartWidget: false,
+            showFavoritesWidget: true,
+            showSupplementsWidget: true,
+            showWeightWidget: false,
+            showMealBreakdownWidget: true,
+            showTopFoodsWidget: false,
+            showSummaryWidget: true,
+            showDayLogWidget: true,
+            showStreakWidget: false,
+            widgetOrder: ["chart", "weight"],
+            startPage: "dashboard",
+            favoriteTapAction: "instant",
+            favoriteMealAssignmentMode: "ask_meal",
+            visibleNutrients: ["sugar", "sodium"],
+            locale: "de"
+        )
+
+        let local = LocalPreferences(preferences: preferences)
+        let restored = try #require(local.toPreferences())
+
+        #expect(local.id == LocalPreferences.singletonId)
+        #expect(restored.showChartWidget == false)
+        #expect(restored.widgetOrder == ["chart", "weight"])
+        #expect(restored.favoriteMealAssignmentMode == "ask_meal")
+        #expect(restored.visibleNutrients == ["sugar", "sodium"])
+        #expect(restored.locale == "de")
+    }
+
+    @Test("LocalDayProperties round-trips")
+    func localDayPropertiesRoundTrip() throws {
+        let properties = DayProperties(date: "2026-06-01", userId: "u1", isFastingDay: true)
+
+        let local = LocalDayProperties(properties: properties)
+        let restored = try #require(local.toDayProperties())
+
+        #expect(local.date == "2026-06-01")
+        #expect(local.isFastingDay == true)
+        #expect(restored.date == "2026-06-01")
+        #expect(restored.userId == "u1")
+        #expect(restored.isFastingDay == true)
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/MigratorTests.swift
+++ b/mobile/iosApp/BissbilanzTests/MigratorTests.swift
@@ -1,0 +1,294 @@
+@testable import Bissbilanz
+import Foundation
+import SwiftData
+import Testing
+
+@Suite("Local data migrator")
+@MainActor
+struct MigratorTests {
+    // MARK: - Seeding helpers
+
+    /// Seeds one row of every entity, all `temp_`-keyed, with an entry and a
+    /// recipe ingredient referencing the temp food and a log referencing the
+    /// temp supplement.
+    private func seedLocalData(
+        _ harness: RepositoryHarness,
+        foodId: String = "temp_food1",
+        supplementId: String = "temp_supp1"
+    ) throws {
+        try harness.context.insert(LocalFood(food: harness.food(id: foodId, name: "Local Rice")))
+        try harness.context.insert(LocalRecipe(recipe: harness.recipe(
+            id: "temp_recipe1",
+            name: "Bowl",
+            ingredientFoodId: foodId
+        )))
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: "temp_entry1", date: "2026-06-01", foodId: foodId),
+            date: "2026-06-01"
+        ))
+        try harness.context.insert(LocalWeightEntry(entry: harness.weight(
+            id: "temp_weight1",
+            date: "2026-06-01",
+            kg: 74
+        )))
+        try harness.context.insert(LocalSupplement(supplement: harness.supplement(
+            id: supplementId,
+            name: "Vitamin D"
+        )))
+        harness.context.insert(LocalSupplementLog(
+            supplementId: supplementId,
+            date: "2026-06-01",
+            takenAt: "2026-06-01T08:00:00Z"
+        ))
+        harness.context.insert(LocalGoals(goals: .defaults))
+        harness.context.insert(LocalPreferences(preferences: .defaults))
+        harness.context.insert(LocalDayProperties(properties: DayProperties(
+            date: "2026-06-01",
+            userId: "",
+            isFastingDay: true
+        )))
+        try harness.context.save()
+    }
+
+    private func stubAllCreates(_ harness: RepositoryHarness) {
+        harness.stub("POST", "/api/foods", json: """
+        {"food": {
+            "id": "f-server", "userId": "u1", "name": "Local Rice", "servingSize": 100, "servingUnit": "g",
+            "calories": 100, "protein": 10, "carbs": 20, "fat": 5, "fiber": 3, "isFavorite": false
+        }}
+        """)
+        harness.stub("POST", "/api/recipes", json: """
+        {"recipe": {"id": "r-server", "userId": "u1", "name": "Bowl", "totalServings": 2, "isFavorite": false}}
+        """)
+        harness.stub("POST", "/api/entries", json: """
+        {"entry": {"id": "e-server", "userId": "u1", "date": "2026-06-01", "mealType": "lunch", "servings": 1}}
+        """)
+        harness.stub("POST", "/api/weight", json: """
+        {"entry": {"id": "w-server", "userId": "u1", "weightKg": 74, "entryDate": "2026-06-01"}}
+        """)
+        harness.stub("POST", "/api/supplements", json: """
+        {"supplement": {
+            "id": "s-server", "userId": "u1", "name": "Vitamin D",
+            "scheduleType": "daily", "isActive": true, "sortOrder": 0, "ingredients": []
+        }}
+        """)
+        harness.stub("POST", "/api/supplements/s-server/log", json: """
+        {"log": {"supplementId": "s-server", "date": "2026-06-01", "takenAt": "2026-06-01T08:00:00Z", "entryIds": []}}
+        """)
+        harness.stub("POST", "/api/goals", json: "{}")
+        harness.stub("PATCH", "/api/preferences", json: """
+        {
+            "showChartWidget": true, "showFavoritesWidget": true, "showSupplementsWidget": true,
+            "showWeightWidget": true, "showMealBreakdownWidget": true, "showTopFoodsWidget": true,
+            "showSummaryWidget": true, "showDayLogWidget": true, "showStreakWidget": true,
+            "widgetOrder": [], "startPage": "dashboard", "favoriteTapAction": "instant",
+            "favoriteMealAssignmentMode": "time_based", "visibleNutrients": []
+        }
+        """)
+        harness.stub("POST", "/api/day-properties/2026-06-01", json: """
+        {"properties": {"date": "2026-06-01", "user_id": "u1", "is_fasting_day": true}}
+        """)
+    }
+
+    // MARK: - Plan / preflight
+
+    @Test("plan counts every local entity")
+    func planCountsLocalRows() throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try seedLocalData(harness)
+
+        let plan = harness.migrator.plan()
+
+        #expect(plan.foods == 1)
+        #expect(plan.recipes == 1)
+        #expect(plan.entries == 1)
+        #expect(plan.weights == 1)
+        #expect(plan.supplements == 1)
+        #expect(plan.supplementLogs == 1)
+        #expect(plan.dayProperties == 1)
+        #expect(plan.hasGoals)
+        #expect(plan.hasPreferences)
+        #expect(plan.total == 9)
+    }
+
+    @Test("serverHasData checks foods, then recent foods")
+    func serverHasDataChecks() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        harness.stub("GET", "/api/foods", json: """
+        {"foods": [{
+            "id": "f1", "userId": "u1", "name": "Existing", "servingSize": 100, "servingUnit": "g",
+            "calories": 1, "protein": 0, "carbs": 0, "fat": 0, "fiber": 0, "isFavorite": false
+        }]}
+        """)
+        #expect(try await harness.migrator.serverHasData() == true)
+
+        let empty = try RepositoryHarness(mode: .local)
+        empty.stub("GET", "/api/foods", json: #"{"foods": []}"#)
+        empty.stub("GET", "/api/foods/recent", json: #"{"foods": []}"#)
+        #expect(try await empty.migrator.serverHasData() == false)
+    }
+
+    // MARK: - Migration
+
+    @Test("migrate uploads in dependency order, remaps references and flips the mode")
+    func migrateUploadsInDependencyOrder() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try seedLocalData(harness)
+        stubAllCreates(harness)
+        // A stale queued op must be cleared, not double-applied.
+        harness.context.insert(PendingSyncOperation(seq: 1, operation: .deleteFood(id: "f-x")))
+        try harness.context.save()
+
+        let migrator = harness.migrator
+        await migrator.migrate()
+
+        #expect(migrator.state == .completed)
+        #expect(harness.appMode.mode == .synced)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+
+        // Dependency order: foods → recipes → entries → weights →
+        // supplements → supplement logs → goals → preferences → day props.
+        let posts = harness.recordedRequests
+        #expect(posts == [
+            "POST /api/foods",
+            "POST /api/recipes",
+            "POST /api/entries",
+            "POST /api/weight",
+            "POST /api/supplements",
+            "POST /api/supplements/s-server/log",
+            "POST /api/goals",
+            "PATCH /api/preferences",
+            "POST /api/day-properties/2026-06-01",
+        ])
+
+        // The uploaded recipe and entry already carried the server food id.
+        let recipeBody = try #require(harness.recordedBodies("POST", "/api/recipes").first)
+        let recipeCreate = try JSONDecoder().decode(RecipeCreate.self, from: recipeBody)
+        #expect(recipeCreate.ingredients.map(\.foodId) == ["f-server"])
+        let entryBody = try #require(harness.recordedBodies("POST", "/api/entries").first)
+        let entryCreate = try JSONDecoder().decode(EntryCreate.self, from: entryBody)
+        #expect(entryCreate.foodId == "f-server")
+
+        // Every local row is re-keyed to its server record.
+        #expect(harness.foodRepository.food(id: "f-server") != nil)
+        #expect(harness.recipeRepository.recipe(id: "r-server") != nil)
+        #expect(harness.entryRepository.entries(date: "2026-06-01").map(\.id) == ["e-server"])
+        #expect(harness.weightRepository.entries().map(\.id) == ["w-server"])
+        #expect(harness.supplementRepository.supplements().map(\.id) == ["s-server"])
+        #expect(harness.supplementRepository.loggedSupplementIds(date: "2026-06-01") == ["s-server"])
+    }
+
+    @Test("Non-temp leftovers are normalized to temp ids and uploaded")
+    func normalizationRekeysServerLeftovers() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        // Leftovers from an earlier synced session: server-keyed rows.
+        try harness.context.insert(LocalFood(food: harness.food(id: "old-server-food", name: "Leftover")))
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: "old-server-entry", date: "2026-06-01", foodId: "old-server-food"),
+            date: "2026-06-01"
+        ))
+        try harness.context.save()
+        stubAllCreates(harness)
+
+        let migrator = harness.migrator
+        await migrator.migrate()
+
+        #expect(migrator.state == .completed)
+        #expect(harness.recordedRequests == ["POST /api/foods", "POST /api/entries"])
+        #expect(harness.foodRepository.food(id: "f-server") != nil)
+        #expect(harness.foodRepository.food(id: "old-server-food") == nil)
+        // The entry reference followed the food through normalize + upload.
+        let entryBody = try #require(harness.recordedBodies("POST", "/api/entries").first)
+        let entryCreate = try JSONDecoder().decode(EntryCreate.self, from: entryBody)
+        #expect(entryCreate.foodId == "f-server")
+    }
+
+    @Test("A failed run resumes by uploading only the remaining temp rows")
+    func failedRunResumes() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try harness.context.insert(LocalFood(food: harness.food(id: "temp_food1", name: "Local Rice")))
+        try harness.context.insert(LocalRecipe(recipe: harness.recipe(
+            id: "temp_recipe1",
+            name: "Bowl",
+            ingredientFoodId: "temp_food1"
+        )))
+        try harness.context.save()
+        stubAllCreates(harness)
+        harness.stub("POST", "/api/recipes", status: 500, json: #"{"error": "boom"}"#)
+
+        let migrator = harness.migrator
+        await migrator.migrate()
+
+        guard case .failed = migrator.state else {
+            Issue.record("expected the migration to fail on the recipe upload")
+            return
+        }
+        // Partial progress is preserved: the food already has its server id.
+        #expect(harness.appMode.mode == .local)
+        #expect(harness.foodRepository.food(id: "f-server") != nil)
+        #expect(harness.recipeRepository.recipes().allSatisfy { LocalStore.isTempId($0.id) })
+
+        // Retry: only the recipe uploads — the food is not re-keyed or re-sent.
+        harness.stub("POST", "/api/recipes", json: """
+        {"recipe": {"id": "r-server", "userId": "u1", "name": "Bowl", "totalServings": 2, "isFavorite": false}}
+        """)
+        await migrator.migrate()
+
+        #expect(migrator.state == .completed)
+        #expect(harness.appMode.mode == .synced)
+        #expect(harness.recordedRequests.count(where: { $0 == "POST /api/foods" }) == 1)
+        #expect(harness.recordedRequests.count(where: { $0 == "POST /api/recipes" }) == 2)
+        #expect(harness.recipeRepository.recipe(id: "r-server") != nil)
+    }
+
+    @Test("Dangling references upload as quick entries and dropped ingredients")
+    func danglingReferencesDegradeGracefully() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        // Entry + recipe reference a food that no longer exists locally.
+        try harness.context.insert(LocalRecipe(recipe: harness.recipe(
+            id: "temp_recipe1",
+            name: "Bowl",
+            ingredientFoodId: "temp_gone"
+        )))
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: "temp_entry1", date: "2026-06-01", foodId: "temp_gone"),
+            date: "2026-06-01"
+        ))
+        try harness.context.save()
+        stubAllCreates(harness)
+
+        let migrator = harness.migrator
+        await migrator.migrate()
+
+        #expect(migrator.state == .completed)
+        let recipeBody = try #require(harness.recordedBodies("POST", "/api/recipes").first)
+        let recipeCreate = try JSONDecoder().decode(RecipeCreate.self, from: recipeBody)
+        #expect(recipeCreate.ingredients.isEmpty)
+        let entryBody = try #require(harness.recordedBodies("POST", "/api/entries").first)
+        let entryCreate = try JSONDecoder().decode(EntryCreate.self, from: entryBody)
+        #expect(entryCreate.foodId == nil)
+        #expect(entryCreate.quickName == "Seed temp_entry1") // display fallback
+        #expect(entryCreate.quickCalories == 100)
+    }
+
+    @Test("discardLocalData wipes the store and queue, then flips to synced")
+    func discardWipesEverything() throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try seedLocalData(harness)
+        harness.context.insert(PendingSyncOperation(seq: 1, operation: .deleteFood(id: "f-x")))
+        try harness.context.save()
+
+        harness.migrator.discardLocalData()
+
+        #expect(harness.appMode.mode == .synced)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.foodRepository.favorites().isEmpty)
+        #expect(harness.foodRepository.searchLocal("Local").isEmpty)
+        #expect(harness.entryRepository.entries(date: "2026-06-01").isEmpty)
+        #expect(harness.weightRepository.entries().isEmpty)
+        #expect(harness.supplementRepository.supplements().isEmpty)
+        #expect(harness.goalsRepository.goals() == nil)
+        #expect(harness.preferencesRepository.preferences() == nil)
+        #expect(harness.recordedRequests.isEmpty)
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/MigratorTests.swift
+++ b/mobile/iosApp/BissbilanzTests/MigratorTests.swift
@@ -271,6 +271,91 @@ struct MigratorTests {
         #expect(entryCreate.quickCalories == 100)
     }
 
+    @Test("Local-mode supplement ingredients upload as inline backing foods")
+    func supplementInlineIngredientsUploadInline() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        // Created through the repository like the Local-mode editor would.
+        _ = try await harness.supplementRepository.createSupplement(SupplementCreate(
+            name: "Magnesium",
+            scheduleType: .daily,
+            ingredients: [SupplementIngredientInput(
+                foodId: nil,
+                food: SupplementBackingFoodInput(
+                    name: "Magnesium citrate", servingSize: 1, servingUnit: "g",
+                    calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0,
+                    ingredientsText: "300 mg"
+                ),
+                servings: 1,
+                sortOrder: 0
+            )]
+        ))
+        stubAllCreates(harness)
+
+        let migrator = harness.migrator
+        await migrator.migrate()
+
+        #expect(migrator.state == .completed)
+        let body = try #require(harness.recordedBodies("POST", "/api/supplements").first)
+        let create = try JSONDecoder().decode(SupplementCreate.self, from: body)
+        #expect(create.ingredients.count == 1)
+        #expect(create.ingredients.first?.foodId == nil)
+        #expect(create.ingredients.first?.food?.name == "Magnesium citrate")
+        #expect(create.ingredients.first?.food?.ingredientsText == "300 mg")
+    }
+
+    @Test("wipeLocalData clears the store, the queue and the normalization marker")
+    func wipeLocalDataClearsEverythingButKeepsMode() throws {
+        let harness = try RepositoryHarness(mode: .synced)
+        try seedLocalData(harness)
+        harness.context.insert(PendingSyncOperation(seq: 1, operation: .deleteFood(id: "f-x")))
+        try harness.context.save()
+        harness.defaults.set(true, forKey: "migration_normalized")
+
+        harness.migrator.wipeLocalData()
+
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.syncManager.pendingCount == 0)
+        #expect(harness.foodRepository.searchLocal("Local").isEmpty)
+        #expect(harness.entryRepository.entries(date: "2026-06-01").isEmpty)
+        #expect(harness.recipeRepository.recipes().isEmpty)
+        #expect(harness.weightRepository.entries().isEmpty)
+        #expect(harness.supplementRepository.supplements().isEmpty)
+        #expect(harness.supplementRepository.loggedSupplementIds(date: "2026-06-01").isEmpty)
+        #expect(harness.goalsRepository.goals() == nil)
+        #expect(harness.preferencesRepository.preferences() == nil)
+        #expect(harness.entryRepository.isFastingDay(date: "2026-06-01") == false)
+        #expect(harness.defaults.bool(forKey: "migration_normalized") == false)
+        // Unlike discardLocalData, the mode is untouched (the caller decides).
+        #expect(harness.appMode.mode == .synced)
+        #expect(harness.recordedRequests.isEmpty)
+    }
+
+    @Test("Abandoning a failed migration clears the normalization marker")
+    func abandonMigrationClearsNormalizationMarker() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try seedLocalData(harness)
+        stubAllCreates(harness)
+        harness.stub("POST", "/api/foods", status: 500, json: #"{"error": "boom"}"#)
+
+        let migrator = harness.migrator
+        await migrator.migrate()
+        guard case .failed = migrator.state else {
+            Issue.record("expected the migration to fail on the food upload")
+            return
+        }
+        // The partial run normalized the store and left the marker behind.
+        #expect(harness.defaults.bool(forKey: "migration_normalized") == true)
+
+        // "Continue without account": data stays, marker must not survive —
+        // a later sign-in (possibly another account) needs re-normalization.
+        migrator.abandonMigration()
+
+        #expect(harness.defaults.bool(forKey: "migration_normalized") == false)
+        #expect(migrator.state == .idle)
+        #expect(harness.appMode.mode == .local)
+        #expect(harness.foodRepository.searchLocal("Local Rice").count == 1)
+    }
+
     @Test("discardLocalData wipes the store and queue, then flips to synced")
     func discardWipesEverything() throws {
         let harness = try RepositoryHarness(mode: .local)

--- a/mobile/iosApp/BissbilanzTests/ModelTests.swift
+++ b/mobile/iosApp/BissbilanzTests/ModelTests.swift
@@ -1,7 +1,6 @@
+@testable import Bissbilanz
 import Foundation
 import Testing
-
-@testable import Bissbilanz
 
 @Suite("Food Model Tests")
 struct FoodModelTests {
@@ -355,9 +354,54 @@ struct FoodNutrientGroupsTests {
 struct RecipeModelTests {
     @Test("Recipe equality based on id")
     func recipeEquality() {
-        let r1 = Recipe(id: "r1", userId: "u1", name: "A", totalServings: 1, isFavorite: false, imageUrl: nil, calories: 100, protein: 5, carbs: 10, fat: 3, fiber: 2, createdAt: nil, updatedAt: nil, ingredients: nil)
-        let r2 = Recipe(id: "r1", userId: "u1", name: "B", totalServings: 2, isFavorite: true, imageUrl: nil, calories: 200, protein: 10, carbs: 20, fat: 6, fiber: 4, createdAt: nil, updatedAt: nil, ingredients: nil)
-        let r3 = Recipe(id: "r2", userId: "u1", name: "A", totalServings: 1, isFavorite: false, imageUrl: nil, calories: 100, protein: 5, carbs: 10, fat: 3, fiber: 2, createdAt: nil, updatedAt: nil, ingredients: nil)
+        let r1 = Recipe(
+            id: "r1",
+            userId: "u1",
+            name: "A",
+            totalServings: 1,
+            isFavorite: false,
+            imageUrl: nil,
+            calories: 100,
+            protein: 5,
+            carbs: 10,
+            fat: 3,
+            fiber: 2,
+            createdAt: nil,
+            updatedAt: nil,
+            ingredients: nil
+        )
+        let r2 = Recipe(
+            id: "r1",
+            userId: "u1",
+            name: "B",
+            totalServings: 2,
+            isFavorite: true,
+            imageUrl: nil,
+            calories: 200,
+            protein: 10,
+            carbs: 20,
+            fat: 6,
+            fiber: 4,
+            createdAt: nil,
+            updatedAt: nil,
+            ingredients: nil
+        )
+        let r3 = Recipe(
+            id: "r2",
+            userId: "u1",
+            name: "A",
+            totalServings: 1,
+            isFavorite: false,
+            imageUrl: nil,
+            calories: 100,
+            protein: 5,
+            carbs: 10,
+            fat: 3,
+            fiber: 2,
+            createdAt: nil,
+            updatedAt: nil,
+            ingredients: nil
+        )
 
         #expect(r1 == r2)
         #expect(r1 != r3)
@@ -365,8 +409,38 @@ struct RecipeModelTests {
 
     @Test("Recipe hashable uses id")
     func recipeHashable() {
-        let r1 = Recipe(id: "r1", userId: "u1", name: "A", totalServings: 1, isFavorite: false, imageUrl: nil, calories: nil, protein: nil, carbs: nil, fat: nil, fiber: nil, createdAt: nil, updatedAt: nil, ingredients: nil)
-        let r2 = Recipe(id: "r1", userId: "u1", name: "B", totalServings: 2, isFavorite: true, imageUrl: nil, calories: nil, protein: nil, carbs: nil, fat: nil, fiber: nil, createdAt: nil, updatedAt: nil, ingredients: nil)
+        let r1 = Recipe(
+            id: "r1",
+            userId: "u1",
+            name: "A",
+            totalServings: 1,
+            isFavorite: false,
+            imageUrl: nil,
+            calories: nil,
+            protein: nil,
+            carbs: nil,
+            fat: nil,
+            fiber: nil,
+            createdAt: nil,
+            updatedAt: nil,
+            ingredients: nil
+        )
+        let r2 = Recipe(
+            id: "r1",
+            userId: "u1",
+            name: "B",
+            totalServings: 2,
+            isFavorite: true,
+            imageUrl: nil,
+            calories: nil,
+            protein: nil,
+            carbs: nil,
+            fat: nil,
+            fiber: nil,
+            createdAt: nil,
+            updatedAt: nil,
+            ingredients: nil
+        )
 
         var set = Set<Recipe>()
         set.insert(r1)
@@ -475,7 +549,7 @@ struct WeightModelTests {
         let create = WeightCreate(weightKg: 74.0, entryDate: "2026-03-13")
 
         let data = try JSONEncoder().encode(create)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         #expect(json["weightKg"] as? Double == 74.0)
         #expect(json["notes"] == nil)

--- a/mobile/iosApp/BissbilanzTests/OpenFoodFactsClientTests.swift
+++ b/mobile/iosApp/BissbilanzTests/OpenFoodFactsClientTests.swift
@@ -1,0 +1,107 @@
+@testable import Bissbilanz
+import Foundation
+import Testing
+
+@Suite("Open Food Facts direct client")
+@MainActor
+struct OpenFoodFactsClientTests {
+    private func makeClient() -> OpenFoodFactsClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return OpenFoodFactsClient(session: URLSession(configuration: configuration))
+    }
+
+    private func stubProduct(_ barcode: String, json: String) {
+        StubURLProtocol.stub(
+            "GET",
+            "https://world.openfoodfacts.org/api/v2/product/\(barcode).json",
+            json: json
+        )
+    }
+
+    @Test("Maps an OFF product onto the Food prefill shape with unit conversions")
+    func mapsProductWithConversions() async throws {
+        stubProduct("7610000000001", json: """
+        {
+            "status": 1,
+            "product": {
+                "product_name": "Crackers",
+                "brands": "Acme",
+                "nutriscore_grade": "b",
+                "nova_group": 4,
+                "additives_tags": ["en:e322"],
+                "ingredients_text": "Wheat flour, salt",
+                "image_front_url": "https://images.example/crackers.jpg",
+                "nutriments": {
+                    "energy-kcal_100g": 380,
+                    "proteins_100g": "9.7",
+                    "carbohydrates_100g": 71.4,
+                    "fat_100g": 4.5,
+                    "fiber_100g": 2,
+                    "sodium_100g": 0.512,
+                    "vitamin-c_100g": 0.012,
+                    "vitamin-b12_100g": 0.0000007,
+                    "salt_100g": 1.28
+                }
+            }
+        }
+        """)
+
+        let food = try #require(try await makeClient().lookupBarcode("7610000000001"))
+
+        #expect(food.name == "Crackers")
+        #expect(food.brand == "Acme")
+        #expect(food.barcode == "7610000000001")
+        #expect(food.servingSize == 100)
+        #expect(food.servingUnit == .g)
+        #expect(food.calories == 380)
+        #expect(food.protein == 9.7) // numeric string
+        #expect(food.carbs == 71.4)
+        #expect(food.fat == 4.5)
+        #expect(food.fiber == 2)
+        #expect(food.sodium == 512) // g → mg
+        #expect(food.vitaminC == 12) // g → mg
+        #expect(food.vitaminB12 == 0.7) // g → µg
+        #expect(food.salt == 1.28)
+        #expect(food.nutriScore == "b")
+        #expect(food.novaGroup == 4)
+        #expect(food.additives == ["en:e322"])
+        #expect(food.ingredientsText == "Wheat flour, salt")
+        #expect(food.imageUrl == "https://images.example/crackers.jpg")
+    }
+
+    @Test("Unknown products and invalid payloads return nil")
+    func unknownProductReturnsNil() async throws {
+        stubProduct("7610000000002", json: #"{"status": 0, "status_verbose": "product not found"}"#)
+        #expect(try await makeClient().lookupBarcode("7610000000002") == nil)
+
+        stubProduct("7610000000003", json: "not json")
+        #expect(try await makeClient().lookupBarcode("7610000000003") == nil)
+
+        StubURLProtocol.stub(
+            "GET",
+            "https://world.openfoodfacts.org/api/v2/product/7610000000004.json",
+            status: 500,
+            json: #"{"error": "boom"}"#
+        )
+        #expect(try await makeClient().lookupBarcode("7610000000004") == nil)
+    }
+
+    @Test("Missing optional fields map to defaults")
+    func missingFieldsMapToDefaults() async throws {
+        stubProduct("7610000000005", json: """
+        {"status": 1, "product": {"product_name": "Mystery", "nutriments": {}}}
+        """)
+
+        let food = try #require(try await makeClient().lookupBarcode("7610000000005"))
+
+        #expect(food.name == "Mystery")
+        #expect(food.brand == nil)
+        #expect(food.calories == 0)
+        #expect(food.protein == 0)
+        #expect(food.nutriScore == nil)
+        #expect(food.novaGroup == nil)
+        #expect(food.saturatedFat == nil)
+        #expect(food.imageUrl == nil)
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
+++ b/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
@@ -1,0 +1,581 @@
+@testable import Bissbilanz
+import Foundation
+import SwiftData
+import Testing
+
+// MARK: - Networking stub
+
+/// Routes stubbed responses by "METHOD path". Unstubbed requests get a 404 so
+/// repository API calls fail loudly instead of hanging.
+final class StubURLProtocol: URLProtocol {
+    struct Stub {
+        let status: Int
+        let body: Data
+    }
+
+    private nonisolated(unsafe) static var stubs: [String: Stub] = [:]
+    private nonisolated(unsafe) static var recorded: [String] = []
+    private static let lock = NSLock()
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        stubs = [:]
+        recorded = []
+    }
+
+    static func stub(_ method: String, _ path: String, status: Int = 200, json: String = "{}") {
+        lock.lock()
+        defer { lock.unlock() }
+        stubs["\(method) \(path)"] = Stub(status: status, body: Data(json.utf8))
+    }
+
+    static var recordedRequests: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let key = "\(request.httpMethod ?? "GET") \(request.url?.path ?? "")"
+        Self.lock.lock()
+        Self.recorded.append(key)
+        let stub = Self.stubs[key]
+        Self.lock.unlock()
+
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://stub.local")!,
+            statusCode: stub?.status ?? 404,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub?.body ?? Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test harness
+
+@MainActor
+struct RepositoryHarness {
+    let container: ModelContainer
+    let context: ModelContext
+    let api: BissbilanzAPI
+
+    init() throws {
+        StubURLProtocol.reset()
+        container = try LocalStore.makeContainer(inMemory: true)
+        context = container.mainContext
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        api = BissbilanzAPI(
+            baseURL: "https://stub.local",
+            authManager: AuthManager(baseURL: "https://stub.local"),
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    func entry(id: String, date: String, mealType: String = "lunch", foodId: String? = nil) throws -> Entry {
+        var dict: [String: Any] = [
+            "id": id,
+            "mealType": mealType,
+            "servings": 1,
+            "foodName": "Seed \(id)",
+            "calories": 100,
+            "date": date,
+        ]
+        if let foodId { dict["foodId"] = foodId }
+        return try JSONPatch.decode(Entry.self, from: dict)
+    }
+
+    func food(id: String, name: String, isFavorite: Bool = false, barcode: String? = nil) throws -> Food {
+        var dict: [String: Any] = [
+            "id": id,
+            "userId": "u1",
+            "name": name,
+            "servingSize": 100,
+            "servingUnit": "g",
+            "calories": 100,
+            "protein": 10,
+            "carbs": 20,
+            "fat": 5,
+            "fiber": 3,
+            "isFavorite": isFavorite,
+        ]
+        if let barcode { dict["barcode"] = barcode }
+        return try JSONPatch.decode(Food.self, from: dict)
+    }
+
+    func recipe(id: String, name: String, isFavorite: Bool = false) throws -> Recipe {
+        try JSONPatch.decode(Recipe.self, from: [
+            "id": id,
+            "userId": "u1",
+            "name": name,
+            "totalServings": 2,
+            "isFavorite": isFavorite,
+        ])
+    }
+
+    func weight(id: String, date: String, kg: Double) throws -> WeightEntry {
+        try JSONPatch.decode(WeightEntry.self, from: [
+            "id": id,
+            "userId": "u1",
+            "weightKg": kg,
+            "entryDate": date,
+        ])
+    }
+
+    func supplement(id: String, name: String, sortOrder: Int = 0) throws -> Supplement {
+        try JSONPatch.decode(Supplement.self, from: [
+            "id": id,
+            "userId": "u1",
+            "name": name,
+            "scheduleType": "daily",
+            "isActive": true,
+            "sortOrder": sortOrder,
+            "ingredients": [],
+        ])
+    }
+}
+
+// MARK: - Tests
+
+@Suite("Repository tests", .serialized)
+@MainActor
+struct RepositoryTests {
+    // MARK: Entries
+
+    @Test("Entry refresh replaces the cached day, leaving other days untouched")
+    func entryRefreshReplacesByDate() async throws {
+        let harness = try RepositoryHarness()
+        let repo = EntryRepository(context: harness.context, api: harness.api)
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: "old-1", date: "2026-06-01"),
+            date: "2026-06-01"
+        ))
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: "other-1", date: "2026-06-02"),
+            date: "2026-06-02"
+        ))
+        try harness.context.save()
+
+        StubURLProtocol.stub("GET", "/api/entries", json: """
+        {"entries": [{
+            "id": "new-1", "mealType": "breakfast", "servings": 2,
+            "foodId": "f1", "foodName": "Oats",
+            "calories": 150, "protein": 5, "carbs": 27, "fat": 2.5, "fiber": 4
+        }]}
+        """)
+
+        try await repo.refresh(date: "2026-06-01")
+
+        let day = repo.entries(date: "2026-06-01")
+        #expect(day.count == 1)
+        #expect(day.first?.id == "new-1")
+        #expect(day.first?.date == "2026-06-01")
+        #expect(repo.entries(date: "2026-06-02").map(\.id) == ["other-1"])
+    }
+
+    @Test("Entry create writes locally first, then replaces the temp row with the server record")
+    func entryCreateReplacesTempWithServerRecord() async throws {
+        let harness = try RepositoryHarness()
+        let repo = EntryRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/entries", json: """
+        {"entry": {
+            "id": "server-1", "userId": "u1", "date": "2026-06-01",
+            "mealType": "lunch", "servings": 1.5, "foodId": "f1"
+        }}
+        """)
+
+        let create = EntryCreate(foodId: "f1", mealType: "lunch", servings: 1.5, date: "2026-06-01")
+        let created = try await repo.createEntry(create, food: harness.food(id: "f1", name: "Rice"))
+
+        #expect(created.id == "server-1")
+        let day = repo.entries(date: "2026-06-01")
+        #expect(day.count == 1)
+        #expect(day.first?.id == "server-1")
+        // Raw POST responses lack resolved macros — merged from the optimistic row.
+        #expect(day.first?.displayName == "Rice")
+        #expect(day.first?.totalCalories == 150)
+        #expect(!day.contains { LocalStore.isTempId($0.id) })
+    }
+
+    @Test("Entry create keeps the optimistic local row when the API fails")
+    func entryCreateKeepsLocalRowOnAPIFailure() async throws {
+        let harness = try RepositoryHarness()
+        let repo = EntryRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/entries", status: 500, json: #"{"error": "boom"}"#)
+
+        let create = EntryCreate(foodId: "f1", mealType: "dinner", servings: 1, date: "2026-06-01")
+        await #expect(throws: (any Error).self) {
+            try await repo.createEntry(create, food: harness.food(id: "f1", name: "Rice"))
+        }
+
+        let day = repo.entries(date: "2026-06-01")
+        #expect(day.count == 1)
+        #expect(LocalStore.isTempId(day.first?.id ?? ""))
+        #expect(day.first?.displayName == "Rice")
+    }
+
+    @Test("Entry delete removes the local row and skips the API for temp ids")
+    func entryDeleteSkipsAPIForTempIds() async throws {
+        let harness = try RepositoryHarness()
+        let repo = EntryRepository(context: harness.context, api: harness.api)
+        let tempId = LocalStore.makeTempId()
+        try harness.context.insert(LocalEntry(entry: harness.entry(id: tempId, date: "2026-06-01"), date: "2026-06-01"))
+        try harness.context.save()
+
+        try await repo.deleteEntry(id: tempId)
+
+        #expect(repo.entries(date: "2026-06-01").isEmpty)
+        #expect(!StubURLProtocol.recordedRequests.contains { $0.hasPrefix("DELETE") })
+    }
+
+    @Test("Day properties write locally first and survive an API failure")
+    func dayPropertiesKeepLocalOnAPIFailure() async throws {
+        let harness = try RepositoryHarness()
+        let repo = EntryRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/day-properties/2026-06-01", status: 500, json: #"{"error": "boom"}"#)
+
+        await #expect(throws: (any Error).self) {
+            try await repo.setDayProperties(date: "2026-06-01", isFastingDay: true)
+        }
+
+        #expect(repo.isFastingDay(date: "2026-06-01") == true)
+    }
+
+    // MARK: Foods
+
+    @Test("Food create replaces the temp id with the server record")
+    func foodCreateReplacesTempId() async throws {
+        let harness = try RepositoryHarness()
+        let repo = FoodRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/foods", json: """
+        {"food": {
+            "id": "f-server", "userId": "u1", "name": "Skyr", "servingSize": 150, "servingUnit": "g",
+            "calories": 98, "protein": 16, "carbs": 6, "fat": 0.2, "fiber": 0, "isFavorite": false
+        }}
+        """)
+
+        let create = FoodCreate(
+            name: "Skyr", servingSize: 150, servingUnit: .g,
+            calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
+        )
+        let created = try await repo.createFood(create)
+
+        #expect(created.id == "f-server")
+        #expect(repo.food(id: "f-server")?.name == "Skyr")
+        #expect(repo.searchLocal("Skyr").count == 1)
+    }
+
+    @Test("Food create keeps the temp row when the API fails")
+    func foodCreateKeepsTempRowOnFailure() async throws {
+        let harness = try RepositoryHarness()
+        let repo = FoodRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/foods", status: 500, json: #"{"error": "boom"}"#)
+
+        let create = FoodCreate(
+            name: "Skyr", servingSize: 150, servingUnit: .g,
+            calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
+        )
+        await #expect(throws: (any Error).self) {
+            try await repo.createFood(create)
+        }
+
+        let local = repo.searchLocal("Skyr")
+        #expect(local.count == 1)
+        #expect(LocalStore.isTempId(local.first?.id ?? ""))
+    }
+
+    @Test("Toggle favorite flips the local row before the API call")
+    func toggleFavoriteUpdatesLocalFirst() async throws {
+        let harness = try RepositoryHarness()
+        let repo = FoodRepository(context: harness.context, api: harness.api)
+        try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Rice")))
+        try harness.context.save()
+        StubURLProtocol.stub("PATCH", "/api/foods/f1", status: 500, json: #"{"error": "boom"}"#)
+
+        await #expect(throws: (any Error).self) {
+            try await repo.toggleFavorite(foodId: "f1", isFavorite: true)
+        }
+
+        #expect(repo.food(id: "f1")?.isFavorite == true)
+        #expect(repo.favorites().map(\.id) == ["f1"])
+    }
+
+    @Test("Favorites refresh upserts foods and recipes and reconciles un-favorited rows")
+    func refreshFavoritesReconciles() async throws {
+        let harness = try RepositoryHarness()
+        let repo = FoodRepository(context: harness.context, api: harness.api)
+        try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Old Fav", isFavorite: true)))
+        try harness.context.save()
+        StubURLProtocol.stub("GET", "/api/favorites", json: """
+        {
+            "foods": [{
+                "id": "f2", "userId": "u1", "name": "New Fav", "servingSize": 100, "servingUnit": "g",
+                "calories": 50, "protein": 5, "carbs": 5, "fat": 1, "fiber": 1, "isFavorite": true
+            }],
+            "recipes": [{
+                "id": "r1", "userId": "u1", "name": "Fav Recipe", "totalServings": 1, "isFavorite": true
+            }]
+        }
+        """)
+
+        try await repo.refreshFavorites()
+
+        #expect(repo.favorites().map(\.id) == ["f2"])
+        #expect(repo.food(id: "f1")?.isFavorite == false)
+        let recipeRepo = RecipeRepository(context: harness.context, api: harness.api)
+        #expect(recipeRepo.favoriteRecipes().map(\.id) == ["r1"])
+    }
+
+    @Test("Barcode lookup answers from the local store before hitting the API")
+    func findByBarcodePrefersLocal() async throws {
+        let harness = try RepositoryHarness()
+        let repo = FoodRepository(context: harness.context, api: harness.api)
+        try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Bar", barcode: "123")))
+        try harness.context.save()
+
+        let found = try await repo.findByBarcode("123")
+
+        #expect(found?.id == "f1")
+        #expect(StubURLProtocol.recordedRequests.isEmpty)
+    }
+
+    // MARK: Recipes
+
+    @Test("Recipe refresh upserts by id, drops server-deleted rows and keeps temp rows")
+    func recipeRefreshUpserts() async throws {
+        let harness = try RepositoryHarness()
+        let repo = RecipeRepository(context: harness.context, api: harness.api)
+        let tempId = LocalStore.makeTempId()
+        try harness.context.insert(LocalRecipe(recipe: harness.recipe(id: "r1", name: "Stale")))
+        try harness.context.insert(LocalRecipe(recipe: harness.recipe(id: tempId, name: "Pending")))
+        try harness.context.save()
+        StubURLProtocol.stub("GET", "/api/recipes", json: """
+        {"recipes": [{
+            "id": "r2", "userId": "u1", "name": "Fresh", "totalServings": 4,
+            "isFavorite": false, "calories": 800, "protein": 40, "carbs": 90, "fat": 25, "fiber": 10
+        }]}
+        """)
+
+        try await repo.refresh()
+
+        let ids = Set(repo.recipes().map(\.id))
+        #expect(ids == [tempId, "r2"])
+        #expect(repo.recipe(id: "r2")?.calories == 800)
+    }
+
+    @Test("Recipe create replaces the temp id with the server record")
+    func recipeCreateReplacesTempId() async throws {
+        let harness = try RepositoryHarness()
+        let repo = RecipeRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/recipes", json: """
+        {"recipe": {
+            "id": "r-server", "userId": "u1", "name": "Bowl", "totalServings": 2,
+            "isFavorite": false, "calories": 500, "protein": 30, "carbs": 60, "fat": 15, "fiber": 8
+        }}
+        """)
+
+        let create = RecipeCreate(
+            name: "Bowl",
+            totalServings: 2,
+            ingredients: [RecipeIngredientInput(foodId: "f1", quantity: 80, servingUnit: .g)]
+        )
+        let created = try await repo.createRecipe(create)
+
+        #expect(created.id == "r-server")
+        #expect(repo.recipes().map(\.id) == ["r-server"])
+        #expect(repo.recipe(id: "r-server")?.calories == 500)
+    }
+
+    // MARK: Weight
+
+    @Test("Weight refresh upserts by id and updates changed rows")
+    func weightRefreshUpsertsById() async throws {
+        let harness = try RepositoryHarness()
+        let repo = WeightRepository(context: harness.context, api: harness.api)
+        try harness.context.insert(LocalWeightEntry(entry: harness.weight(id: "w1", date: "2026-06-01", kg: 80)))
+        try harness.context.save()
+        StubURLProtocol.stub("GET", "/api/weight", json: """
+        {"entries": [
+            {"id": "w1", "userId": "u1", "weightKg": 81, "entryDate": "2026-06-01"},
+            {"id": "w2", "userId": "u1", "weightKg": 80.4, "entryDate": "2026-06-02"}
+        ]}
+        """)
+
+        try await repo.refresh()
+
+        let entries = repo.entries()
+        #expect(entries.map(\.id) == ["w2", "w1"]) // newest first
+        #expect(entries.last?.weightKg == 81)
+        #expect(repo.latest()?.id == "w2")
+    }
+
+    @Test("Weight create writes locally then replaces the temp row with the server record")
+    func weightCreateReplacesTempId() async throws {
+        let harness = try RepositoryHarness()
+        let repo = WeightRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/weight", json: """
+        {"entry": {"id": "w-server", "userId": "u1", "weightKg": 74.2, "entryDate": "2026-06-01"}}
+        """)
+
+        let created = try await repo.createEntry(WeightCreate(weightKg: 74.2, entryDate: "2026-06-01"))
+
+        #expect(created.id == "w-server")
+        #expect(repo.entries().map(\.id) == ["w-server"])
+    }
+
+    @Test("Weight create keeps the temp row when the API fails")
+    func weightCreateKeepsTempRowOnFailure() async throws {
+        let harness = try RepositoryHarness()
+        let repo = WeightRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/weight", status: 500, json: #"{"error": "boom"}"#)
+
+        await #expect(throws: (any Error).self) {
+            try await repo.createEntry(WeightCreate(weightKg: 74.2, entryDate: "2026-06-01"))
+        }
+
+        let entries = repo.entries()
+        #expect(entries.count == 1)
+        #expect(LocalStore.isTempId(entries.first?.id ?? ""))
+        #expect(entries.first?.weightKg == 74.2)
+    }
+
+    // MARK: Supplements
+
+    @Test("Supplement log writes the local row even when the API fails")
+    func supplementLogKeepsLocalOnFailure() async throws {
+        let harness = try RepositoryHarness()
+        let repo = SupplementRepository(context: harness.context, api: harness.api)
+        try harness.context.insert(LocalSupplement(supplement: harness.supplement(id: "s1", name: "Vitamin D")))
+        try harness.context.save()
+        StubURLProtocol.stub("POST", "/api/supplements/s1/log", status: 500, json: #"{"error": "boom"}"#)
+
+        await #expect(throws: (any Error).self) {
+            try await repo.logSupplement(id: "s1", date: "2026-06-01")
+        }
+
+        #expect(repo.loggedSupplementIds(date: "2026-06-01") == ["s1"])
+        #expect(repo.localChecklist(date: "2026-06-01").first?.taken == true)
+    }
+
+    @Test("Checklist refresh replaces the cached logs for the day")
+    func checklistRefreshReplacesLogsByDate() async throws {
+        let harness = try RepositoryHarness()
+        let repo = SupplementRepository(context: harness.context, api: harness.api)
+        try harness.context.insert(LocalSupplement(supplement: harness.supplement(id: "s1", name: "Vitamin D")))
+        try harness.context.insert(LocalSupplement(supplement: harness.supplement(
+            id: "s2",
+            name: "Omega-3",
+            sortOrder: 1
+        )))
+        harness.context.insert(LocalSupplementLog(supplementId: "s1", date: "2026-06-01", takenAt: "old"))
+        try harness.context.save()
+        StubURLProtocol.stub("GET", "/api/supplements/2026-06-01/checklist", json: """
+        {"checklist": [
+            {
+                "supplement": {"id": "s1", "userId": "u1", "name": "Vitamin D", "scheduleType": "daily", "isActive": true, "sortOrder": 0, "ingredients": []},
+                "taken": false, "takenAt": null
+            },
+            {
+                "supplement": {"id": "s2", "userId": "u1", "name": "Omega-3", "scheduleType": "daily", "isActive": true, "sortOrder": 1, "ingredients": []},
+                "taken": true, "takenAt": "2026-06-01T08:00:00Z"
+            }
+        ]}
+        """)
+
+        let checklist = try await repo.refreshChecklist(date: "2026-06-01")
+
+        #expect(checklist.count == 2)
+        #expect(repo.loggedSupplementIds(date: "2026-06-01") == ["s2"])
+    }
+
+    @Test("Supplement create replaces the temp id with the server record")
+    func supplementCreateReplacesTempId() async throws {
+        let harness = try RepositoryHarness()
+        let repo = SupplementRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/supplements", json: """
+        {"supplement": {
+            "id": "s-server", "userId": "u1", "name": "Magnesium",
+            "scheduleType": "daily", "isActive": true, "sortOrder": 0, "ingredients": []
+        }}
+        """)
+
+        let create = SupplementCreate(name: "Magnesium", scheduleType: .daily, ingredients: [])
+        let created = try await repo.createSupplement(create)
+
+        #expect(created.id == "s-server")
+        #expect(repo.supplements().map(\.id) == ["s-server"])
+    }
+
+    // MARK: Goals
+
+    @Test("Goals write locally first and survive an API failure")
+    func goalsKeepLocalOnAPIFailure() async throws {
+        let harness = try RepositoryHarness()
+        let repo = GoalsRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("POST", "/api/goals", status: 500, json: #"{"error": "boom"}"#)
+
+        let goals = Goals(
+            calorieGoal: 2100, proteinGoal: 155, carbGoal: 230,
+            fatGoal: 68, fiberGoal: 32, sodiumGoal: nil, sugarGoal: nil
+        )
+        await #expect(throws: (any Error).self) {
+            try await repo.setGoals(goals)
+        }
+
+        #expect(repo.goals()?.calorieGoal == 2100)
+        #expect(repo.goals()?.proteinGoal == 155)
+    }
+
+    @Test("Goals refresh caches the server value")
+    func goalsRefreshCachesServerValue() async throws {
+        let harness = try RepositoryHarness()
+        let repo = GoalsRepository(context: harness.context, api: harness.api)
+        StubURLProtocol.stub("GET", "/api/goals", json: """
+        {"goals": {"calorieGoal": 1900, "proteinGoal": 140, "carbGoal": 200, "fatGoal": 60, "fiberGoal": 28}}
+        """)
+
+        try await repo.refresh()
+
+        #expect(repo.goals()?.calorieGoal == 1900)
+        #expect(repo.goals()?.fiberGoal == 28)
+    }
+
+    // MARK: Preferences
+
+    @Test("Preferences update merges the partial update onto the cached value locally")
+    func preferencesUpdateMergesLocally() async throws {
+        let harness = try RepositoryHarness()
+        let repo = PreferencesRepository(context: harness.context, api: harness.api)
+        harness.context.insert(LocalPreferences(preferences: .defaults))
+        try harness.context.save()
+        StubURLProtocol.stub("PATCH", "/api/preferences", status: 500, json: #"{"error": "boom"}"#)
+
+        var update = PreferencesUpdate()
+        update.showWeightWidget = false
+        update.visibleNutrients = ["sugar"]
+        await #expect(throws: (any Error).self) {
+            try await repo.update(update)
+        }
+
+        let merged = try #require(repo.preferences())
+        #expect(merged.showWeightWidget == false)
+        #expect(merged.visibleNutrients == ["sugar"])
+        // Untouched fields keep their cached values.
+        #expect(merged.showChartWidget == Preferences.defaults.showChartWidget)
+        #expect(merged.startPage == Preferences.defaults.startPage)
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
+++ b/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
@@ -3,165 +3,22 @@ import Foundation
 import SwiftData
 import Testing
 
-// MARK: - Networking stub
-
-/// Routes stubbed responses by "METHOD path". Unstubbed requests get a 404 so
-/// repository API calls fail loudly instead of hanging.
-final class StubURLProtocol: URLProtocol {
-    struct Stub {
-        let status: Int
-        let body: Data
-    }
-
-    private nonisolated(unsafe) static var stubs: [String: Stub] = [:]
-    private nonisolated(unsafe) static var recorded: [String] = []
-    private static let lock = NSLock()
-
-    static func reset() {
-        lock.lock()
-        defer { lock.unlock() }
-        stubs = [:]
-        recorded = []
-    }
-
-    static func stub(_ method: String, _ path: String, status: Int = 200, json: String = "{}") {
-        lock.lock()
-        defer { lock.unlock() }
-        stubs["\(method) \(path)"] = Stub(status: status, body: Data(json.utf8))
-    }
-
-    static var recordedRequests: [String] {
-        lock.lock()
-        defer { lock.unlock() }
-        return recorded
-    }
-
-    override class func canInit(with _: URLRequest) -> Bool {
-        true
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        let key = "\(request.httpMethod ?? "GET") \(request.url?.path ?? "")"
-        Self.lock.lock()
-        Self.recorded.append(key)
-        let stub = Self.stubs[key]
-        Self.lock.unlock()
-
-        let response = HTTPURLResponse(
-            url: request.url ?? URL(string: "https://stub.local")!,
-            statusCode: stub?.status ?? 404,
-            httpVersion: nil,
-            headerFields: ["Content-Type": "application/json"]
-        )!
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: stub?.body ?? Data("{}".utf8))
-        client?.urlProtocolDidFinishLoading(self)
-    }
-
-    override func stopLoading() {}
-}
-
-// MARK: - Test harness
-
-@MainActor
-struct RepositoryHarness {
-    let container: ModelContainer
-    let context: ModelContext
-    let api: BissbilanzAPI
-
-    init() throws {
-        StubURLProtocol.reset()
-        container = try LocalStore.makeContainer(inMemory: true)
-        context = container.mainContext
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [StubURLProtocol.self]
-        api = BissbilanzAPI(
-            baseURL: "https://stub.local",
-            authManager: AuthManager(baseURL: "https://stub.local"),
-            session: URLSession(configuration: configuration)
-        )
-    }
-
-    func entry(id: String, date: String, mealType: String = "lunch", foodId: String? = nil) throws -> Entry {
-        var dict: [String: Any] = [
-            "id": id,
-            "mealType": mealType,
-            "servings": 1,
-            "foodName": "Seed \(id)",
-            "calories": 100,
-            "date": date,
-        ]
-        if let foodId { dict["foodId"] = foodId }
-        return try JSONPatch.decode(Entry.self, from: dict)
-    }
-
-    func food(id: String, name: String, isFavorite: Bool = false, barcode: String? = nil) throws -> Food {
-        var dict: [String: Any] = [
-            "id": id,
-            "userId": "u1",
-            "name": name,
-            "servingSize": 100,
-            "servingUnit": "g",
-            "calories": 100,
-            "protein": 10,
-            "carbs": 20,
-            "fat": 5,
-            "fiber": 3,
-            "isFavorite": isFavorite,
-        ]
-        if let barcode { dict["barcode"] = barcode }
-        return try JSONPatch.decode(Food.self, from: dict)
-    }
-
-    func recipe(id: String, name: String, isFavorite: Bool = false) throws -> Recipe {
-        try JSONPatch.decode(Recipe.self, from: [
-            "id": id,
-            "userId": "u1",
-            "name": name,
-            "totalServings": 2,
-            "isFavorite": isFavorite,
-        ])
-    }
-
-    func weight(id: String, date: String, kg: Double) throws -> WeightEntry {
-        try JSONPatch.decode(WeightEntry.self, from: [
-            "id": id,
-            "userId": "u1",
-            "weightKg": kg,
-            "entryDate": date,
-        ])
-    }
-
-    func supplement(id: String, name: String, sortOrder: Int = 0) throws -> Supplement {
-        try JSONPatch.decode(Supplement.self, from: [
-            "id": id,
-            "userId": "u1",
-            "name": name,
-            "scheduleType": "daily",
-            "isActive": true,
-            "sortOrder": sortOrder,
-            "ingredients": [],
-        ])
-    }
-}
-
-// MARK: - Tests
-
-@Suite("Repository tests", .serialized)
+@Suite("Repository tests")
 @MainActor
 struct RepositoryTests {
     // MARK: Entries
 
-    @Test("Entry refresh replaces the cached day, leaving other days untouched")
+    @Test("Entry refresh replaces the cached day, keeping temp rows and other days")
     func entryRefreshReplacesByDate() async throws {
         let harness = try RepositoryHarness()
-        let repo = EntryRepository(context: harness.context, api: harness.api)
+        let repo = harness.entryRepository
+        let tempId = LocalStore.makeTempId()
         try harness.context.insert(LocalEntry(
             entry: harness.entry(id: "old-1", date: "2026-06-01"),
+            date: "2026-06-01"
+        ))
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: tempId, date: "2026-06-01"),
             date: "2026-06-01"
         ))
         try harness.context.insert(LocalEntry(
@@ -170,7 +27,7 @@ struct RepositoryTests {
         ))
         try harness.context.save()
 
-        StubURLProtocol.stub("GET", "/api/entries", json: """
+        harness.stub("GET", "/api/entries", json: """
         {"entries": [{
             "id": "new-1", "mealType": "breakfast", "servings": 2,
             "foodId": "f1", "foodName": "Oats",
@@ -181,17 +38,34 @@ struct RepositoryTests {
         try await repo.refresh(date: "2026-06-01")
 
         let day = repo.entries(date: "2026-06-01")
-        #expect(day.count == 1)
-        #expect(day.first?.id == "new-1")
-        #expect(day.first?.date == "2026-06-01")
+        #expect(Set(day.map(\.id)) == [tempId, "new-1"])
         #expect(repo.entries(date: "2026-06-02").map(\.id) == ["other-1"])
     }
 
-    @Test("Entry create writes locally first, then replaces the temp row with the server record")
-    func entryCreateReplacesTempWithServerRecord() async throws {
+    @Test("Entry create writes the temp row locally and queues the upload")
+    func entryCreateWritesLocallyAndQueues() async throws {
         let harness = try RepositoryHarness()
-        let repo = EntryRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/entries", json: """
+        let repo = harness.entryRepository
+
+        let create = EntryCreate(foodId: "f1", mealType: "lunch", servings: 1.5, date: "2026-06-01")
+        let created = try await repo.createEntry(create, food: harness.food(id: "f1", name: "Rice"))
+
+        #expect(LocalStore.isTempId(created.id))
+        #expect(created.displayName == "Rice")
+        #expect(repo.entries(date: "2026-06-01").map(\.id) == [created.id])
+        let queued = harness.syncManager.queuedRows()
+        #expect(queued.count == 1)
+        #expect(queued.first?.type == "create_entry")
+        #expect(queued.first?.affectedId == created.id)
+        // The write itself never touches the network.
+        #expect(harness.recordedRequests.isEmpty)
+    }
+
+    @Test("Drained entry create replaces the temp row with the merged server record")
+    func entryCreateDrainReplacesTempRow() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.entryRepository
+        harness.stub("POST", "/api/entries", json: """
         {"entry": {
             "id": "server-1", "userId": "u1", "date": "2026-06-01",
             "mealType": "lunch", "servings": 1.5, "foodId": "f1"
@@ -199,128 +73,225 @@ struct RepositoryTests {
         """)
 
         let create = EntryCreate(foodId: "f1", mealType: "lunch", servings: 1.5, date: "2026-06-01")
-        let created = try await repo.createEntry(create, food: harness.food(id: "f1", name: "Rice"))
+        _ = try await repo.createEntry(create, food: harness.food(id: "f1", name: "Rice"))
+        await harness.syncManager.drainPendingQueue()
 
-        #expect(created.id == "server-1")
         let day = repo.entries(date: "2026-06-01")
-        #expect(day.count == 1)
-        #expect(day.first?.id == "server-1")
+        #expect(day.map(\.id) == ["server-1"])
         // Raw POST responses lack resolved macros — merged from the optimistic row.
         #expect(day.first?.displayName == "Rice")
         #expect(day.first?.totalCalories == 150)
-        #expect(!day.contains { LocalStore.isTempId($0.id) })
+        #expect(harness.syncManager.queuedRows().isEmpty)
     }
 
-    @Test("Entry create keeps the optimistic local row when the API fails")
+    @Test("Entry create keeps the optimistic local row when the upload fails")
     func entryCreateKeepsLocalRowOnAPIFailure() async throws {
         let harness = try RepositoryHarness()
-        let repo = EntryRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/entries", status: 500, json: #"{"error": "boom"}"#)
+        let repo = harness.entryRepository
+        harness.stub("POST", "/api/entries", status: 500, json: #"{"error": "boom"}"#)
 
         let create = EntryCreate(foodId: "f1", mealType: "dinner", servings: 1, date: "2026-06-01")
-        await #expect(throws: (any Error).self) {
-            try await repo.createEntry(create, food: harness.food(id: "f1", name: "Rice"))
-        }
+        _ = try await repo.createEntry(create, food: harness.food(id: "f1", name: "Rice"))
+        await harness.syncManager.drainPendingQueue()
 
         let day = repo.entries(date: "2026-06-01")
         #expect(day.count == 1)
         #expect(LocalStore.isTempId(day.first?.id ?? ""))
         #expect(day.first?.displayName == "Rice")
+        // The op stays queued for a retry.
+        #expect(harness.syncManager.queuedRows().count == 1)
+        #expect(harness.syncManager.queuedRows().first?.retryCount == 1)
     }
 
-    @Test("Entry delete removes the local row and skips the API for temp ids")
-    func entryDeleteSkipsAPIForTempIds() async throws {
+    @Test("Entry delete removes the local row and cancels the queued create for temp ids")
+    func entryDeleteCancelsQueuedCreateForTempIds() async throws {
         let harness = try RepositoryHarness()
-        let repo = EntryRepository(context: harness.context, api: harness.api)
-        let tempId = LocalStore.makeTempId()
-        try harness.context.insert(LocalEntry(entry: harness.entry(id: tempId, date: "2026-06-01"), date: "2026-06-01"))
-        try harness.context.save()
+        let repo = harness.entryRepository
 
-        try await repo.deleteEntry(id: tempId)
+        let create = EntryCreate(foodId: "f1", mealType: "lunch", servings: 1, date: "2026-06-01")
+        let created = try await repo.createEntry(create)
+        try await repo.deleteEntry(id: created.id)
+        await harness.syncManager.drainPendingQueue()
 
         #expect(repo.entries(date: "2026-06-01").isEmpty)
-        #expect(!StubURLProtocol.recordedRequests.contains { $0.hasPrefix("DELETE") })
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.recordedRequests.isEmpty)
     }
 
-    @Test("Day properties write locally first and survive an API failure")
-    func dayPropertiesKeepLocalOnAPIFailure() async throws {
+    @Test("Updating a temp entry rewrites the queued create payload")
+    func entryUpdateCoalescesIntoQueuedCreate() async throws {
         let harness = try RepositoryHarness()
-        let repo = EntryRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/day-properties/2026-06-01", status: 500, json: #"{"error": "boom"}"#)
+        let repo = harness.entryRepository
 
-        await #expect(throws: (any Error).self) {
-            try await repo.setDayProperties(date: "2026-06-01", isFastingDay: true)
+        let create = EntryCreate(foodId: "f1", mealType: "lunch", servings: 1, date: "2026-06-01")
+        let created = try await repo.createEntry(create)
+        _ = try await repo.updateEntry(id: created.id, EntryUpdate(mealType: "dinner", servings: 3))
+
+        let queued = harness.syncManager.queuedRows()
+        #expect(queued.count == 1)
+        guard case let .createEntry(body, localId)? = queued.first?.operation() else {
+            Issue.record("expected a coalesced createEntry operation")
+            return
         }
+        #expect(localId == created.id)
+        #expect(body.mealType == "dinner")
+        #expect(body.servings == 3)
+        #expect(repo.entries(date: "2026-06-01").first?.servings == 3)
+    }
+
+    @Test("Day properties write locally first and queue the upload")
+    func dayPropertiesWriteLocallyAndQueue() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.entryRepository
+        harness.stub("POST", "/api/day-properties/2026-06-01", status: 500, json: #"{"error": "boom"}"#)
+
+        try await repo.setDayProperties(date: "2026-06-01", isFastingDay: true)
+        await harness.syncManager.drainPendingQueue()
 
         #expect(repo.isFastingDay(date: "2026-06-01") == true)
+        #expect(harness.syncManager.queuedRows().count == 1)
+    }
+
+    @Test("Copy entries duplicates the day locally and queues one create per entry")
+    func copyEntriesCopiesLocally() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.entryRepository
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: "e1", date: "2026-06-01", foodId: "f1"),
+            date: "2026-06-01"
+        ))
+        try harness.context.insert(LocalEntry(
+            entry: harness.entry(id: "e2", date: "2026-06-01", mealType: "dinner"),
+            date: "2026-06-01"
+        ))
+        try harness.context.save()
+
+        let copied = try await repo.copyEntries(fromDate: "2026-06-01", toDate: "2026-06-02")
+
+        #expect(copied == 2)
+        let day = repo.entries(date: "2026-06-02")
+        #expect(day.count == 2)
+        #expect(day.allSatisfy { LocalStore.isTempId($0.id) })
+        #expect(day.first?.totalCalories == 100) // display macros survive the copy
+        #expect(harness.syncManager.queuedRows().count == 2)
+        #expect(harness.recordedRequests.isEmpty)
     }
 
     // MARK: Foods
 
-    @Test("Food create replaces the temp id with the server record")
-    func foodCreateReplacesTempId() async throws {
+    @Test("Drained food create replaces the temp id and remaps entry references")
+    func foodCreateDrainReplacesTempIdAndRemaps() async throws {
         let harness = try RepositoryHarness()
-        let repo = FoodRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/foods", json: """
+        let foodRepo = harness.foodRepository
+        let entryRepo = harness.entryRepository
+        harness.stub("POST", "/api/foods", json: """
         {"food": {
             "id": "f-server", "userId": "u1", "name": "Skyr", "servingSize": 150, "servingUnit": "g",
             "calories": 98, "protein": 16, "carbs": 6, "fat": 0.2, "fiber": 0, "isFavorite": false
         }}
+        """)
+        harness.stub("POST", "/api/entries", json: """
+        {"entry": {"id": "e-server", "userId": "u1", "date": "2026-06-01", "mealType": "lunch", "servings": 1}}
         """)
 
         let create = FoodCreate(
             name: "Skyr", servingSize: 150, servingUnit: .g,
             calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
         )
-        let created = try await repo.createFood(create)
+        let temp = try await foodRepo.createFood(create)
+        _ = try await entryRepo.createEntry(
+            EntryCreate(foodId: temp.id, mealType: "lunch", servings: 1, date: "2026-06-01"),
+            food: temp
+        )
+        await harness.syncManager.drainPendingQueue()
 
-        #expect(created.id == "f-server")
-        #expect(repo.food(id: "f-server")?.name == "Skyr")
-        #expect(repo.searchLocal("Skyr").count == 1)
+        #expect(foodRepo.food(id: "f-server")?.name == "Skyr")
+        #expect(foodRepo.food(id: temp.id) == nil)
+        // The entry row now points at the server food id.
+        #expect(entryRepo.entries(date: "2026-06-01").first?.foodId == "f-server")
+        #expect(harness.syncManager.queuedRows().isEmpty)
     }
 
-    @Test("Food create keeps the temp row when the API fails")
+    @Test("Food create keeps the temp row when the upload fails")
     func foodCreateKeepsTempRowOnFailure() async throws {
         let harness = try RepositoryHarness()
-        let repo = FoodRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/foods", status: 500, json: #"{"error": "boom"}"#)
+        let repo = harness.foodRepository
+        harness.stub("POST", "/api/foods", status: 500, json: #"{"error": "boom"}"#)
 
         let create = FoodCreate(
             name: "Skyr", servingSize: 150, servingUnit: .g,
             calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
         )
-        await #expect(throws: (any Error).self) {
-            try await repo.createFood(create)
-        }
+        _ = try await repo.createFood(create)
+        await harness.syncManager.drainPendingQueue()
 
         let local = repo.searchLocal("Skyr")
         #expect(local.count == 1)
         #expect(LocalStore.isTempId(local.first?.id ?? ""))
+        #expect(harness.syncManager.queuedRows().count == 1)
     }
 
-    @Test("Toggle favorite flips the local row before the API call")
+    @Test("Updating a temp food rewrites the queued create body")
+    func foodUpdateCoalescesIntoQueuedCreate() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.foodRepository
+
+        let create = FoodCreate(
+            name: "Skyr", servingSize: 150, servingUnit: .g,
+            calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
+        )
+        let temp = try await repo.createFood(create)
+        let edited = FoodCreate(
+            name: "Skyr Vanilla", servingSize: 150, servingUnit: .g,
+            calories: 105, protein: 15, carbs: 9, fat: 0.2, fiber: 0
+        )
+        _ = try await repo.updateFood(id: temp.id, edited)
+
+        let queued = harness.syncManager.queuedRows()
+        #expect(queued.count == 1)
+        guard case let .createFood(body, localId)? = queued.first?.operation() else {
+            Issue.record("expected a coalesced createFood operation")
+            return
+        }
+        #expect(localId == temp.id)
+        #expect(body.name == "Skyr Vanilla")
+        #expect(body.calories == 105)
+        #expect(repo.food(id: temp.id)?.name == "Skyr Vanilla")
+    }
+
+    @Test("Toggle favorite flips the local row and queues; temp ids patch the queued create")
     func toggleFavoriteUpdatesLocalFirst() async throws {
         let harness = try RepositoryHarness()
-        let repo = FoodRepository(context: harness.context, api: harness.api)
+        let repo = harness.foodRepository
         try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Rice")))
         try harness.context.save()
-        StubURLProtocol.stub("PATCH", "/api/foods/f1", status: 500, json: #"{"error": "boom"}"#)
 
-        await #expect(throws: (any Error).self) {
-            try await repo.toggleFavorite(foodId: "f1", isFavorite: true)
-        }
-
+        _ = try await repo.toggleFavorite(foodId: "f1", isFavorite: true)
         #expect(repo.food(id: "f1")?.isFavorite == true)
         #expect(repo.favorites().map(\.id) == ["f1"])
+        #expect(harness.syncManager.queuedRows().last?.type == "toggle_favorite")
+
+        let temp = try await repo.createFood(FoodCreate(
+            name: "Oats", servingSize: 40, servingUnit: .g,
+            calories: 150, protein: 5, carbs: 27, fat: 2.5, fiber: 4
+        ))
+        _ = try await repo.toggleFavorite(foodId: temp.id, isFavorite: true)
+        let createRow = harness.syncManager.queuedOperations(table: "foods", affectedId: temp.id)
+        #expect(createRow.count == 1)
+        guard case let .createFood(body, _)? = createRow.first?.operation() else {
+            Issue.record("expected the queued createFood to absorb the favorite flag")
+            return
+        }
+        #expect(body.isFavorite == true)
     }
 
     @Test("Favorites refresh upserts foods and recipes and reconciles un-favorited rows")
     func refreshFavoritesReconciles() async throws {
         let harness = try RepositoryHarness()
-        let repo = FoodRepository(context: harness.context, api: harness.api)
+        let repo = harness.foodRepository
         try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Old Fav", isFavorite: true)))
         try harness.context.save()
-        StubURLProtocol.stub("GET", "/api/favorites", json: """
+        harness.stub("GET", "/api/favorites", json: """
         {
             "foods": [{
                 "id": "f2", "userId": "u1", "name": "New Fav", "servingSize": 100, "servingUnit": "g",
@@ -336,21 +307,20 @@ struct RepositoryTests {
 
         #expect(repo.favorites().map(\.id) == ["f2"])
         #expect(repo.food(id: "f1")?.isFavorite == false)
-        let recipeRepo = RecipeRepository(context: harness.context, api: harness.api)
-        #expect(recipeRepo.favoriteRecipes().map(\.id) == ["r1"])
+        #expect(harness.recipeRepository.favoriteRecipes().map(\.id) == ["r1"])
     }
 
     @Test("Barcode lookup answers from the local store before hitting the API")
     func findByBarcodePrefersLocal() async throws {
         let harness = try RepositoryHarness()
-        let repo = FoodRepository(context: harness.context, api: harness.api)
+        let repo = harness.foodRepository
         try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Bar", barcode: "123")))
         try harness.context.save()
 
         let found = try await repo.findByBarcode("123")
 
         #expect(found?.id == "f1")
-        #expect(StubURLProtocol.recordedRequests.isEmpty)
+        #expect(harness.recordedRequests.isEmpty)
     }
 
     // MARK: Recipes
@@ -358,12 +328,12 @@ struct RepositoryTests {
     @Test("Recipe refresh upserts by id, drops server-deleted rows and keeps temp rows")
     func recipeRefreshUpserts() async throws {
         let harness = try RepositoryHarness()
-        let repo = RecipeRepository(context: harness.context, api: harness.api)
+        let repo = harness.recipeRepository
         let tempId = LocalStore.makeTempId()
         try harness.context.insert(LocalRecipe(recipe: harness.recipe(id: "r1", name: "Stale")))
         try harness.context.insert(LocalRecipe(recipe: harness.recipe(id: tempId, name: "Pending")))
         try harness.context.save()
-        StubURLProtocol.stub("GET", "/api/recipes", json: """
+        harness.stub("GET", "/api/recipes", json: """
         {"recipes": [{
             "id": "r2", "userId": "u1", "name": "Fresh", "totalServings": 4,
             "isFavorite": false, "calories": 800, "protein": 40, "carbs": 90, "fat": 25, "fiber": 10
@@ -377,11 +347,11 @@ struct RepositoryTests {
         #expect(repo.recipe(id: "r2")?.calories == 800)
     }
 
-    @Test("Recipe create replaces the temp id with the server record")
-    func recipeCreateReplacesTempId() async throws {
+    @Test("Drained recipe create replaces the temp id with the server record")
+    func recipeCreateDrainReplacesTempId() async throws {
         let harness = try RepositoryHarness()
-        let repo = RecipeRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/recipes", json: """
+        let repo = harness.recipeRepository
+        harness.stub("POST", "/api/recipes", json: """
         {"recipe": {
             "id": "r-server", "userId": "u1", "name": "Bowl", "totalServings": 2,
             "isFavorite": false, "calories": 500, "protein": 30, "carbs": 60, "fat": 15, "fiber": 8
@@ -393,9 +363,10 @@ struct RepositoryTests {
             totalServings: 2,
             ingredients: [RecipeIngredientInput(foodId: "f1", quantity: 80, servingUnit: .g)]
         )
-        let created = try await repo.createRecipe(create)
+        let temp = try await repo.createRecipe(create)
+        #expect(LocalStore.isTempId(temp.id))
+        await harness.syncManager.drainPendingQueue()
 
-        #expect(created.id == "r-server")
         #expect(repo.recipes().map(\.id) == ["r-server"])
         #expect(repo.recipe(id: "r-server")?.calories == 500)
     }
@@ -405,10 +376,10 @@ struct RepositoryTests {
     @Test("Weight refresh upserts by id and updates changed rows")
     func weightRefreshUpsertsById() async throws {
         let harness = try RepositoryHarness()
-        let repo = WeightRepository(context: harness.context, api: harness.api)
+        let repo = harness.weightRepository
         try harness.context.insert(LocalWeightEntry(entry: harness.weight(id: "w1", date: "2026-06-01", kg: 80)))
         try harness.context.save()
-        StubURLProtocol.stub("GET", "/api/weight", json: """
+        harness.stub("GET", "/api/weight", json: """
         {"entries": [
             {"id": "w1", "userId": "u1", "weightKg": 81, "entryDate": "2026-06-01"},
             {"id": "w2", "userId": "u1", "weightKg": 80.4, "entryDate": "2026-06-02"}
@@ -423,29 +394,29 @@ struct RepositoryTests {
         #expect(repo.latest()?.id == "w2")
     }
 
-    @Test("Weight create writes locally then replaces the temp row with the server record")
-    func weightCreateReplacesTempId() async throws {
+    @Test("Drained weight create replaces the temp row with the server record")
+    func weightCreateDrainReplacesTempId() async throws {
         let harness = try RepositoryHarness()
-        let repo = WeightRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/weight", json: """
+        let repo = harness.weightRepository
+        harness.stub("POST", "/api/weight", json: """
         {"entry": {"id": "w-server", "userId": "u1", "weightKg": 74.2, "entryDate": "2026-06-01"}}
         """)
 
-        let created = try await repo.createEntry(WeightCreate(weightKg: 74.2, entryDate: "2026-06-01"))
+        let temp = try await repo.createEntry(WeightCreate(weightKg: 74.2, entryDate: "2026-06-01"))
+        #expect(LocalStore.isTempId(temp.id))
+        await harness.syncManager.drainPendingQueue()
 
-        #expect(created.id == "w-server")
         #expect(repo.entries().map(\.id) == ["w-server"])
     }
 
-    @Test("Weight create keeps the temp row when the API fails")
+    @Test("Weight create keeps the temp row when the upload fails")
     func weightCreateKeepsTempRowOnFailure() async throws {
         let harness = try RepositoryHarness()
-        let repo = WeightRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/weight", status: 500, json: #"{"error": "boom"}"#)
+        let repo = harness.weightRepository
+        harness.stub("POST", "/api/weight", status: 500, json: #"{"error": "boom"}"#)
 
-        await #expect(throws: (any Error).self) {
-            try await repo.createEntry(WeightCreate(weightKg: 74.2, entryDate: "2026-06-01"))
-        }
+        _ = try await repo.createEntry(WeightCreate(weightKg: 74.2, entryDate: "2026-06-01"))
+        await harness.syncManager.drainPendingQueue()
 
         let entries = repo.entries()
         #expect(entries.count == 1)
@@ -455,26 +426,62 @@ struct RepositoryTests {
 
     // MARK: Supplements
 
-    @Test("Supplement log writes the local row even when the API fails")
+    @Test("Supplement log writes the local row and queues; the row survives upload failure")
     func supplementLogKeepsLocalOnFailure() async throws {
         let harness = try RepositoryHarness()
-        let repo = SupplementRepository(context: harness.context, api: harness.api)
+        let repo = harness.supplementRepository
         try harness.context.insert(LocalSupplement(supplement: harness.supplement(id: "s1", name: "Vitamin D")))
         try harness.context.save()
-        StubURLProtocol.stub("POST", "/api/supplements/s1/log", status: 500, json: #"{"error": "boom"}"#)
+        harness.stub("POST", "/api/supplements/s1/log", status: 500, json: #"{"error": "boom"}"#)
 
-        await #expect(throws: (any Error).self) {
-            try await repo.logSupplement(id: "s1", date: "2026-06-01")
-        }
+        try await repo.logSupplement(id: "s1", date: "2026-06-01")
+        await harness.syncManager.drainPendingQueue()
 
         #expect(repo.loggedSupplementIds(date: "2026-06-01") == ["s1"])
         #expect(repo.localChecklist(date: "2026-06-01").first?.taken == true)
+        #expect(harness.syncManager.queuedRows().count == 1)
+    }
+
+    @Test("Deleting a temp supplement removes its queued create and queued logs")
+    func deleteTempSupplementCancelsQueuedCreateAndLogs() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.supplementRepository
+
+        let temp = try await repo.createSupplement(
+            SupplementCreate(name: "Magnesium", scheduleType: .daily, ingredients: [])
+        )
+        try await repo.logSupplement(id: temp.id, date: "2026-06-01")
+        #expect(harness.syncManager.queuedRows().count == 2)
+
+        try await repo.deleteSupplement(id: temp.id)
+        await harness.syncManager.drainPendingQueue()
+
+        #expect(repo.supplements().isEmpty)
+        #expect(repo.loggedSupplementIds(date: "2026-06-01").isEmpty)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.recordedRequests.isEmpty)
+    }
+
+    @Test("Unlogging a temp supplement cancels the queued log instead of queueing an unlog")
+    func unlogTempSupplementCancelsQueuedLog() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.supplementRepository
+
+        let temp = try await repo.createSupplement(
+            SupplementCreate(name: "Zinc", scheduleType: .daily, ingredients: [])
+        )
+        try await repo.logSupplement(id: temp.id, date: "2026-06-01")
+        try await repo.unlogSupplement(id: temp.id, date: "2026-06-01")
+
+        let types = harness.syncManager.queuedRows().map(\.type)
+        #expect(types == ["create_supplement"])
+        #expect(repo.loggedSupplementIds(date: "2026-06-01").isEmpty)
     }
 
     @Test("Checklist refresh replaces the cached logs for the day")
     func checklistRefreshReplacesLogsByDate() async throws {
         let harness = try RepositoryHarness()
-        let repo = SupplementRepository(context: harness.context, api: harness.api)
+        let repo = harness.supplementRepository
         try harness.context.insert(LocalSupplement(supplement: harness.supplement(id: "s1", name: "Vitamin D")))
         try harness.context.insert(LocalSupplement(supplement: harness.supplement(
             id: "s2",
@@ -483,7 +490,7 @@ struct RepositoryTests {
         )))
         harness.context.insert(LocalSupplementLog(supplementId: "s1", date: "2026-06-01", takenAt: "old"))
         try harness.context.save()
-        StubURLProtocol.stub("GET", "/api/supplements/2026-06-01/checklist", json: """
+        harness.stub("GET", "/api/supplements/2026-06-01/checklist", json: """
         {"checklist": [
             {
                 "supplement": {"id": "s1", "userId": "u1", "name": "Vitamin D", "scheduleType": "daily", "isActive": true, "sortOrder": 0, "ingredients": []},
@@ -502,49 +509,51 @@ struct RepositoryTests {
         #expect(repo.loggedSupplementIds(date: "2026-06-01") == ["s2"])
     }
 
-    @Test("Supplement create replaces the temp id with the server record")
-    func supplementCreateReplacesTempId() async throws {
+    @Test("Drained supplement create replaces the temp id with the server record")
+    func supplementCreateDrainReplacesTempId() async throws {
         let harness = try RepositoryHarness()
-        let repo = SupplementRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/supplements", json: """
+        let repo = harness.supplementRepository
+        harness.stub("POST", "/api/supplements", json: """
         {"supplement": {
             "id": "s-server", "userId": "u1", "name": "Magnesium",
             "scheduleType": "daily", "isActive": true, "sortOrder": 0, "ingredients": []
         }}
         """)
 
-        let create = SupplementCreate(name: "Magnesium", scheduleType: .daily, ingredients: [])
-        let created = try await repo.createSupplement(create)
+        let temp = try await repo.createSupplement(
+            SupplementCreate(name: "Magnesium", scheduleType: .daily, ingredients: [])
+        )
+        #expect(LocalStore.isTempId(temp.id))
+        await harness.syncManager.drainPendingQueue()
 
-        #expect(created.id == "s-server")
         #expect(repo.supplements().map(\.id) == ["s-server"])
     }
 
     // MARK: Goals
 
-    @Test("Goals write locally first and survive an API failure")
+    @Test("Goals write locally first and survive an upload failure")
     func goalsKeepLocalOnAPIFailure() async throws {
         let harness = try RepositoryHarness()
-        let repo = GoalsRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("POST", "/api/goals", status: 500, json: #"{"error": "boom"}"#)
+        let repo = harness.goalsRepository
+        harness.stub("POST", "/api/goals", status: 500, json: #"{"error": "boom"}"#)
 
         let goals = Goals(
             calorieGoal: 2100, proteinGoal: 155, carbGoal: 230,
             fatGoal: 68, fiberGoal: 32, sodiumGoal: nil, sugarGoal: nil
         )
-        await #expect(throws: (any Error).self) {
-            try await repo.setGoals(goals)
-        }
+        _ = try await repo.setGoals(goals)
+        await harness.syncManager.drainPendingQueue()
 
         #expect(repo.goals()?.calorieGoal == 2100)
         #expect(repo.goals()?.proteinGoal == 155)
+        #expect(harness.syncManager.queuedRows().count == 1)
     }
 
     @Test("Goals refresh caches the server value")
     func goalsRefreshCachesServerValue() async throws {
         let harness = try RepositoryHarness()
-        let repo = GoalsRepository(context: harness.context, api: harness.api)
-        StubURLProtocol.stub("GET", "/api/goals", json: """
+        let repo = harness.goalsRepository
+        harness.stub("GET", "/api/goals", json: """
         {"goals": {"calorieGoal": 1900, "proteinGoal": 140, "carbGoal": 200, "fatGoal": 60, "fiberGoal": 28}}
         """)
 
@@ -559,17 +568,16 @@ struct RepositoryTests {
     @Test("Preferences update merges the partial update onto the cached value locally")
     func preferencesUpdateMergesLocally() async throws {
         let harness = try RepositoryHarness()
-        let repo = PreferencesRepository(context: harness.context, api: harness.api)
+        let repo = harness.preferencesRepository
         harness.context.insert(LocalPreferences(preferences: .defaults))
         try harness.context.save()
-        StubURLProtocol.stub("PATCH", "/api/preferences", status: 500, json: #"{"error": "boom"}"#)
+        harness.stub("PATCH", "/api/preferences", status: 500, json: #"{"error": "boom"}"#)
 
         var update = PreferencesUpdate()
         update.showWeightWidget = false
         update.visibleNutrients = ["sugar"]
-        await #expect(throws: (any Error).self) {
-            try await repo.update(update)
-        }
+        _ = try await repo.update(update)
+        await harness.syncManager.drainPendingQueue()
 
         let merged = try #require(repo.preferences())
         #expect(merged.showWeightWidget == false)
@@ -577,5 +585,65 @@ struct RepositoryTests {
         // Untouched fields keep their cached values.
         #expect(merged.showChartWidget == Preferences.defaults.showChartWidget)
         #expect(merged.startPage == Preferences.defaults.startPage)
+    }
+
+    // MARK: Local mode
+
+    @Test("Local mode repositories never hit the network and never enqueue")
+    func localModeNeverHitsNetwork() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        let entryRepo = harness.entryRepository
+        let foodRepo = harness.foodRepository
+        let recipeRepo = harness.recipeRepository
+        let weightRepo = harness.weightRepository
+        let supplementRepo = harness.supplementRepository
+        let goalsRepo = harness.goalsRepository
+        let preferencesRepo = harness.preferencesRepository
+
+        // Refreshes are no-ops.
+        try await entryRepo.refresh(date: "2026-06-01")
+        try await entryRepo.refreshDayProperties(date: "2026-06-01")
+        try await foodRepo.refreshFavorites()
+        try await foodRepo.refreshFood(id: "f1")
+        _ = await foodRepo.refreshRecentFoods()
+        try await recipeRepo.refresh()
+        try await weightRepo.refresh()
+        try await supplementRepo.refresh()
+        _ = try await supplementRepo.refreshChecklist(date: "2026-06-01")
+        _ = await supplementRepo.history(startDate: "2026-06-01", endDate: "2026-06-07")
+        try await goalsRepo.refresh()
+        try await preferencesRepo.refresh()
+
+        // Reads stay local.
+        _ = await foodRepo.searchFoods(query: "rice")
+        _ = try await foodRepo.findByBarcode("123")
+
+        // Writes are purely local — temp ids are permanent until migration.
+        let food = try await foodRepo.createFood(FoodCreate(
+            name: "Local Rice", servingSize: 100, servingUnit: .g,
+            calories: 130, protein: 2.7, carbs: 28, fat: 0.3, fiber: 0.4
+        ))
+        _ = try await entryRepo.createEntry(
+            EntryCreate(foodId: food.id, mealType: "lunch", servings: 1, date: "2026-06-01"),
+            food: food
+        )
+        _ = try await weightRepo.createEntry(WeightCreate(weightKg: 74, entryDate: "2026-06-01"))
+        let supplement = try await supplementRepo.createSupplement(
+            SupplementCreate(name: "Vitamin D", scheduleType: .daily, ingredients: [])
+        )
+        try await supplementRepo.logSupplement(id: supplement.id, date: "2026-06-01")
+        _ = try await goalsRepo.setGoals(.defaults)
+        try await entryRepo.setDayProperties(date: "2026-06-01", isFastingDay: true)
+        try await foodRepo.deleteFood(id: food.id)
+
+        // Even an explicit drain uploads nothing in Local mode.
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 0)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.recordedRequests.isEmpty)
+        #expect(LocalStore.isTempId(food.id))
+        #expect(weightRepo.entries().count == 1)
+        #expect(entryRepo.entries(date: "2026-06-01").count == 1)
     }
 }

--- a/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
+++ b/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
@@ -562,6 +562,24 @@ struct RepositoryTests {
         #expect(repo.latest()?.id == "w2")
     }
 
+    @Test("Weight pagination returns newest-first pages without overlap")
+    func weightPaginationPages() throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.weightRepository
+        for day in 1 ... 7 {
+            try harness.context.insert(LocalWeightEntry(entry: harness.weight(
+                id: "w\(day)", date: String(format: "2026-06-%02d", day), kg: 80
+            )))
+        }
+        try harness.context.save()
+
+        #expect(repo.entries(offset: 0, limit: 3).map(\.id) == ["w7", "w6", "w5"])
+        #expect(repo.entries(offset: 3, limit: 3).map(\.id) == ["w4", "w3", "w2"])
+        // Last page is short; past the end is empty
+        #expect(repo.entries(offset: 6, limit: 3).map(\.id) == ["w1"])
+        #expect(repo.entries(offset: 7, limit: 3).isEmpty)
+    }
+
     @Test("Drained weight create replaces the temp row with the server record")
     func weightCreateDrainReplacesTempId() async throws {
         let harness = try RepositoryHarness()

--- a/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
+++ b/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
@@ -177,6 +177,40 @@ struct RepositoryTests {
         #expect(harness.recordedRequests.isEmpty)
     }
 
+    @Test("Copy entries falls back to the server copy when the local source day is empty")
+    func copyEntriesFallsBackToServerCopy() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.entryRepository
+        // Fresh install/upgrade: the local store has nothing for the source day.
+        harness.stub("POST", "/api/entries/copy", json: """
+        {"entries": [
+            {"id": "c1", "mealType": "lunch", "servings": 1, "foodId": "f1",
+             "foodName": "Rice", "calories": 130, "date": "2026-06-02"},
+            {"id": "c2", "mealType": "dinner", "servings": 2, "quickName": "Soup",
+             "quickCalories": 90, "date": "2026-06-02"}
+        ]}
+        """)
+
+        let copied = try await repo.copyEntries(fromDate: "2026-06-01", toDate: "2026-06-02")
+
+        #expect(copied == 2)
+        #expect(harness.recordedRequests == ["POST /api/entries/copy"])
+        let day = repo.entries(date: "2026-06-02")
+        #expect(Set(day.map(\.id)) == ["c1", "c2"])
+        // Server-side copies are already persisted — nothing queues.
+        #expect(harness.syncManager.queuedRows().isEmpty)
+    }
+
+    @Test("Copy entries stays local-only in Local mode even when the source day is empty")
+    func copyEntriesLocalModeNeverCallsServer() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+
+        let copied = try await harness.entryRepository.copyEntries(fromDate: "2026-06-01", toDate: "2026-06-02")
+
+        #expect(copied == 0)
+        #expect(harness.recordedRequests.isEmpty)
+    }
+
     // MARK: Foods
 
     @Test("Drained food create replaces the temp id and remaps entry references")
@@ -210,6 +244,16 @@ struct RepositoryTests {
         // The entry row now points at the server food id.
         #expect(entryRepo.entries(date: "2026-06-01").first?.foodId == "f-server")
         #expect(harness.syncManager.queuedRows().isEmpty)
+
+        // The POSTed bodies must carry the create payload and — for the
+        // chained entry — the remapped server food id, not the temp id.
+        let foodBody = try #require(harness.recordedBodies("POST", "/api/foods").first)
+        let foodCreate = try JSONDecoder().decode(FoodCreate.self, from: foodBody)
+        #expect(foodCreate.name == "Skyr")
+        #expect(foodCreate.calories == 98)
+        let entryBody = try #require(harness.recordedBodies("POST", "/api/entries").first)
+        let entryCreate = try JSONDecoder().decode(EntryCreate.self, from: entryBody)
+        #expect(entryCreate.foodId == "f-server")
     }
 
     @Test("Food create keeps the temp row when the upload fails")
@@ -257,6 +301,75 @@ struct RepositoryTests {
         #expect(body.name == "Skyr Vanilla")
         #expect(body.calories == 105)
         #expect(repo.food(id: temp.id)?.name == "Skyr Vanilla")
+    }
+
+    @Test("Editing a food merge-patches the local row, preserving extended nutrients")
+    func foodUpdateMergePreservesExtendedNutrients() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.foodRepository
+        // A scanned food carrying extended nutrients and OFF metadata.
+        let scanned = try JSONPatch.decode(Food.self, from: [
+            "id": "f1", "userId": "u1", "name": "Skyr", "servingSize": 150, "servingUnit": "g",
+            "calories": 98, "protein": 16, "carbs": 6, "fat": 0.2, "fiber": 0, "isFavorite": false,
+            "saturatedFat": 0.1, "sodium": 55, "vitaminB12": 0.7,
+            "nutriScore": "a", "novaGroup": 1, "additives": ["en:e330"],
+            "ingredientsText": "Milk, cultures", "imageUrl": "https://img.example/skyr.jpg",
+        ])
+        try harness.context.insert(LocalFood(food: scanned))
+        try harness.context.save()
+
+        // The edit form only carries the basic fields.
+        _ = try await repo.updateFood(id: "f1", FoodCreate(
+            name: "Skyr Natural", servingSize: 150, servingUnit: .g,
+            calories: 99, protein: 16, carbs: 6, fat: 0.2, fiber: 0
+        ))
+
+        let updated = try #require(repo.food(id: "f1"))
+        #expect(updated.name == "Skyr Natural")
+        #expect(updated.calories == 99)
+        #expect(updated.saturatedFat == 0.1)
+        #expect(updated.sodium == 55)
+        #expect(updated.vitaminB12 == 0.7)
+        #expect(updated.nutriScore == "a")
+        #expect(updated.novaGroup == 1)
+        #expect(updated.additives == ["en:e330"])
+        #expect(updated.ingredientsText == "Milk, cultures")
+        #expect(updated.imageUrl == "https://img.example/skyr.jpg")
+    }
+
+    @Test("Editing a temp food merges into the queued create instead of replacing it")
+    func foodUpdateMergesIntoQueuedCreate() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.foodRepository
+
+        var create = FoodCreate(
+            name: "Skyr", servingSize: 150, servingUnit: .g,
+            calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
+        )
+        create.saturatedFat = 0.1
+        create.nutriScore = "a"
+        create.ingredientsText = "Milk, cultures"
+        let temp = try await repo.createFood(create)
+
+        // Editing the name must not strip the scanned fields from the upload.
+        _ = try await repo.updateFood(id: temp.id, FoodCreate(
+            name: "Skyr Natural", servingSize: 150, servingUnit: .g,
+            calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
+        ))
+
+        let queued = harness.syncManager.queuedRows()
+        #expect(queued.count == 1)
+        guard case let .createFood(body, _)? = queued.first?.operation() else {
+            Issue.record("expected a coalesced createFood operation")
+            return
+        }
+        #expect(body.name == "Skyr Natural")
+        #expect(body.saturatedFat == 0.1)
+        #expect(body.nutriScore == "a")
+        #expect(body.ingredientsText == "Milk, cultures")
+        // The local row keeps them too.
+        #expect(repo.food(id: temp.id)?.saturatedFat == 0.1)
+        #expect(repo.food(id: temp.id)?.nutriScore == "a")
     }
 
     @Test("Toggle favorite flips the local row and queues; temp ids patch the queued create")
@@ -369,6 +482,61 @@ struct RepositoryTests {
 
         #expect(repo.recipes().map(\.id) == ["r-server"])
         #expect(repo.recipe(id: "r-server")?.calories == 500)
+    }
+
+    @Test("Local mode recipes compute macros from the local ingredient foods")
+    func localModeRecipeMacrosComputedLocally() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        let recipeRepo = harness.recipeRepository
+        let entryRepo = harness.entryRepository
+        // 100 kcal / 10 P / 20 C / 5 F / 3 Fib per 100 g serving.
+        try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Rice")))
+        try harness.context.save()
+
+        // 150 g of f1 → factor 1.5 → 150 kcal total, 2 servings.
+        let recipe = try await recipeRepo.createRecipe(RecipeCreate(
+            name: "Bowl",
+            totalServings: 2,
+            ingredients: [RecipeIngredientInput(foodId: "f1", quantity: 150, servingUnit: .g)]
+        ))
+
+        #expect(recipe.calories == 150)
+        #expect(recipe.protein == 15)
+        #expect(recipe.carbs == 30)
+        #expect(recipe.fat == 7.5)
+        #expect(recipe.fiber == 4.5)
+
+        // Logging the recipe contributes per-serving macros (total / servings).
+        let entry = try await entryRepo.createEntry(
+            EntryCreate(recipeId: recipe.id, mealType: "lunch", servings: 1, date: "2026-06-01"),
+            recipe: recipe
+        )
+        #expect(entry.totalCalories == 75)
+        let day = entryRepo.calendarDays(year: 2026, month: 6, calorieGoal: nil)
+        #expect(day.first?.calories == 75)
+    }
+
+    @Test("Recipe ingredient edits apply to the local row and recompute macros")
+    func recipeIngredientEditAppliesLocally() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        let repo = harness.recipeRepository
+        try harness.context.insert(LocalFood(food: harness.food(id: "f1", name: "Rice")))
+        try harness.context.save()
+        let recipe = try await repo.createRecipe(RecipeCreate(
+            name: "Bowl",
+            totalServings: 2,
+            ingredients: [RecipeIngredientInput(foodId: "f1", quantity: 150, servingUnit: .g)]
+        ))
+
+        _ = try await repo.updateRecipe(id: recipe.id, RecipeUpdate(
+            ingredients: [RecipeIngredientInput(foodId: "f1", quantity: 300, servingUnit: .g)]
+        ))
+
+        let updated = try #require(repo.recipe(id: recipe.id))
+        #expect(updated.ingredients?.count == 1)
+        #expect(updated.ingredients?.first?.quantity == 300)
+        #expect(updated.calories == 300)
+        #expect(updated.protein == 30)
     }
 
     // MARK: Weight
@@ -527,6 +695,41 @@ struct RepositoryTests {
         await harness.syncManager.drainPendingQueue()
 
         #expect(repo.supplements().map(\.id) == ["s-server"])
+    }
+
+    @Test("Supplement ingredient edits apply to the local row in both modes")
+    func supplementIngredientEditsApplyLocally() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        let repo = harness.supplementRepository
+
+        // The supplement editor sends inline backing foods, not food ids.
+        let inline = SupplementIngredientInput(
+            foodId: nil,
+            food: SupplementBackingFoodInput(
+                name: "Magnesium citrate", servingSize: 1, servingUnit: "g",
+                calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0,
+                ingredientsText: "300 mg"
+            ),
+            servings: 1,
+            sortOrder: 0
+        )
+        let created = try await repo.createSupplement(
+            SupplementCreate(name: "Magnesium", scheduleType: .daily, ingredients: [inline])
+        )
+        #expect(created.ingredients.map(\.food.name) == ["Magnesium citrate"])
+        #expect(repo.supplements().first?.ingredients.map(\.food.name) == ["Magnesium citrate"])
+
+        var replacement = inline
+        replacement.food = SupplementBackingFoodInput(
+            name: "Magnesium glycinate", servingSize: 1, servingUnit: "g",
+            calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0,
+            ingredientsText: "200 mg"
+        )
+        _ = try await repo.updateSupplement(id: created.id, SupplementUpdate(ingredients: [replacement]))
+
+        let updated = try #require(repo.supplements().first)
+        #expect(updated.ingredients.map(\.food.name) == ["Magnesium glycinate"])
+        #expect(updated.ingredients.first?.food.ingredientsText == "200 mg")
     }
 
     // MARK: Goals

--- a/mobile/iosApp/BissbilanzTests/SyncManagerTests.swift
+++ b/mobile/iosApp/BissbilanzTests/SyncManagerTests.swift
@@ -24,7 +24,14 @@ struct SyncManagerTests {
         """)
         harness.stub("POST", "/api/goals", json: "{}")
 
-        harness.syncManager.enqueue(.createFood(body: makeFoodCreate(), localId: LocalStore.makeTempId()))
+        // Creates always have their optimistic local row (repositories write
+        // it before enqueueing) — a missing row means "deleted while in
+        // flight" and would enqueue a compensating delete.
+        let tempId = LocalStore.makeTempId()
+        let temp = try FoodRepository.makeFood(from: makeFoodCreate(), id: tempId)
+        harness.context.insert(LocalFood(food: temp))
+        try harness.context.save()
+        harness.syncManager.enqueue(.createFood(body: makeFoodCreate(), localId: tempId))
         harness.syncManager.enqueue(.setGoals(body: .defaults))
 
         let drained = await harness.syncManager.drainPendingQueue()
@@ -119,6 +126,168 @@ struct SyncManagerTests {
         #expect(drained == 0)
         #expect(harness.syncManager.queuedRows().isEmpty)
         #expect(harness.recordedRequests.isEmpty)
+    }
+
+    @Test("Offline create chain: the queued entry create uploads the server food id")
+    func offlineCreateChainRemapsQueuedEntryPayload() async throws {
+        let harness = try RepositoryHarness(online: false)
+        harness.stub("POST", "/api/foods", json: """
+        {"food": {
+            "id": "f-server", "userId": "u1", "name": "Skyr", "servingSize": 150, "servingUnit": "g",
+            "calories": 98, "protein": 16, "carbs": 6, "fat": 0.2, "fiber": 0, "isFavorite": false
+        }}
+        """)
+        harness.stub("POST", "/api/entries", json: """
+        {"entry": {"id": "e-server", "userId": "u1", "date": "2026-06-01", "mealType": "lunch", "servings": 1}}
+        """)
+
+        // Offline: both creates queue up, nothing drains.
+        let temp = try await harness.foodRepository.createFood(makeFoodCreate())
+        _ = try await harness.entryRepository.createEntry(
+            EntryCreate(foodId: temp.id, mealType: "lunch", servings: 1, date: "2026-06-01"),
+            food: temp
+        )
+        #expect(harness.syncManager.queuedRows().count == 2)
+        #expect(harness.recordedRequests.isEmpty)
+
+        // Back online: the food create drains first and the queued entry
+        // payload must be rewritten to the server food id before it uploads.
+        harness.connectivity.isOnline = true
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 2)
+        let entryBody = try #require(harness.recordedBodies("POST", "/api/entries").first)
+        let entryCreate = try JSONDecoder().decode(EntryCreate.self, from: entryBody)
+        #expect(entryCreate.foodId == "f-server")
+        #expect(harness.entryRepository.entries(date: "2026-06-01").first?.foodId == "f-server")
+        #expect(harness.syncManager.queuedRows().isEmpty)
+    }
+
+    @Test("Offline create chain: queued recipe ingredients remap to the server food id")
+    func offlineCreateChainRemapsQueuedRecipeIngredients() async throws {
+        let harness = try RepositoryHarness(online: false)
+        harness.stub("POST", "/api/foods", json: """
+        {"food": {
+            "id": "f-server", "userId": "u1", "name": "Skyr", "servingSize": 150, "servingUnit": "g",
+            "calories": 98, "protein": 16, "carbs": 6, "fat": 0.2, "fiber": 0, "isFavorite": false
+        }}
+        """)
+        harness.stub("POST", "/api/recipes", json: """
+        {"recipe": {"id": "r-server", "userId": "u1", "name": "Bowl", "totalServings": 2, "isFavorite": false}}
+        """)
+
+        let temp = try await harness.foodRepository.createFood(makeFoodCreate())
+        _ = try await harness.recipeRepository.createRecipe(RecipeCreate(
+            name: "Bowl",
+            totalServings: 2,
+            ingredients: [RecipeIngredientInput(foodId: temp.id, quantity: 80, servingUnit: .g)]
+        ))
+
+        harness.connectivity.isOnline = true
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 2)
+        let recipeBody = try #require(harness.recordedBodies("POST", "/api/recipes").first)
+        let recipeCreate = try JSONDecoder().decode(RecipeCreate.self, from: recipeBody)
+        #expect(recipeCreate.ingredients.map(\.foodId) == ["f-server"])
+        #expect(harness.syncManager.queuedRows().isEmpty)
+    }
+
+    @Test("Offline create chain: a queued supplement log remaps to the server supplement id")
+    func offlineCreateChainRemapsQueuedSupplementLog() async throws {
+        let harness = try RepositoryHarness(online: false)
+        harness.stub("POST", "/api/supplements", json: """
+        {"supplement": {
+            "id": "s-server", "userId": "u1", "name": "Magnesium",
+            "scheduleType": "daily", "isActive": true, "sortOrder": 0, "ingredients": []
+        }}
+        """)
+        harness.stub("POST", "/api/supplements/s-server/log", json: """
+        {"log": {"supplementId": "s-server", "date": "2026-06-01", "takenAt": "2026-06-01T08:00:00Z", "entryIds": []}}
+        """)
+
+        let temp = try await harness.supplementRepository.createSupplement(
+            SupplementCreate(name: "Magnesium", scheduleType: .daily, ingredients: [])
+        )
+        try await harness.supplementRepository.logSupplement(id: temp.id, date: "2026-06-01")
+
+        harness.connectivity.isOnline = true
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 2)
+        // The queued log was re-keyed: it POSTed against the server id.
+        #expect(harness.recordedRequests == ["POST /api/supplements", "POST /api/supplements/s-server/log"])
+        #expect(harness.syncManager.queuedRows().isEmpty)
+    }
+
+    @Test("Connectivity failures stop draining without consuming the retry budget")
+    func connectivityFailureDoesNotConsumeRetries() async throws {
+        let harness = try RepositoryHarness()
+        // The connectivity monitor still reports the optimistic online default,
+        // but the request fails at the transport level (offline launch).
+        harness.stubError("POST", "/api/goals", code: .notConnectedToInternet)
+
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+        for _ in 0 ..< (SyncManager.maxRetries + 1) {
+            await harness.syncManager.drainPendingQueue()
+        }
+
+        // Still queued, with an untouched retry budget.
+        #expect(harness.syncManager.queuedRows().count == 1)
+        #expect(harness.syncManager.queuedRows().first?.retryCount == 0)
+
+        // Once the connection is back the op uploads normally.
+        harness.stub("POST", "/api/goals", json: "{}")
+        let drained = await harness.syncManager.drainPendingQueue()
+        #expect(drained == 1)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+    }
+
+    @Test("Operations enqueued during an active drain are uploaded by that drain")
+    func opsEnqueuedDuringDrainAreProcessed() async throws {
+        let harness = try RepositoryHarness()
+        harness.stub("POST", "/api/goals", json: "{}", delayMs: 500)
+        harness.stub("DELETE", "/api/foods/f1", json: "{}")
+
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+        let drainTask = Task { await harness.syncManager.drainPendingQueue() }
+        // Let the drain start and suspend on the delayed response, then
+        // enqueue another op mid-drain (its scheduleDrain is a no-op here).
+        try await Task.sleep(for: .milliseconds(100))
+        harness.syncManager.enqueue(.deleteFood(id: "f1"))
+
+        let drained = await drainTask.value
+
+        #expect(drained == 2)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.recordedRequests == ["POST /api/goals", "DELETE /api/foods/f1"])
+    }
+
+    @Test("Deleting a temp row while its create is in flight does not resurrect it")
+    func deleteDuringInFlightCreateDoesNotResurrect() async throws {
+        let harness = try RepositoryHarness()
+        harness.stub("POST", "/api/foods", json: """
+        {"food": {
+            "id": "f-server", "userId": "u1", "name": "Skyr", "servingSize": 150, "servingUnit": "g",
+            "calories": 98, "protein": 16, "carbs": 6, "fat": 0.2, "fiber": 0, "isFavorite": false
+        }}
+        """, delayMs: 500)
+        harness.stub("DELETE", "/api/foods/f-server", json: "{}")
+
+        let temp = try await harness.foodRepository.createFood(makeFoodCreate())
+        let drainTask = Task { await harness.syncManager.drainPendingQueue() }
+        // Delete the temp row while the POST is in flight.
+        try await Task.sleep(for: .milliseconds(100))
+        try await harness.foodRepository.deleteFood(id: temp.id)
+
+        _ = await drainTask.value
+
+        // The server record is not re-inserted locally; instead its deletion
+        // was enqueued and drained.
+        #expect(harness.foodRepository.food(id: "f-server") == nil)
+        #expect(harness.foodRepository.searchLocal("Skyr").isEmpty)
+        #expect(harness.recordedRequests == ["POST /api/foods", "DELETE /api/foods/f-server"])
+        #expect(harness.syncManager.queuedRows().isEmpty)
     }
 
     @Test("Queue survives across manager instances (persisted in the store)")

--- a/mobile/iosApp/BissbilanzTests/SyncManagerTests.swift
+++ b/mobile/iosApp/BissbilanzTests/SyncManagerTests.swift
@@ -1,0 +1,141 @@
+@testable import Bissbilanz
+import Foundation
+import SwiftData
+import Testing
+
+@Suite("Sync manager drain semantics")
+@MainActor
+struct SyncManagerTests {
+    private func makeFoodCreate(name: String = "Skyr") -> FoodCreate {
+        FoodCreate(
+            name: name, servingSize: 150, servingUnit: .g,
+            calories: 98, protein: 16, carbs: 6, fat: 0.2, fiber: 0
+        )
+    }
+
+    @Test("Successful drain uploads FIFO and empties the queue")
+    func successfulDrainUploadsFIFO() async throws {
+        let harness = try RepositoryHarness()
+        harness.stub("POST", "/api/foods", json: """
+        {"food": {
+            "id": "f-server", "userId": "u1", "name": "Skyr", "servingSize": 150, "servingUnit": "g",
+            "calories": 98, "protein": 16, "carbs": 6, "fat": 0.2, "fiber": 0, "isFavorite": false
+        }}
+        """)
+        harness.stub("POST", "/api/goals", json: "{}")
+
+        harness.syncManager.enqueue(.createFood(body: makeFoodCreate(), localId: LocalStore.makeTempId()))
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 2)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.syncManager.pendingCount == 0)
+        #expect(harness.recordedRequests == ["POST /api/foods", "POST /api/goals"])
+        #expect(harness.syncManager.errors.isEmpty)
+    }
+
+    @Test("4xx responses drop the operation and record an error")
+    func clientErrorDropsOperation() async throws {
+        let harness = try RepositoryHarness()
+        harness.stub("POST", "/api/foods", status: 400, json: #"{"error": "invalid"}"#)
+        harness.stub("POST", "/api/goals", json: "{}")
+
+        harness.syncManager.enqueue(.createFood(body: makeFoodCreate(), localId: LocalStore.makeTempId()))
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+
+        await harness.syncManager.drainPendingQueue()
+
+        // The rejected op is gone, draining continued with the next op.
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.syncManager.errors.count == 1)
+        #expect(harness.syncManager.errors.first?.contains("HTTP 400") == true)
+        #expect(harness.recordedRequests.contains("POST /api/goals"))
+    }
+
+    @Test("5xx responses stop draining, then drop after the retry cap")
+    func serverErrorRetriesThenDrops() async throws {
+        let harness = try RepositoryHarness()
+        harness.stub("POST", "/api/foods", status: 500, json: #"{"error": "boom"}"#)
+        harness.stub("POST", "/api/goals", json: "{}")
+
+        harness.syncManager.enqueue(.createFood(body: makeFoodCreate(), localId: LocalStore.makeTempId()))
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+
+        // Attempts 1 and 2: the failing head-of-queue blocks everything behind it.
+        await harness.syncManager.drainPendingQueue()
+        #expect(harness.syncManager.queuedRows().count == 2)
+        #expect(harness.syncManager.queuedRows().first?.retryCount == 1)
+        #expect(!harness.recordedRequests.contains("POST /api/goals"))
+
+        await harness.syncManager.drainPendingQueue()
+        #expect(harness.syncManager.queuedRows().first?.retryCount == 2)
+
+        // Attempt 3 hits the cap: the op is dropped and draining continues.
+        await harness.syncManager.drainPendingQueue()
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.syncManager.errors.contains { $0.contains("Gave up syncing create food") })
+        #expect(harness.recordedRequests.contains("POST /api/goals"))
+    }
+
+    @Test("A final 401 stops draining and keeps the queue")
+    func unauthorizedStopsDraining() async throws {
+        let harness = try RepositoryHarness()
+        harness.stub("POST", "/api/foods", status: 401, json: #"{"error": "unauthorized"}"#)
+        harness.stub("POST", "/api/goals", json: "{}")
+
+        harness.syncManager.enqueue(.createFood(body: makeFoodCreate(), localId: LocalStore.makeTempId()))
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+
+        await harness.syncManager.drainPendingQueue()
+
+        #expect(harness.syncManager.queuedRows().count == 2)
+        #expect(harness.syncManager.errors.first?.contains("Session expired") == true)
+        #expect(!harness.recordedRequests.contains("POST /api/goals"))
+    }
+
+    @Test("Offline drain is a no-op")
+    func offlineDrainDoesNothing() async throws {
+        let harness = try RepositoryHarness(online: false)
+        harness.stub("POST", "/api/goals", json: "{}")
+
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 0)
+        #expect(harness.syncManager.queuedRows().count == 1)
+        #expect(harness.recordedRequests.isEmpty)
+    }
+
+    @Test("Local mode never enqueues and never drains")
+    func localModeNoEnqueueNoDrain() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        harness.stub("POST", "/api/goals", json: "{}")
+
+        harness.syncManager.enqueue(.setGoals(body: .defaults))
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 0)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.recordedRequests.isEmpty)
+    }
+
+    @Test("Queue survives across manager instances (persisted in the store)")
+    func queuePersistsInStore() throws {
+        let harness = try RepositoryHarness()
+        harness.syncManager.enqueue(.deleteFood(id: "f1"))
+        harness.syncManager.enqueue(.deleteEntry(id: "e1"))
+
+        // A fresh manager over the same context sees the same rows in order.
+        let second = SyncManager(
+            context: harness.context,
+            api: harness.api,
+            appMode: harness.appMode,
+            connectivity: harness.connectivity
+        )
+        second.autoDrain = false
+        #expect(second.pendingCount == 2)
+        #expect(second.queuedRows().map(\.type) == ["delete_food", "delete_entry"])
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/TestSupport.swift
+++ b/mobile/iosApp/BissbilanzTests/TestSupport.swift
@@ -13,6 +13,8 @@ final class StubURLProtocol: URLProtocol {
     struct Stub {
         let status: Int
         let body: Data
+        var errorCode: URLError.Code?
+        var delayMs: Int = 0
     }
 
     private nonisolated(unsafe) static var stubs: [String: Stub] = [:]
@@ -20,10 +22,17 @@ final class StubURLProtocol: URLProtocol {
     private nonisolated(unsafe) static var bodies: [String: [Data]] = [:]
     private static let lock = NSLock()
 
-    static func stub(_ method: String, _ url: String, status: Int = 200, json: String = "{}") {
+    static func stub(_ method: String, _ url: String, status: Int = 200, json: String = "{}", delayMs: Int = 0) {
         lock.lock()
         defer { lock.unlock() }
-        stubs["\(method) \(url)"] = Stub(status: status, body: Data(json.utf8))
+        stubs["\(method) \(url)"] = Stub(status: status, body: Data(json.utf8), delayMs: delayMs)
+    }
+
+    /// Makes "METHOD url" fail with a transport-level URLError.
+    static func stubError(_ method: String, _ url: String, code: URLError.Code) {
+        lock.lock()
+        defer { lock.unlock() }
+        stubs["\(method) \(url)"] = Stub(status: 0, body: Data(), errorCode: code)
     }
 
     /// Request bodies sent to "METHOD url", in arrival order.
@@ -65,6 +74,22 @@ final class StubURLProtocol: URLProtocol {
         let stub = Self.stubs[key]
         Self.lock.unlock()
 
+        if let stub, stub.delayMs > 0 {
+            // Delayed delivery lets tests interleave work with an in-flight request.
+            let box = UncheckedSendableBox(value: self)
+            Self.deliveryQueue.asyncAfter(deadline: .now() + .milliseconds(stub.delayMs)) {
+                box.value.deliver(stub, url: url)
+            }
+        } else {
+            deliver(stub, url: url)
+        }
+    }
+
+    private func deliver(_ stub: Stub?, url: URL?) {
+        if let code = stub?.errorCode {
+            client?.urlProtocol(self, didFailWithError: URLError(code))
+            return
+        }
         let response = HTTPURLResponse(
             url: url ?? URL(string: "https://stub.local")!,
             statusCode: stub?.status ?? 404,
@@ -75,6 +100,8 @@ final class StubURLProtocol: URLProtocol {
         client?.urlProtocol(self, didLoad: stub?.body ?? Data("{}".utf8))
         client?.urlProtocolDidFinishLoading(self)
     }
+
+    private static let deliveryQueue = DispatchQueue(label: "stub-delayed-delivery")
 
     override func stopLoading() {}
 
@@ -95,6 +122,11 @@ final class StubURLProtocol: URLProtocol {
         }
         return data
     }
+}
+
+/// Moves a non-Sendable value across a dispatch hop (delayed stub delivery).
+private struct UncheckedSendableBox<T>: @unchecked Sendable {
+    let value: T
 }
 
 // MARK: - Test harness
@@ -136,8 +168,12 @@ struct RepositoryHarness {
 
     // MARK: Stubbing
 
-    func stub(_ method: String, _ path: String, status: Int = 200, json: String = "{}") {
-        StubURLProtocol.stub(method, "\(baseURL)\(path)", status: status, json: json)
+    func stub(_ method: String, _ path: String, status: Int = 200, json: String = "{}", delayMs: Int = 0) {
+        StubURLProtocol.stub(method, "\(baseURL)\(path)", status: status, json: json, delayMs: delayMs)
+    }
+
+    func stubError(_ method: String, _ path: String, code: URLError.Code) {
+        StubURLProtocol.stubError(method, "\(baseURL)\(path)", code: code)
     }
 
     var recordedRequests: [String] {

--- a/mobile/iosApp/BissbilanzTests/TestSupport.swift
+++ b/mobile/iosApp/BissbilanzTests/TestSupport.swift
@@ -1,0 +1,265 @@
+@testable import Bissbilanz
+import Foundation
+import SwiftData
+import Testing
+
+// MARK: - Networking stub
+
+/// Routes stubbed responses by "METHOD scheme://host/path". Stubs and the
+/// request log are keyed by host, so every harness gets a unique fake host and
+/// suites can run in parallel without clobbering each other. Unstubbed
+/// requests get a 404 so API calls fail loudly instead of hanging.
+final class StubURLProtocol: URLProtocol {
+    struct Stub {
+        let status: Int
+        let body: Data
+    }
+
+    private nonisolated(unsafe) static var stubs: [String: Stub] = [:]
+    private nonisolated(unsafe) static var recorded: [String] = []
+    private nonisolated(unsafe) static var bodies: [String: [Data]] = [:]
+    private static let lock = NSLock()
+
+    static func stub(_ method: String, _ url: String, status: Int = 200, json: String = "{}") {
+        lock.lock()
+        defer { lock.unlock() }
+        stubs["\(method) \(url)"] = Stub(status: status, body: Data(json.utf8))
+    }
+
+    /// Request bodies sent to "METHOD url", in arrival order.
+    static func recordedBodies(_ method: String, _ url: String) -> [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return bodies["\(method) \(url)"] ?? []
+    }
+
+    /// Requests seen for `baseURL`, as "METHOD /path" in arrival order.
+    static func recordedRequests(baseURL: String) -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded.compactMap { key in
+            let parts = key.split(separator: " ", maxSplits: 1)
+            guard parts.count == 2, parts[1].hasPrefix(baseURL) else { return nil }
+            return "\(parts[0]) \(parts[1].dropFirst(baseURL.count))"
+        }
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let url = request.url
+        let base = url.map { "\($0.scheme ?? "")://\($0.host() ?? "")" } ?? ""
+        let key = "\(request.httpMethod ?? "GET") \(base)\(url?.path ?? "")"
+        let body = Self.body(of: request)
+        Self.lock.lock()
+        Self.recorded.append(key)
+        if let body {
+            Self.bodies[key, default: []].append(body)
+        }
+        let stub = Self.stubs[key]
+        Self.lock.unlock()
+
+        let response = HTTPURLResponse(
+            url: url ?? URL(string: "https://stub.local")!,
+            statusCode: stub?.status ?? 404,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub?.body ?? Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    /// URLSession hands POST bodies to protocols as a stream — drain it.
+    private static func body(of request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}
+
+// MARK: - Test harness
+
+/// In-memory SwiftData store + stubbed API + isolated mode/connectivity/sync
+/// stack. `autoDrain` is disabled so tests control queue draining explicitly.
+@MainActor
+struct RepositoryHarness {
+    let container: ModelContainer
+    let context: ModelContext
+    let api: BissbilanzAPI
+    let appMode: AppModeManager
+    let connectivity: ConnectivityMonitor
+    let syncManager: SyncManager
+    let defaults: UserDefaults
+    let baseURL: String
+
+    init(mode: AppMode? = .synced, online: Bool = true) throws {
+        baseURL = "https://stub-\(UUID().uuidString.lowercased()).local"
+        container = try LocalStore.makeContainer(inMemory: true)
+        context = container.mainContext
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        api = BissbilanzAPI(
+            baseURL: baseURL,
+            authManager: AuthManager(baseURL: baseURL),
+            session: URLSession(configuration: configuration)
+        )
+        defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+        appMode = AppModeManager(defaults: defaults)
+        if let mode {
+            appMode.setMode(mode)
+        }
+        connectivity = ConnectivityMonitor()
+        connectivity.isOnline = online
+        syncManager = SyncManager(context: context, api: api, appMode: appMode, connectivity: connectivity)
+        syncManager.autoDrain = false
+    }
+
+    // MARK: Stubbing
+
+    func stub(_ method: String, _ path: String, status: Int = 200, json: String = "{}") {
+        StubURLProtocol.stub(method, "\(baseURL)\(path)", status: status, json: json)
+    }
+
+    var recordedRequests: [String] {
+        StubURLProtocol.recordedRequests(baseURL: baseURL)
+    }
+
+    func recordedBodies(_ method: String, _ path: String) -> [Data] {
+        StubURLProtocol.recordedBodies(method, "\(baseURL)\(path)")
+    }
+
+    // MARK: Repositories
+
+    var entryRepository: EntryRepository {
+        EntryRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
+    var foodRepository: FoodRepository {
+        FoodRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
+    var recipeRepository: RecipeRepository {
+        RecipeRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
+    var weightRepository: WeightRepository {
+        WeightRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
+    var supplementRepository: SupplementRepository {
+        SupplementRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
+    var goalsRepository: GoalsRepository {
+        GoalsRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
+    var preferencesRepository: PreferencesRepository {
+        PreferencesRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
+    var migrator: LocalDataMigrator {
+        LocalDataMigrator(context: context, api: api, appMode: appMode, syncManager: syncManager, defaults: defaults)
+    }
+
+    // MARK: Model factories
+
+    func entry(
+        id: String,
+        date: String,
+        mealType: String = "lunch",
+        foodId: String? = nil,
+        recipeId: String? = nil
+    ) throws -> Entry {
+        var dict: [String: Any] = [
+            "id": id,
+            "mealType": mealType,
+            "servings": 1,
+            "foodName": "Seed \(id)",
+            "calories": 100,
+            "date": date,
+        ]
+        if let foodId { dict["foodId"] = foodId }
+        if let recipeId { dict["recipeId"] = recipeId }
+        return try JSONPatch.decode(Entry.self, from: dict)
+    }
+
+    func food(id: String, name: String, isFavorite: Bool = false, barcode: String? = nil) throws -> Food {
+        var dict: [String: Any] = [
+            "id": id,
+            "userId": "u1",
+            "name": name,
+            "servingSize": 100,
+            "servingUnit": "g",
+            "calories": 100,
+            "protein": 10,
+            "carbs": 20,
+            "fat": 5,
+            "fiber": 3,
+            "isFavorite": isFavorite,
+        ]
+        if let barcode { dict["barcode"] = barcode }
+        return try JSONPatch.decode(Food.self, from: dict)
+    }
+
+    func recipe(id: String, name: String, isFavorite: Bool = false, ingredientFoodId: String? = nil) throws -> Recipe {
+        var dict: [String: Any] = [
+            "id": id,
+            "userId": "u1",
+            "name": name,
+            "totalServings": 2,
+            "isFavorite": isFavorite,
+        ]
+        if let ingredientFoodId {
+            dict["ingredients"] = [[
+                "recipeId": id,
+                "foodId": ingredientFoodId,
+                "quantity": 100,
+                "servingUnit": "g",
+                "sortOrder": 0,
+            ]]
+        }
+        return try JSONPatch.decode(Recipe.self, from: dict)
+    }
+
+    func weight(id: String, date: String, kg: Double) throws -> WeightEntry {
+        try JSONPatch.decode(WeightEntry.self, from: [
+            "id": id,
+            "userId": "u1",
+            "weightKg": kg,
+            "entryDate": date,
+        ])
+    }
+
+    func supplement(id: String, name: String, sortOrder: Int = 0) throws -> Supplement {
+        try JSONPatch.decode(Supplement.self, from: [
+            "id": id,
+            "userId": "u1",
+            "name": name,
+            "scheduleType": "daily",
+            "isActive": true,
+            "sortOrder": sortOrder,
+            "ingredients": [],
+        ])
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/ViewLogicTests.swift
+++ b/mobile/iosApp/BissbilanzTests/ViewLogicTests.swift
@@ -315,3 +315,79 @@ private func makeEntry(
         date: "2026-03-12", eatenAt: nil, createdAt: nil, updatedAt: nil
     )
 }
+
+// MARK: - Weight Trend
+
+// Tests the trend classification and local 7-day delta used by the
+// WeightView trend card.
+
+@Suite("Weight Trend Tests")
+struct WeightTrendTests {
+    private func makeWeight(date: String, kg: Double) -> WeightEntry {
+        WeightEntry(
+            id: "w-\(date)", userId: "u1", weightKg: kg, entryDate: date,
+            loggedAt: nil, notes: nil, createdAt: nil, updatedAt: nil
+        )
+    }
+
+    @Test("Delta classification", arguments: [
+        (nil, WeightTrend.steady(nil)),
+        (0.5, WeightTrend.rising(0.5)),
+        (-0.5, WeightTrend.falling(-0.5)),
+        (0.2, WeightTrend.steady(0.2)),
+        (-0.2, WeightTrend.steady(-0.2)),
+        // The band boundary itself still counts as steady
+        (WeightTrend.steadyBandKg, WeightTrend.steady(WeightTrend.steadyBandKg)),
+        (-WeightTrend.steadyBandKg, WeightTrend.steady(-WeightTrend.steadyBandKg)),
+    ] as [(Double?, WeightTrend)])
+    func deltaClassification(delta: Double?, expected: WeightTrend) {
+        #expect(WeightTrend.from(delta: delta) == expected)
+    }
+
+    @Test("Local delta averages last 7 days against the 7 days before")
+    func localDeltaAverages() throws {
+        let entries = [
+            makeWeight(date: "2026-06-10", kg: 101.0),
+            makeWeight(date: "2026-06-08", kg: 102.0),
+            // 8 and 9 days before the newest entry
+            makeWeight(date: "2026-06-02", kg: 102.0),
+            makeWeight(date: "2026-06-01", kg: 103.0),
+        ]
+        let delta = try #require(WeightTrend.localDelta7d(entries: entries))
+        #expect(abs(delta - -1.0) < 0.0001)
+    }
+
+    @Test("Local delta ignores entries older than 14 days")
+    func localDeltaIgnoresOldEntries() throws {
+        let entries = [
+            makeWeight(date: "2026-06-10", kg: 101.0),
+            makeWeight(date: "2026-06-02", kg: 102.0),
+            // Far outside both windows — must not skew the average
+            makeWeight(date: "2026-01-01", kg: 90.0),
+        ]
+        let delta = try #require(WeightTrend.localDelta7d(entries: entries))
+        #expect(abs(delta - -1.0) < 0.0001)
+    }
+
+    @Test("Local delta is order-independent")
+    func localDeltaOrderIndependent() {
+        let sorted = [
+            makeWeight(date: "2026-06-10", kg: 101.0),
+            makeWeight(date: "2026-06-02", kg: 102.0),
+        ]
+        #expect(WeightTrend.localDelta7d(entries: sorted) == WeightTrend.localDelta7d(entries: sorted.reversed()))
+    }
+
+    @Test("Local delta requires entries in both windows")
+    func localDeltaInsufficientData() {
+        #expect(WeightTrend.localDelta7d(entries: []) == nil)
+        // Only recent entries, nothing 7-14 days back
+        let recentOnly = [
+            makeWeight(date: "2026-06-10", kg: 101.0),
+            makeWeight(date: "2026-06-09", kg: 102.0),
+        ]
+        #expect(WeightTrend.localDelta7d(entries: recentOnly) == nil)
+        // Unparseable dates are skipped entirely
+        #expect(WeightTrend.localDelta7d(entries: [makeWeight(date: "garbage", kg: 100)]) == nil)
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/ViewLogicTests.swift
+++ b/mobile/iosApp/BissbilanzTests/ViewLogicTests.swift
@@ -1,9 +1,9 @@
+@testable import Bissbilanz
 import Foundation
 import Testing
 
-@testable import Bissbilanz
-
 // MARK: - Meal Grouping Logic
+
 // Tests the meal ordering and grouping logic used in DashboardView.mealGroups
 
 @Suite("Meal Grouping Tests")
@@ -108,7 +108,9 @@ struct MealGroupingTests {
 
 @Suite("Entry Macro Totals Tests")
 struct EntryMacroTotalsTests {
-    private func computeTotals(_ entries: [Entry]) -> (calories: Double, protein: Double, carbs: Double, fat: Double, fiber: Double) {
+    private func computeTotals(_ entries: [Entry])
+        -> (calories: Double, protein: Double, carbs: Double, fat: Double, fiber: Double)
+    {
         (
             entries.reduce(0) { $0 + $1.totalCalories },
             entries.reduce(0) { $0 + $1.totalProtein },
@@ -191,51 +193,51 @@ struct EntryMacroTotalsTests {
 @Suite("Date Navigation Tests")
 struct DateNavigationTests {
     @Test("Adding one day moves to next day")
-    func nextDay() {
-        let date = DateFormatting.date(from: "2026-03-12")!
+    func nextDay() throws {
+        let date = try #require(DateFormatting.date(from: "2026-03-12"))
         let next = date.adding(days: 1)
         #expect(next.isoDateString == "2026-03-13")
     }
 
     @Test("Subtracting one day moves to previous day")
-    func previousDay() {
-        let date = DateFormatting.date(from: "2026-03-12")!
+    func previousDay() throws {
+        let date = try #require(DateFormatting.date(from: "2026-03-12"))
         let prev = date.adding(days: -1)
         #expect(prev.isoDateString == "2026-03-11")
     }
 
     @Test("Navigation across month boundary")
-    func crossMonthBoundary() {
-        let date = DateFormatting.date(from: "2026-03-31")!
+    func crossMonthBoundary() throws {
+        let date = try #require(DateFormatting.date(from: "2026-03-31"))
         let next = date.adding(days: 1)
         #expect(next.isoDateString == "2026-04-01")
     }
 
     @Test("Navigation across year boundary")
-    func crossYearBoundary() {
-        let date = DateFormatting.date(from: "2025-12-31")!
+    func crossYearBoundary() throws {
+        let date = try #require(DateFormatting.date(from: "2025-12-31"))
         let next = date.adding(days: 1)
         #expect(next.isoDateString == "2026-01-01")
     }
 
     @Test("Navigation through February leap year")
-    func leapYearFebruary() {
-        let date = DateFormatting.date(from: "2028-02-28")!
+    func leapYearFebruary() throws {
+        let date = try #require(DateFormatting.date(from: "2028-02-28"))
         let next = date.adding(days: 1)
         #expect(next.isoDateString == "2028-02-29") // 2028 is a leap year
     }
 
     @Test("Navigation through February non-leap year")
-    func nonLeapYearFebruary() {
-        let date = DateFormatting.date(from: "2026-02-28")!
+    func nonLeapYearFebruary() throws {
+        let date = try #require(DateFormatting.date(from: "2026-02-28"))
         let next = date.adding(days: 1)
         #expect(next.isoDateString == "2026-03-01")
     }
 
     @Test("weekdayOffset returns Monday-based offset")
-    func weekdayOffset() {
+    func weekdayOffset() throws {
         // 2026-03-01 is a Sunday
-        let march2026 = DateFormatting.date(from: "2026-03-01")!
+        let march2026 = try #require(DateFormatting.date(from: "2026-03-01"))
         let offset = march2026.weekdayOffset
         #expect(offset == 6) // Sunday = 6 in Monday-based (Mon=0, Tue=1, ..., Sun=6)
     }
@@ -246,84 +248,22 @@ struct DateNavigationTests {
 @Suite("DateFormatting Display Tests")
 struct DateFormattingDisplayTests {
     @Test("Display string is non-empty")
-    func displayStringNotEmpty() {
-        let date = DateFormatting.date(from: "2026-03-12")!
+    func displayStringNotEmpty() throws {
+        let date = try #require(DateFormatting.date(from: "2026-03-12"))
         let display = DateFormatting.displayString(from: date)
         #expect(!display.isEmpty)
     }
 
     @Test("Month year format")
-    func monthYearFormat() {
-        let date = DateFormatting.date(from: "2026-03-12")!
+    func monthYearFormat() throws {
+        let date = try #require(DateFormatting.date(from: "2026-03-12"))
         let monthYear = DateFormatting.monthYear(from: date)
         #expect(monthYear.contains("2026"))
     }
 }
 
-// MARK: - Localization Logic Tests
-
-@Suite("Localization Meal Name Tests")
-struct LocalizationMealNameTests {
-    @Test("Meal name handles case-insensitive input")
-    func mealNameCaseInsensitive() {
-        L10n.currentLocale = .en
-        #expect(L10n.mealName("BREAKFAST") == "Breakfast")
-        #expect(L10n.mealName("Lunch") == "Lunch")
-        #expect(L10n.mealName("DINNER") == "Dinner")
-    }
-
-    @Test("Snack alias maps to Snacks")
-    func snackAlias() {
-        L10n.currentLocale = .en
-        #expect(L10n.mealName("snack") == "Snacks")
-        #expect(L10n.mealName("snacks") == "Snacks")
-    }
-
-    @Test("Unknown meal type returns capitalized")
-    func unknownMealCapitalized() {
-        #expect(L10n.mealName("pre-workout") == "Pre-workout")
-        #expect(L10n.mealName("brunch") == "Brunch")
-    }
-
-    @Test("NOVA group descriptions")
-    func novaGroupDescriptions() {
-        L10n.currentLocale = .en
-        #expect(L10n.novaGroupDescription(1) == "Unprocessed")
-        #expect(L10n.novaGroupDescription(2) == "Processed ingredients")
-        #expect(L10n.novaGroupDescription(3) == "Processed")
-        #expect(L10n.novaGroupDescription(4) == "Ultra-processed")
-        #expect(L10n.novaGroupDescription(0) == "Unknown")
-        #expect(L10n.novaGroupDescription(5) == "Unknown")
-    }
-
-    @Test("Weekday headers differ by locale")
-    func weekdayHeaders() {
-        let saved = L10n.currentLocale
-        defer { L10n.currentLocale = saved }
-
-        L10n.currentLocale = .en
-        let enHeaders = L10n.weekdayHeaders
-        #expect(enHeaders.count == 7)
-        #expect(enHeaders[0] == "M")
-        #expect(enHeaders[2] == "W") // Wednesday
-
-        L10n.currentLocale = .de
-        let deHeaders = L10n.weekdayHeaders
-        #expect(deHeaders[2] == "M") // Mittwoch
-    }
-
-    @Test("Entries copied interpolation")
-    func entriesCopiedMessage() {
-        let saved = L10n.currentLocale
-        defer { L10n.currentLocale = saved }
-
-        L10n.currentLocale = .en
-        #expect(L10n.entriesCopied(3) == "3 entries copied")
-
-        L10n.currentLocale = .de
-        #expect(L10n.entriesCopied(3) == "3 Einträge kopiert")
-    }
-}
+// NOTE: Tests that mutate the process-global `L10n.currentLocale` live in the
+// serialized "Localization Tests" suite in DateFormattingTests.swift.
 
 // MARK: - Test Helpers
 

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -26,11 +26,6 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.bissbilanz.ios
-        FRAMEWORK_SEARCH_PATHS:
-          - '$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)'
-        OTHER_LDFLAGS:
-          - '-framework'
-          - 'shared'
     info:
       path: Bissbilanz/Info.plist
       properties:
@@ -43,8 +38,6 @@ targets:
     entitlements:
       path: Bissbilanz/Bissbilanz.entitlements
     dependencies:
-      - framework: '../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/shared.framework'
-        embed: false
       - sdk: HealthKit.framework
 
   BissbilanzTests:

--- a/mobile/shared/build.gradle.kts
+++ b/mobile/shared/build.gradle.kts
@@ -75,8 +75,17 @@ android {
 
 sqldelight {
     databases {
+        // Server-derived/transient state (sync queue, sync meta, meal-type cache).
+        // Lives in bissbilanz.db, which is excluded from Android Auto Backup.
         create("BissbilanzDatabase") {
             packageName.set("com.bissbilanz.cache")
+            srcDirs.setFrom("src/commonMain/sqldelight")
+        }
+        // The user's own data. Lives in userdata.db, which IS backed up by
+        // Android Auto Backup, so it must never share a file with the sync queue.
+        create("UserDataDatabase") {
+            packageName.set("com.bissbilanz.userdata")
+            srcDirs.setFrom("src/commonMain/sqldelight-userdata")
         }
     }
 }

--- a/mobile/shared/src/androidMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
+++ b/mobile/shared/src/androidMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
@@ -7,5 +7,13 @@ import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 actual class DatabaseDriverFactory(
     private val context: Context,
 ) {
-    actual fun createDriver(): SqlDriver = AndroidSqliteDriver(BissbilanzDatabase.Schema, context, "bissbilanz.db")
+    actual fun createDriver(): SqlDriver {
+        val driver = AndroidSqliteDriver(BissbilanzDatabase.Schema, context, "bissbilanz.db")
+        // The Android driver only runs Schema.create on a brand-new database, so tables
+        // added in app updates would never materialize on existing installs. Re-running
+        // create here is idempotent because the schema is (and must remain)
+        // IF-NOT-EXISTS-only and additive-only.
+        BissbilanzDatabase.Schema.create(driver)
+        return driver
+    }
 }

--- a/mobile/shared/src/androidMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
+++ b/mobile/shared/src/androidMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
@@ -1,8 +1,10 @@
 package com.bissbilanz.cache
 
 import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.bissbilanz.userdata.UserDataDatabase
 
 actual class DatabaseDriverFactory(
     private val context: Context,
@@ -14,6 +16,39 @@ actual class DatabaseDriverFactory(
         // create here is idempotent because the schema is (and must remain)
         // IF-NOT-EXISTS-only and additive-only.
         BissbilanzDatabase.Schema.create(driver)
+        return driver
+    }
+
+    actual fun createUserDataDriver(): SqlDriver {
+        val driver =
+            AndroidSqliteDriver(
+                schema = UserDataDatabase.Schema,
+                context = context,
+                name = "userdata.db",
+                callback =
+                    object : AndroidSqliteDriver.Callback(UserDataDatabase.Schema) {
+                        override fun onConfigure(db: SupportSQLiteDatabase) {
+                            super.onConfigure(db)
+                            // journal_mode=DELETE (no WAL): Android Auto Backup copies
+                            // userdata.db as a single file, and a WAL database is only
+                            // self-consistent together with its -wal/-shm sidecars.
+                            // Write volume here is tiny, so DELETE journaling is fine.
+                            db.disableWriteAheadLogging()
+                            db.query("PRAGMA journal_mode=DELETE").use { it.moveToFirst() }
+                        }
+                    },
+            )
+        // Same idempotent-create pattern as createDriver(), see above.
+        UserDataDatabase.Schema.create(driver)
+        // One-time copy of user data out of the legacy single-database file (existing
+        // installs have the user tables populated inside bissbilanz.db). Idempotent;
+        // see LegacyUserDataMigration for the crash-safety story.
+        val legacyDriver = AndroidSqliteDriver(BissbilanzDatabase.Schema, context, "bissbilanz.db")
+        try {
+            LegacyUserDataMigration.run(source = legacyDriver, target = driver)
+        } finally {
+            legacyDriver.close()
+        }
         return driver
     }
 }

--- a/mobile/shared/src/androidMain/kotlin/com/bissbilanz/storage/AndroidPlainStorage.kt
+++ b/mobile/shared/src/androidMain/kotlin/com/bissbilanz/storage/AndroidPlainStorage.kt
@@ -1,0 +1,26 @@
+package com.bissbilanz.storage
+
+import android.content.Context
+
+/**
+ * Plain (unencrypted) SharedPreferences. Deliberately not encrypted so the values
+ * survive Android Auto Backup and device restores. Never store secrets here.
+ */
+actual class PlainStorage(
+    context: Context,
+) : KeyValueStore {
+    private val prefs = context.getSharedPreferences("bissbilanz_app_prefs", Context.MODE_PRIVATE)
+
+    actual override fun save(
+        key: String,
+        value: String,
+    ) {
+        prefs.edit().putString(key, value).apply()
+    }
+
+    actual override fun load(key: String): String? = prefs.getString(key, null)
+
+    actual override fun delete(key: String) {
+        prefs.edit().remove(key).apply()
+    }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/api/OpenFoodFactsClientTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/api/OpenFoodFactsClientTest.kt
@@ -1,0 +1,162 @@
+package com.bissbilanz.api
+
+import com.bissbilanz.api.generated.model.OpenFoodFactsProduct
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class OpenFoodFactsClientTest {
+    // Realistic OFF v2 response shape: mixed number/string nutriments, per-100g keys.
+    private val fixture =
+        """
+        {
+          "code": "7622210449283",
+          "status": 1,
+          "status_verbose": "product found",
+          "product": {
+            "product_name": "Prince Chocolat",
+            "brands": "LU,Mondelez",
+            "nutriscore_grade": "d",
+            "nova_group": 4,
+            "additives_tags": ["en:e322", "en:e500"],
+            "ingredients_text": "Getreide 50,7 % (Weizenmehl, Vollkornweizenmehl 14,5 %), Zucker",
+            "image_front_url": "https://images.openfoodfacts.org/images/products/762/221/044/9283/front_de.jpg",
+            "nutriments": {
+              "energy-kcal_100g": 467,
+              "proteins_100g": 6.3,
+              "carbohydrates_100g": 69,
+              "fat_100g": 17,
+              "fiber_100g": 4,
+              "saturated-fat_100g": 5.6,
+              "sugars_100g": "32.5",
+              "salt_100g": 0.58,
+              "sodium_100g": 0.232,
+              "calcium_100g": 0.12,
+              "iron_100g": "0.0042",
+              "vitamin-b1_100g": 0.00026,
+              "vitamin-b12_100g": 0.0000009,
+              "caffeine_100g": 0.011,
+              "alcohol_100g": 0
+            }
+          }
+        }
+        """.trimIndent()
+
+    private fun clientRespondingWith(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+        onRequest: (io.ktor.client.request.HttpRequestData) -> Unit = {},
+    ): OpenFoodFactsClient {
+        val engine =
+            MockEngine { request ->
+                onRequest(request)
+                respond(
+                    content = body,
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+        return OpenFoodFactsClient(engine)
+    }
+
+    @Test
+    fun fetchProductMapsOffFieldsLikeTheServerProxy() =
+        runTest {
+            val client = clientRespondingWith(fixture)
+
+            val product = client.fetchProduct("7622210449283")
+
+            checkNotNull(product)
+            assertEquals("7622210449283", product.id)
+            assertEquals("7622210449283", product.barcode)
+            assertEquals("Prince Chocolat", product.name)
+            assertEquals("LU,Mondelez", product.brand)
+            assertEquals(OpenFoodFactsProduct.NutriScore.d, product.nutriScore)
+            assertEquals(4.0, product.novaGroup)
+            assertEquals(listOf("en:e322", "en:e500"), product.additives)
+            assertEquals(
+                "https://images.openfoodfacts.org/images/products/762/221/044/9283/front_de.jpg",
+                product.imageUrl,
+            )
+            assertTrue(product.ingredientsText!!.startsWith("Getreide"))
+
+            // Core macros: per 100 g, no conversion.
+            assertEquals(100.0, product.servingSize)
+            assertEquals("g", product.servingUnit)
+            assertEquals(467.0, product.calories)
+            assertEquals(6.3, product.protein)
+            assertEquals(69.0, product.carbs)
+            assertEquals(17.0, product.fat)
+            assertEquals(4.0, product.fiber)
+
+            // Extended nutrients: unit conversion + 2-decimal rounding, strings parsed.
+            assertEquals(5.6, product.saturatedFat)
+            assertEquals(32.5, product.sugar)
+            assertEquals(0.58, product.salt)
+            assertEquals(232.0, product.sodium) // g -> mg
+            assertEquals(120.0, product.calcium) // g -> mg
+            assertEquals(4.2, product.iron) // string g -> mg
+            assertEquals(0.26, product.vitaminB1) // g -> mg, rounded
+            assertEquals(0.9, product.vitaminB12) // g -> µg
+            assertEquals(11.0, product.caffeine) // g -> mg
+            assertEquals(0.0, product.alcohol)
+            // Missing nutriments stay null.
+            assertNull(product.transFat)
+            assertNull(product.vitaminC)
+        }
+
+    @Test
+    fun fetchProductSendsUserAgentAndFieldsToOffApi() =
+        runTest {
+            var requestedUrl = ""
+            var userAgent: String? = null
+            val client =
+                clientRespondingWith(fixture) { request ->
+                    requestedUrl = request.url.toString()
+                    userAgent = request.headers[HttpHeaders.UserAgent]
+                }
+
+            client.fetchProduct("7622210449283")
+
+            assertTrue(requestedUrl.startsWith("https://world.openfoodfacts.org/api/v2/product/7622210449283.json"))
+            assertTrue(requestedUrl.contains("fields="))
+            assertEquals("Bissbilanz/1.0 (https://bissbilanz.orellbuehler.ch)", userAgent)
+        }
+
+    @Test
+    fun fetchProductReturnsNullWhenProductNotFound() =
+        runTest {
+            val client = clientRespondingWith("""{"code":"0000","status":0,"status_verbose":"product not found"}""")
+
+            assertNull(client.fetchProduct("0000"))
+        }
+
+    @Test
+    fun fetchProductReturnsNullOnHttpError() =
+        runTest {
+            val client = clientRespondingWith("not found", status = HttpStatusCode.NotFound)
+
+            assertNull(client.fetchProduct("0000"))
+        }
+
+    @Test
+    fun fetchProductDefaultsMissingNameAndMacrosLikeTheProxy() =
+        runTest {
+            val sparse = """{"status":1,"product":{"nutriments":{}}}"""
+            val client = clientRespondingWith(sparse)
+
+            val product = client.fetchProduct("123")
+
+            checkNotNull(product)
+            assertEquals("", product.name)
+            assertEquals("", product.brand)
+            assertEquals(0.0, product.calories)
+            assertEquals(emptyList(), product.additives)
+            assertNull(product.nutriScore)
+            assertNull(product.ingredientsText)
+        }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/cache/LocalDataWiperTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/cache/LocalDataWiperTest.kt
@@ -1,0 +1,123 @@
+package com.bissbilanz.cache
+
+import com.bissbilanz.sync.SyncOperation
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Deliberate logout must leave nothing behind: no user rows that could leak into the
+ * next account, no queued uploads, no sync markers (including `migration_normalized`).
+ */
+class LocalDataWiperTest {
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
+    private lateinit var syncQueue: SyncQueue
+    private lateinit var wiper: LocalDataWiper
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val queries get() = db.userDataDatabaseQueries
+    private val cacheQueries get() = cacheDb.bissbilanzDatabaseQueries
+
+    @BeforeTest
+    fun setup() {
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
+        syncQueue = SyncQueue(cacheDb, json, appModeManager())
+        wiper = LocalDataWiper(db, cacheDb, syncQueue)
+    }
+
+    @Test
+    fun wipeAllClearsEveryUserTableTheQueueAndAllSyncMeta() =
+        runTest {
+            seedEverything()
+
+            wiper.wipeAll()
+
+            assertTrue(queries.selectAllEntries().executeAsList().isEmpty())
+            assertTrue(queries.selectAllFoods().executeAsList().isEmpty())
+            assertNull(queries.selectGoals().executeAsOneOrNull())
+            assertTrue(queries.selectAllRecipes().executeAsList().isEmpty())
+            assertTrue(queries.selectAllSupplements().executeAsList().isEmpty())
+            assertTrue(queries.selectAllSupplementLogs().executeAsList().isEmpty())
+            assertTrue(queries.selectAllWeightEntries().executeAsList().isEmpty())
+            assertTrue(queries.selectAllSleepEntries().executeAsList().isEmpty())
+            assertNull(queries.selectPreferences().executeAsOneOrNull())
+            assertTrue(queries.selectAllDayProperties().executeAsList().isEmpty())
+            assertEquals(0L, syncQueue.pendingCount())
+            assertTrue(cacheQueries.selectAllMealTypes().executeAsList().isEmpty())
+            // The one-shot migration marker is gone together with all other sync meta.
+            assertNull(cacheQueries.selectSyncMeta("migration_normalized").executeAsOneOrNull())
+            assertNull(cacheQueries.selectSyncMeta("foods").executeAsOneOrNull())
+        }
+
+    private suspend fun seedEverything() {
+        queries.insertEntry(
+            id = "e1",
+            date = "2024-01-15",
+            mealType = "lunch",
+            servings = 1.0,
+            foodId = "f1",
+            recipeId = null,
+            foodName = "Rice",
+            calories = 130.0,
+            protein = 2.7,
+            carbs = 28.0,
+            fat = 0.3,
+            fiber = 0.4,
+            jsonData = "{}",
+        )
+        queries.insertFood(
+            id = "f1",
+            name = "Rice",
+            brand = null,
+            calories = 130.0,
+            protein = 2.7,
+            carbs = 28.0,
+            fat = 0.3,
+            fiber = 0.4,
+            isFavorite = 0L,
+            barcode = null,
+            jsonData = "{}",
+        )
+        queries.insertGoals(2000.0, 150.0, 250.0, 65.0, 30.0)
+        queries.insertRecipe(
+            id = "r1",
+            name = "Bowl",
+            totalServings = 2.0,
+            isFavorite = 0L,
+            calories = 100.0,
+            protein = 10.0,
+            carbs = 12.0,
+            fat = 5.0,
+            fiber = 2.0,
+            jsonData = "{}",
+        )
+        queries.insertSupplement(id = "s1", name = "Iron", isActive = 1L, sortOrder = 0L, jsonData = "{}")
+        queries.insertSupplementLog(id = "s1-2024-01-15", supplementId = "s1", date = "2024-01-15", takenAt = "t")
+        queries.insertWeightEntry(id = "w1", entryDate = "2024-01-15", weightKg = 80.0, loggedAt = null, jsonData = "{}")
+        queries.insertSleepEntry(
+            id = "sl1",
+            entryDate = "2024-01-15",
+            durationMinutes = 480L,
+            quality = 4L,
+            loggedAt = null,
+            jsonData = "{}",
+        )
+        queries.insertPreferences("{}")
+        queries.upsertDayProperties("2024-01-15", 1L)
+        syncQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+        cacheQueries.insertMealType(id = "m1", name = "Brunch", sortOrder = 0L)
+        cacheQueries.upsertSyncMeta("migration_normalized", "2024-01-15T00:00:00Z")
+        cacheQueries.upsertSyncMeta("foods", "2024-01-15T00:00:00Z")
+    }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LegacyUserDataMigrationTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LegacyUserDataMigrationTest.kt
@@ -1,0 +1,178 @@
+package com.bissbilanz.migration
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.cache.LegacyUserDataMigration
+import com.bissbilanz.userdata.UserDataDatabase
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the one-time copy of user data out of the legacy single-database file
+ * (bissbilanz.db) into userdata.db. The copy routine is platform-neutral (raw
+ * [SqlDriver] handles), so it is exercised here with two in-memory JVM drivers —
+ * a real on-device AndroidSqliteDriver run is not JVM-testable.
+ */
+class LegacyUserDataMigrationTest {
+    private lateinit var source: SqlDriver
+    private lateinit var target: SqlDriver
+
+    @BeforeTest
+    fun setup() {
+        source = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        target = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        UserDataDatabase.Schema.create(target)
+    }
+
+    @AfterTest
+    fun teardown() {
+        source.close()
+        target.close()
+    }
+
+    /** Recreates the legacy bissbilanz.db layout: sync tables AND user tables in one file. */
+    private fun createLegacyLayout() {
+        BissbilanzDatabase.Schema.create(source)
+        // The user-table DDL is identical to the new userdata schema, so reuse it to
+        // create the legacy user tables (the extra LocalMeta table in the source is
+        // inert — the migration only consults the target's LocalMeta).
+        UserDataDatabase.Schema.create(source)
+    }
+
+    private fun seedSource() {
+        val legacy = UserDataDatabase(source).userDataDatabaseQueries
+        legacy.insertFood("food-1", "Apple", null, 52.0, 0.3, 14.0, 0.2, 2.4, 1L, "123456", "{}")
+        legacy.insertFood("food-2", "Rice", "Brand", 130.0, 2.7, 28.0, 0.3, 0.4, 0L, null, "{}")
+        legacy.insertEntry("entry-1", "2024-01-15", "lunch", 1.5, "food-1", null, "Apple", 78.0, 0.5, 21.0, 0.3, 3.6, "{}")
+        legacy.insertRecipe("recipe-1", "Soup", 4.0, 0L, 100.0, 10.0, 12.0, 5.0, 2.0, "{}")
+        legacy.insertSupplement("supp-1", "Magnesium", 1L, 0L, "{}")
+        legacy.insertSupplementLog("supp-1-2024-01-15", "supp-1", "2024-01-15", "2024-01-15T08:00:00Z")
+        legacy.insertWeightEntry("w-1", "2024-01-15", 80.5, "2024-01-15T07:00:00Z", "{}")
+        legacy.insertSleepEntry("s-1", "2024-01-15", 480L, 4L, null, "{}")
+        legacy.insertGoals(2000.0, 150.0, 250.0, 65.0, 30.0)
+        legacy.insertPreferences("""{"startPage":"dashboard"}""")
+        legacy.upsertDayProperties("2024-01-15", 1L)
+    }
+
+    @Test
+    fun copiesAllUserTablesWritesMarkerAndDropsLegacyTables() {
+        createLegacyLayout()
+        seedSource()
+
+        LegacyUserDataMigration.run(source, target)
+
+        val copied = UserDataDatabase(target).userDataDatabaseQueries
+        assertEquals(listOf("food-1", "food-2"), copied.selectAllFoods().executeAsList().map { it.id })
+        val food = copied.selectFoodById("food-1").executeAsOne()
+        assertEquals("Apple", food.name)
+        assertEquals(52.0, food.calories)
+        assertEquals(1L, food.isFavorite)
+        assertEquals("123456", food.barcode)
+        val entry = copied.selectAllEntries().executeAsList().single()
+        assertEquals("entry-1", entry.id)
+        assertEquals("food-1", entry.foodId)
+        assertEquals(1.5, entry.servings)
+        assertEquals(listOf("recipe-1"), copied.selectAllRecipes().executeAsList().map { it.id })
+        assertEquals(listOf("supp-1"), copied.selectAllSupplements().executeAsList().map { it.id })
+        assertEquals(listOf("supp-1-2024-01-15"), copied.selectAllSupplementLogs().executeAsList().map { it.id })
+        assertEquals(listOf("w-1"), copied.selectAllWeightEntries().executeAsList().map { it.id })
+        assertEquals(listOf("s-1"), copied.selectAllSleepEntries().executeAsList().map { it.id })
+        assertEquals(2000.0, copied.selectGoals().executeAsOne().calorieGoal)
+        assertEquals("""{"startPage":"dashboard"}""", copied.selectPreferences().executeAsOne().jsonData)
+        assertEquals(1L, copied.selectDayProperties("2024-01-15").executeAsOne().isFastingDay)
+
+        assertTrue(LegacyUserDataMigration.isCopied(target))
+        // Legacy user tables are gone from the source; the sync tables survive.
+        assertFalse(LegacyUserDataMigration.tableExists(source, "CachedFood"))
+        assertFalse(LegacyUserDataMigration.tableExists(source, "CachedEntry"))
+        assertFalse(LegacyUserDataMigration.tableExists(source, "CachedPreferences"))
+        assertTrue(LegacyUserDataMigration.tableExists(source, "SyncQueue"))
+        assertTrue(LegacyUserDataMigration.tableExists(source, "SyncMeta"))
+        assertTrue(LegacyUserDataMigration.tableExists(source, "CachedMealType"))
+    }
+
+    @Test
+    fun secondRunIsANoOpAndKeepsNewTargetRows() {
+        createLegacyLayout()
+        seedSource()
+        LegacyUserDataMigration.run(source, target)
+
+        // Data written after the migration must survive a re-run (e.g. app restart).
+        val queries = UserDataDatabase(target).userDataDatabaseQueries
+        queries.insertFood("food-3", "New", null, 1.0, 0.0, 0.0, 0.0, 0.0, 0L, null, "{}")
+
+        LegacyUserDataMigration.run(source, target)
+
+        assertEquals(
+            listOf("food-1", "food-2", "food-3"),
+            queries
+                .selectAllFoods()
+                .executeAsList()
+                .map { it.id }
+                .sorted(),
+        )
+    }
+
+    @Test
+    fun markerPreventsRecopyButLegacyTablesAreStillDropped() {
+        createLegacyLayout()
+        seedSource()
+        // Simulate a restored backup: the marker arrived inside userdata.db.
+        target.execute(null, "INSERT INTO LocalMeta(key, value) VALUES ('legacy_userdata_copied', '1')", 0)
+
+        LegacyUserDataMigration.run(source, target)
+
+        val copied = UserDataDatabase(target).userDataDatabaseQueries
+        assertTrue(copied.selectAllFoods().executeAsList().isEmpty())
+        // Cleanup of leftover legacy tables (crash between commit and drop) still runs.
+        assertFalse(LegacyUserDataMigration.tableExists(source, "CachedFood"))
+    }
+
+    @Test
+    fun freshInstallWithoutLegacyTablesJustWritesMarker() {
+        // New install: bissbilanz.db only ever had the sync/cache tables.
+        BissbilanzDatabase.Schema.create(source)
+
+        LegacyUserDataMigration.run(source, target)
+
+        assertTrue(LegacyUserDataMigration.isCopied(target))
+        assertTrue(
+            UserDataDatabase(target)
+                .userDataDatabaseQueries
+                .selectAllFoods()
+                .executeAsList()
+                .isEmpty(),
+        )
+    }
+
+    @Test
+    fun failedCopyRollsBackAndLeavesMarkerAbsent() {
+        BissbilanzDatabase.Schema.create(source)
+        // CachedEntry is valid and copied first…
+        UserDataDatabase(source.also { UserDataDatabase.Schema.create(it) })
+            .userDataDatabaseQueries
+            .insertEntry("entry-1", "2024-01-15", "lunch", 1.0, null, null, null, 0.0, 0.0, 0.0, 0.0, 0.0, "{}")
+        // …then CachedFood blows up mid-copy: replace it with an incompatible layout.
+        source.execute(null, "DROP TABLE CachedFood", 0)
+        source.execute(null, "CREATE TABLE CachedFood (id TEXT NOT NULL PRIMARY KEY)", 0)
+
+        assertFails { LegacyUserDataMigration.run(source, target) }
+
+        // The target transaction rolled back: no marker, no partial rows. The next
+        // run (after a fix/update) starts from scratch.
+        assertFalse(LegacyUserDataMigration.isCopied(target))
+        assertTrue(
+            UserDataDatabase(target)
+                .userDataDatabaseQueries
+                .selectAllEntries()
+                .executeAsList()
+                .isEmpty(),
+        )
+    }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
@@ -1,5 +1,6 @@
 package com.bissbilanz.migration
 
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.DayProperties
 import com.bissbilanz.api.generated.model.EntryCreate
@@ -17,9 +18,11 @@ import com.bissbilanz.api.generated.model.Supplement
 import com.bissbilanz.api.generated.model.SupplementBackingFood
 import com.bissbilanz.api.generated.model.SupplementCreate
 import com.bissbilanz.api.generated.model.SupplementIngredient
+import com.bissbilanz.api.generated.model.SupplementIngredientInput
 import com.bissbilanz.api.generated.model.SupplementLog
 import com.bissbilanz.api.generated.model.WeightEntry
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.cache.LocalDataWiper
 import com.bissbilanz.mode.AppMode
 import com.bissbilanz.model.Entry
 import com.bissbilanz.sync.SyncQueue
@@ -41,6 +44,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LocalDataMigratorTest {
@@ -62,8 +66,20 @@ class LocalDataMigratorTest {
         cacheDb = inMemoryCacheDatabase()
         appMode = appModeManager(AppMode.LOCAL)
         syncQueue = SyncQueue(cacheDb, json, appMode)
-        migrator = LocalDataMigrator(db, cacheDb, api, json, appMode, syncQueue, NoopErrorReporter())
+        migrator = migratorFor(db)
     }
+
+    private fun migratorFor(userDb: UserDataDatabase) =
+        LocalDataMigrator(
+            userDb,
+            cacheDb,
+            api,
+            json,
+            appMode,
+            syncQueue,
+            NoopErrorReporter(),
+            LocalDataWiper(userDb, cacheDb, syncQueue),
+        )
 
     // -------------------------------------------------------------------------------
     // plan()
@@ -413,6 +429,209 @@ class LocalDataMigratorTest {
             assertEquals(null, queries.selectGoals().executeAsOneOrNull())
             assertEquals(null, queries.selectPreferences().executeAsOneOrNull())
             assertEquals(0L, cacheQueries.countSyncQueue().executeAsOne())
+        }
+
+    // -------------------------------------------------------------------------------
+    // Locally created recipes/supplements (Local mode) carry their ingredients
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun migrateUploadsLocallyCreatedRecipeAndSupplementWithIngredients() =
+        runTest {
+            // Create everything through the repositories, exactly like the Local-mode UI.
+            val foodRepo =
+                com.bissbilanz.repository.FoodRepository(
+                    api,
+                    db,
+                    cacheDb,
+                    syncQueue,
+                    json,
+                    NoopErrorReporter(),
+                    appMode,
+                    mockk(relaxed = true),
+                    kotlinx.coroutines.Dispatchers.Unconfined,
+                )
+            val recipeRepo = com.bissbilanz.repository.RecipeRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appMode)
+            val supplementRepo =
+                com.bissbilanz.repository.SupplementRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appMode)
+
+            val food =
+                foodRepo.createFood(
+                    FoodCreate(
+                        name = "Rice",
+                        servingSize = 100.0,
+                        servingUnit = com.bissbilanz.api.generated.model.ServingUnit.g,
+                        calories = 130.0,
+                        protein = 2.7,
+                        carbs = 28.0,
+                        fat = 0.3,
+                        fiber = 0.4,
+                    ),
+                )
+            recipeRepo.createRecipe(
+                RecipeCreate(
+                    name = "Rice Bowl",
+                    totalServings = 2.0,
+                    ingredients =
+                        listOf(
+                            com.bissbilanz.api.generated.model
+                                .RecipeIngredientInput(food.id, 200.0, com.bissbilanz.api.generated.model.ServingUnit.g),
+                        ),
+                ),
+            )
+            supplementRepo.createSupplement(
+                SupplementCreate(
+                    name = "Iron",
+                    scheduleType = SupplementCreate.ScheduleType.daily,
+                    ingredients =
+                        listOf(
+                            SupplementIngredientInput(
+                                food =
+                                    FoodCreate(
+                                        name = "Iron",
+                                        servingSize = 1.0,
+                                        servingUnit = com.bissbilanz.api.generated.model.ServingUnit.g,
+                                        calories = 0.0,
+                                        protein = 0.0,
+                                        carbs = 0.0,
+                                        fat = 0.0,
+                                        fiber = 0.0,
+                                        ingredientsText = "14 mg",
+                                    ),
+                                servings = 1.0,
+                                sortOrder = 0,
+                            ),
+                        ),
+                ),
+            )
+            val captures = stubHappyApi()
+
+            migrator.migrate()
+
+            assertEquals(MigrationState.Completed, migrator.state.value)
+            // The recipe create carried its ingredient, remapped to the server food id.
+            val recipeCreate = captures.recipeCreates.single()
+            assertEquals(listOf("srv-food-1"), recipeCreate.ingredients.map { it.foodId })
+            assertEquals(listOf(200.0), recipeCreate.ingredients.map { it.quantity })
+            // The supplement create rebuilt the inline backing food.
+            val supplementIngredient =
+                captures.supplementCreates
+                    .single()
+                    .ingredients
+                    .single()
+            assertEquals(null, supplementIngredient.foodId)
+            assertEquals("Iron", supplementIngredient.food?.name)
+            assertEquals("14 mg", supplementIngredient.food?.ingredientsText)
+        }
+
+    @Test
+    fun locallyCreatedRecipeCarriesPerServingMacrosBeforeMigration() =
+        runTest {
+            val foodRepo =
+                com.bissbilanz.repository.FoodRepository(
+                    api,
+                    db,
+                    cacheDb,
+                    syncQueue,
+                    json,
+                    NoopErrorReporter(),
+                    appMode,
+                    mockk(relaxed = true),
+                    kotlinx.coroutines.Dispatchers.Unconfined,
+                )
+            val recipeRepo = com.bissbilanz.repository.RecipeRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appMode)
+
+            val food =
+                foodRepo.createFood(
+                    FoodCreate(
+                        name = "Rice",
+                        servingSize = 100.0,
+                        servingUnit = com.bissbilanz.api.generated.model.ServingUnit.g,
+                        calories = 130.0,
+                        protein = 2.7,
+                        carbs = 28.0,
+                        fat = 0.3,
+                        fiber = 0.4,
+                    ),
+                )
+            val recipe =
+                recipeRepo.createRecipe(
+                    RecipeCreate(
+                        name = "Rice Bowl",
+                        totalServings = 2.0,
+                        ingredients =
+                            listOf(
+                                com.bissbilanz.api.generated.model
+                                    .RecipeIngredientInput(food.id, 200.0, com.bissbilanz.api.generated.model.ServingUnit.g),
+                            ),
+                    ),
+                )
+
+            // Server formula: SUM(macro * quantity / servingSize) / totalServings.
+            assertEquals(130.0, recipe.calories)
+            assertEquals(2.7, recipe.protein)
+        }
+
+    @Test
+    fun migrateSkipsAndDropsIngredientLessRecipeAndSupplementInsteadOfBricking() =
+        runTest {
+            insertRecipe(
+                RecipeDetail(
+                    id = "temp_recipe-empty",
+                    userId = "user-1",
+                    name = "Shell",
+                    totalServings = 1.0,
+                    isFavorite = false,
+                    imageUrl = null,
+                    calories = 0.0,
+                    protein = 0.0,
+                    carbs = 0.0,
+                    fat = 0.0,
+                    fiber = 0.0,
+                    ingredients = emptyList(),
+                ),
+            )
+            insertSupplement(supplement("temp_supp-empty", foodId = "x").copy(ingredients = emptyList()))
+            stubHappyApi()
+
+            migrator.migrate()
+
+            assertEquals(MigrationState.Completed, migrator.state.value)
+            coVerify(exactly = 0) { api.createRecipe(any()) }
+            coVerify(exactly = 0) { api.createSupplement(any()) }
+            assertTrue(queries.selectAllRecipes().executeAsList().isEmpty())
+            assertTrue(queries.selectAllSupplements().executeAsList().isEmpty())
+        }
+
+    // -------------------------------------------------------------------------------
+    // resetNormalization()
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun resetNormalizationClearsTheMarker() {
+        cacheQueries.upsertSyncMeta("migration_normalized", "2024-01-15T00:00:00Z")
+
+        migrator.resetNormalization()
+
+        assertNull(cacheQueries.selectSyncMeta("migration_normalized").executeAsOneOrNull())
+    }
+
+    // -------------------------------------------------------------------------------
+    // Failure containment
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun migrateFailsGracefullyWhenPlanThrows() =
+        runTest {
+            val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+            UserDataDatabase.Schema.create(driver)
+            driver.execute(null, "DROP TABLE CachedFood", 0)
+            val brokenMigrator = migratorFor(UserDataDatabase(driver))
+
+            // Must not throw — a DB error surfaces as Failed state, not a crash.
+            brokenMigrator.migrate()
+
+            assertIs<MigrationState.Failed>(brokenMigrator.state.value)
         }
 
     // -------------------------------------------------------------------------------

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.migration
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.DayProperties
 import com.bissbilanz.api.generated.model.EntryCreate
@@ -27,6 +26,9 @@ import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
@@ -43,23 +45,24 @@ import kotlin.test.assertTrue
 
 class LocalDataMigratorTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private lateinit var appMode: com.bissbilanz.mode.AppModeManager
     private lateinit var syncQueue: SyncQueue
     private lateinit var migrator: LocalDataMigrator
     private val json = Json { ignoreUnknownKeys = true }
 
-    private val queries get() = db.bissbilanzDatabaseQueries
+    private val queries get() = db.userDataDatabaseQueries
+    private val cacheQueries get() = cacheDb.bissbilanzDatabaseQueries
 
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
         appMode = appModeManager(AppMode.LOCAL)
-        syncQueue = SyncQueue(db, json, appMode)
-        migrator = LocalDataMigrator(db, api, json, appMode, syncQueue, NoopErrorReporter())
+        syncQueue = SyncQueue(cacheDb, json, appMode)
+        migrator = LocalDataMigrator(db, cacheDb, api, json, appMode, syncQueue, NoopErrorReporter())
     }
 
     // -------------------------------------------------------------------------------
@@ -162,7 +165,7 @@ class LocalDataMigratorTest {
             insertPreferences()
             insertDayProperties()
             // Stale queue item that must be cleared before uploading the cache state.
-            queries.insertSyncQueueItem("{}", 0L, null, null)
+            cacheQueries.insertSyncQueueItem("{}", 0L, null, null)
 
             val captures = stubHappyApi()
 
@@ -170,7 +173,7 @@ class LocalDataMigratorTest {
 
             assertEquals(MigrationState.Completed, migrator.state.value)
             assertEquals(AppMode.SYNCED, appMode.mode.value)
-            assertEquals(0L, queries.countSyncQueue().executeAsOne())
+            assertEquals(0L, cacheQueries.countSyncQueue().executeAsOne())
 
             coVerifyOrder {
                 api.createFood(any()) // Apple
@@ -393,7 +396,7 @@ class LocalDataMigratorTest {
             insertGoals()
             insertPreferences()
             insertDayProperties()
-            queries.insertSyncQueueItem("{}", 0L, null, null)
+            cacheQueries.insertSyncQueueItem("{}", 0L, null, null)
 
             migrator.discardLocalData()
 
@@ -409,7 +412,7 @@ class LocalDataMigratorTest {
             assertTrue(queries.selectAllDayProperties().executeAsList().isEmpty())
             assertEquals(null, queries.selectGoals().executeAsOneOrNull())
             assertEquals(null, queries.selectPreferences().executeAsOneOrNull())
-            assertEquals(0L, queries.countSyncQueue().executeAsOne())
+            assertEquals(0L, cacheQueries.countSyncQueue().executeAsOne())
         }
 
     // -------------------------------------------------------------------------------

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
@@ -1,0 +1,753 @@
+package com.bissbilanz.migration
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.DayProperties
+import com.bissbilanz.api.generated.model.EntryCreate
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.api.generated.model.FoodCreate
+import com.bissbilanz.api.generated.model.FoodRecent
+import com.bissbilanz.api.generated.model.FoodsListResponse
+import com.bissbilanz.api.generated.model.Goals
+import com.bissbilanz.api.generated.model.Preferences
+import com.bissbilanz.api.generated.model.RecipeCreate
+import com.bissbilanz.api.generated.model.RecipeDetail
+import com.bissbilanz.api.generated.model.RecipeIngredient
+import com.bissbilanz.api.generated.model.SleepEntry
+import com.bissbilanz.api.generated.model.Supplement
+import com.bissbilanz.api.generated.model.SupplementBackingFood
+import com.bissbilanz.api.generated.model.SupplementCreate
+import com.bissbilanz.api.generated.model.SupplementIngredient
+import com.bissbilanz.api.generated.model.SupplementLog
+import com.bissbilanz.api.generated.model.WeightEntry
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.model.Entry
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.TestFixtures
+import com.bissbilanz.test.appModeManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class LocalDataMigratorTest {
+    private lateinit var api: BissbilanzApi
+    private lateinit var db: BissbilanzDatabase
+    private lateinit var appMode: com.bissbilanz.mode.AppModeManager
+    private lateinit var syncQueue: SyncQueue
+    private lateinit var migrator: LocalDataMigrator
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val queries get() = db.bissbilanzDatabaseQueries
+
+    @BeforeTest
+    fun setup() {
+        api = mockk()
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BissbilanzDatabase.Schema.create(driver)
+        db = BissbilanzDatabase(driver)
+        appMode = appModeManager(AppMode.LOCAL)
+        syncQueue = SyncQueue(db, json, appMode)
+        migrator = LocalDataMigrator(db, api, json, appMode, syncQueue, NoopErrorReporter())
+    }
+
+    // -------------------------------------------------------------------------------
+    // plan()
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun planCountsLocalRows() {
+        val apple = TestFixtures.food(id = "temp_food-a", name = "Apple")
+        insertFood(apple)
+        insertFood(TestFixtures.food(id = "temp_food-b", name = "Banana"))
+        insertRecipe(recipeDetail("temp_recipe-1", foodId = "temp_food-a"))
+        insertEntry(entry("temp_entry-1", foodId = "temp_food-a", food = apple))
+        insertWeight(weightEntry("temp_w-1"))
+        insertSleep(sleepEntry("temp_s-1"))
+        insertSupplement(supplement("temp_supp-1", foodId = "temp_food-b"))
+        insertSupplementLog("temp_supp-1")
+        insertGoals()
+        insertPreferences()
+        insertDayProperties()
+
+        val plan = migrator.plan()
+
+        assertEquals(2, plan.foods)
+        assertEquals(1, plan.recipes)
+        assertEquals(1, plan.entries)
+        assertEquals(1, plan.weights)
+        assertEquals(1, plan.sleepEntries)
+        assertEquals(1, plan.supplements)
+        assertEquals(1, plan.supplementLogs)
+        assertEquals(1, plan.dayProperties)
+        assertTrue(plan.hasGoals)
+        assertTrue(plan.hasPreferences)
+        assertEquals(11, plan.total)
+    }
+
+    @Test
+    fun planIsEmptyForEmptyCache() {
+        val plan = migrator.plan()
+
+        assertEquals(0, plan.total)
+        assertFalse(plan.hasGoals)
+        assertFalse(plan.hasPreferences)
+    }
+
+    // -------------------------------------------------------------------------------
+    // serverHasData()
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun serverHasDataIsTrueWhenAccountHasFoods() =
+        runTest {
+            coEvery { api.getFoodsPaginated(limit = 1, offset = 0) } returns
+                FoodsListResponse(foods = listOf(TestFixtures.food()), total = 3)
+
+            assertTrue(migrator.serverHasData())
+            coVerify(exactly = 0) { api.getRecentFoods(any()) }
+        }
+
+    @Test
+    fun serverHasDataIsTrueWhenAccountHasEntries() =
+        runTest {
+            coEvery { api.getFoodsPaginated(limit = 1, offset = 0) } returns
+                FoodsListResponse(foods = emptyList(), total = 0)
+            coEvery { api.getRecentFoods(limit = 1) } returns listOf(foodRecent("srv-food-9"))
+
+            assertTrue(migrator.serverHasData())
+        }
+
+    @Test
+    fun serverHasDataIsFalseForEmptyAccount() =
+        runTest {
+            coEvery { api.getFoodsPaginated(limit = 1, offset = 0) } returns
+                FoodsListResponse(foods = emptyList(), total = 0)
+            coEvery { api.getRecentFoods(limit = 1) } returns emptyList()
+
+            assertFalse(migrator.serverHasData())
+        }
+
+    // -------------------------------------------------------------------------------
+    // migrate(): full happy path
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun migrateUploadsCacheInDependencyOrderAndRemapsIds() =
+        runTest {
+            val apple = TestFixtures.food(id = "temp_food-a", name = "Apple")
+            val banana = TestFixtures.food(id = "temp_food-b", name = "Banana")
+            insertFood(apple)
+            insertFood(banana)
+            val recipe = recipeDetail("temp_recipe-1", foodId = "temp_food-a")
+            insertRecipe(recipe)
+            insertEntry(entry("temp_entry-1", foodId = "temp_food-a", food = apple))
+            insertEntry(entry("temp_entry-2", recipeId = "temp_recipe-1", recipe = recipe))
+            insertWeight(weightEntry("temp_w-1"))
+            insertSleep(sleepEntry("temp_s-1"))
+            insertSupplement(supplement("temp_supp-1", foodId = "temp_food-b"))
+            insertSupplementLog("temp_supp-1")
+            insertGoals()
+            insertPreferences()
+            insertDayProperties()
+            // Stale queue item that must be cleared before uploading the cache state.
+            queries.insertSyncQueueItem("{}", 0L, null, null)
+
+            val captures = stubHappyApi()
+
+            migrator.migrate()
+
+            assertEquals(MigrationState.Completed, migrator.state.value)
+            assertEquals(AppMode.SYNCED, appMode.mode.value)
+            assertEquals(0L, queries.countSyncQueue().executeAsOne())
+
+            coVerifyOrder {
+                api.createFood(any()) // Apple
+                api.createFood(any()) // Banana
+                api.createRecipe(any())
+                api.createEntry(any())
+                api.createEntry(any())
+                api.createWeightEntry(any())
+                api.createSleepEntry(any())
+                api.createSupplement(any())
+                api.logSupplement(any(), any())
+                api.setGoals(any())
+                api.updatePreferences(any())
+                api.setDayProperties(any(), any())
+            }
+
+            // The recipe was uploaded with Apple's server id…
+            assertEquals(
+                listOf("srv-food-1"),
+                captures.recipeCreates
+                    .single()
+                    .ingredients
+                    .map { it.foodId },
+            )
+            // …the entries reference the server food/recipe ids…
+            assertEquals("srv-food-1", captures.entryCreates[0].foodId)
+            assertEquals("srv-recipe-1", captures.entryCreates[1].recipeId)
+            // …the supplement references Banana's server id and its log the server supplement id.
+            assertEquals(
+                listOf("srv-food-2"),
+                captures.supplementCreates
+                    .single()
+                    .ingredients
+                    .map { it.foodId },
+            )
+            coVerify { api.logSupplement("srv-supp-1", "2024-01-15") }
+            coVerify { api.setGoals(Goals(2000.0, 150.0, 250.0, 65.0, 30.0)) }
+            coVerify { api.setDayProperties("2024-01-15", true) }
+
+            // Local rows were re-keyed to the server ids.
+            assertEquals(
+                setOf("srv-food-1", "srv-food-2"),
+                queries
+                    .selectAllFoods()
+                    .executeAsList()
+                    .map { it.id }
+                    .toSet(),
+            )
+            assertEquals(listOf("srv-recipe-1"), queries.selectAllRecipes().executeAsList().map { it.id })
+            assertEquals(
+                setOf("srv-entry-1", "srv-entry-2"),
+                queries
+                    .selectAllEntries()
+                    .executeAsList()
+                    .map { it.id }
+                    .toSet(),
+            )
+            assertEquals(listOf("srv-weight-1"), queries.selectAllWeightEntries().executeAsList().map { it.id })
+            assertEquals(listOf("srv-sleep-1"), queries.selectAllSleepEntries().executeAsList().map { it.id })
+            assertEquals(listOf("srv-supp-1"), queries.selectAllSupplements().executeAsList().map { it.id })
+            assertEquals(
+                listOf("srv-supp-1-2024-01-15"),
+                queries.selectAllSupplementLogs().executeAsList().map { it.id },
+            )
+
+            // The embedded jsonData was rewritten alongside the columns.
+            val foodEntryRow = queries.selectAllEntries().executeAsList().first { it.foodId != null }
+            val decoded = json.decodeFromString<Entry>(foodEntryRow.jsonData)
+            assertEquals(foodEntryRow.id, decoded.id)
+            assertEquals("srv-food-1", decoded.foodId)
+        }
+
+    // -------------------------------------------------------------------------------
+    // migrate(): failure + resume
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun migrateResumesAfterFailureUploadingOnlyRemainingTempRows() =
+        runTest {
+            val apple = TestFixtures.food(id = "temp_food-a", name = "Apple")
+            insertFood(apple)
+            val recipe = recipeDetail("temp_recipe-1", foodId = "temp_food-a")
+            insertRecipe(recipe)
+            insertEntry(entry("temp_entry-1", foodId = "temp_food-a", food = apple))
+            insertEntry(entry("temp_entry-2", recipeId = "temp_recipe-1", recipe = recipe))
+
+            stubHappyApi()
+            coEvery { api.createEntry(any()) } returns
+                serverEntry("srv-entry-1", foodId = "srv-food-1") andThenThrows
+                RuntimeException("network down")
+
+            migrator.migrate()
+
+            val failed = migrator.state.value
+            assertIs<MigrationState.Failed>(failed)
+            assertEquals("network down", failed.message)
+            assertEquals(AppMode.LOCAL, appMode.mode.value)
+            // Partial progress is persisted: food and recipe already carry server ids…
+            assertEquals(listOf("srv-food-1"), queries.selectAllFoods().executeAsList().map { it.id })
+            assertEquals(listOf("srv-recipe-1"), queries.selectAllRecipes().executeAsList().map { it.id })
+            // …the first entry was uploaded, the second is still local.
+            val entryIds = queries.selectAllEntries().executeAsList().map { it.id }
+            assertTrue("srv-entry-1" in entryIds)
+            assertEquals(1, entryIds.count { it.startsWith("temp_") })
+
+            // Second run: only the remaining temp entry is uploaded.
+            val entryCreates = mutableListOf<EntryCreate>()
+            coEvery { api.createEntry(capture(entryCreates)) } answers {
+                serverEntry("srv-entry-2", recipeId = entryCreates.last().recipeId)
+            }
+
+            migrator.migrate()
+
+            assertEquals(MigrationState.Completed, migrator.state.value)
+            assertEquals(AppMode.SYNCED, appMode.mode.value)
+            assertEquals("srv-recipe-1", entryCreates.single().recipeId)
+            coVerify(exactly = 1) { api.createFood(any()) }
+            coVerify(exactly = 1) { api.createRecipe(any()) }
+        }
+
+    @Test
+    fun failedRunLeavesRekeyedRowsWithConsistentReferences() =
+        runTest {
+            // Stale rows from an earlier synced session (no temp_ prefix).
+            val oldFood = TestFixtures.food(id = "old-food-1", name = "Apple")
+            insertFood(oldFood)
+            insertRecipe(recipeDetail("old-recipe-1", foodId = "old-food-1"))
+            insertEntry(entry("old-entry-1", foodId = "old-food-1", food = oldFood))
+            insertSupplement(supplement("old-supp-1", foodId = "old-food-1"))
+            insertSupplementLog("old-supp-1")
+            coEvery { api.createFood(any()) } throws RuntimeException("offline")
+
+            migrator.migrate()
+
+            assertIs<MigrationState.Failed>(migrator.state.value)
+            assertEquals(AppMode.LOCAL, appMode.mode.value)
+
+            // Everything was re-keyed to temp ids with consistent references.
+            val foodId =
+                queries
+                    .selectAllFoods()
+                    .executeAsList()
+                    .single()
+                    .id
+            assertTrue(foodId.startsWith("temp_"))
+            val entryRow = queries.selectAllEntries().executeAsList().single()
+            assertTrue(entryRow.id.startsWith("temp_"))
+            assertEquals(foodId, entryRow.foodId)
+            assertEquals(foodId, json.decodeFromString<Entry>(entryRow.jsonData).foodId)
+            val recipeRow = queries.selectAllRecipes().executeAsList().single()
+            assertTrue(recipeRow.id.startsWith("temp_"))
+            assertEquals(
+                listOf(foodId),
+                json.decodeFromString<RecipeDetail>(recipeRow.jsonData).ingredients.map { it.foodId },
+            )
+            val supplementRow = queries.selectAllSupplements().executeAsList().single()
+            assertTrue(supplementRow.id.startsWith("temp_"))
+            assertEquals(
+                listOf(foodId),
+                json.decodeFromString<Supplement>(supplementRow.jsonData).ingredients.map { it.foodId },
+            )
+            val logRow = queries.selectAllSupplementLogs().executeAsList().single()
+            assertEquals(supplementRow.id, logRow.supplementId)
+            assertEquals("${supplementRow.id}-2024-01-15", logRow.id)
+        }
+
+    @Test
+    fun migrateRekeysAndUploadsRowsFromAnEarlierSyncedSession() =
+        runTest {
+            val oldFood = TestFixtures.food(id = "old-food-1", name = "Apple")
+            insertFood(oldFood)
+            insertRecipe(recipeDetail("old-recipe-1", foodId = "old-food-1"))
+            insertEntry(entry("old-entry-1", foodId = "old-food-1", food = oldFood))
+            insertSupplement(supplement("old-supp-1", foodId = "old-food-1"))
+            insertSupplementLog("old-supp-1")
+
+            val captures = stubHappyApi()
+
+            migrator.migrate()
+
+            assertEquals(MigrationState.Completed, migrator.state.value)
+            assertEquals(AppMode.SYNCED, appMode.mode.value)
+            coVerify(exactly = 1) { api.createFood(any()) }
+            coVerify(exactly = 1) { api.createRecipe(any()) }
+            coVerify(exactly = 1) { api.createEntry(any()) }
+            coVerify(exactly = 1) { api.createSupplement(any()) }
+            coVerify { api.logSupplement("srv-supp-1", "2024-01-15") }
+            assertEquals(
+                listOf("srv-food-1"),
+                captures.recipeCreates
+                    .single()
+                    .ingredients
+                    .map { it.foodId },
+            )
+            assertEquals("srv-food-1", captures.entryCreates.single().foodId)
+            assertEquals(
+                listOf("srv-food-1"),
+                captures.supplementCreates
+                    .single()
+                    .ingredients
+                    .map { it.foodId },
+            )
+        }
+
+    // -------------------------------------------------------------------------------
+    // discardLocalData()
+    // -------------------------------------------------------------------------------
+
+    @Test
+    fun discardLocalDataWipesTablesAndFlipsMode() =
+        runTest {
+            val apple = TestFixtures.food(id = "temp_food-a", name = "Apple")
+            insertFood(apple)
+            insertRecipe(recipeDetail("temp_recipe-1", foodId = "temp_food-a"))
+            insertEntry(entry("temp_entry-1", foodId = "temp_food-a", food = apple))
+            insertWeight(weightEntry("temp_w-1"))
+            insertSleep(sleepEntry("temp_s-1"))
+            insertSupplement(supplement("temp_supp-1", foodId = "temp_food-a"))
+            insertSupplementLog("temp_supp-1")
+            insertGoals()
+            insertPreferences()
+            insertDayProperties()
+            queries.insertSyncQueueItem("{}", 0L, null, null)
+
+            migrator.discardLocalData()
+
+            assertEquals(AppMode.SYNCED, appMode.mode.value)
+            assertEquals(0, migrator.plan().total)
+            assertTrue(queries.selectAllFoods().executeAsList().isEmpty())
+            assertTrue(queries.selectAllEntries().executeAsList().isEmpty())
+            assertTrue(queries.selectAllRecipes().executeAsList().isEmpty())
+            assertTrue(queries.selectAllSupplements().executeAsList().isEmpty())
+            assertTrue(queries.selectAllSupplementLogs().executeAsList().isEmpty())
+            assertTrue(queries.selectAllWeightEntries().executeAsList().isEmpty())
+            assertTrue(queries.selectAllSleepEntries().executeAsList().isEmpty())
+            assertTrue(queries.selectAllDayProperties().executeAsList().isEmpty())
+            assertEquals(null, queries.selectGoals().executeAsOneOrNull())
+            assertEquals(null, queries.selectPreferences().executeAsOneOrNull())
+            assertEquals(0L, queries.countSyncQueue().executeAsOne())
+        }
+
+    // -------------------------------------------------------------------------------
+    // API stubbing
+    // -------------------------------------------------------------------------------
+
+    private class ApiCaptures(
+        val foodCreates: MutableList<FoodCreate>,
+        val recipeCreates: MutableList<RecipeCreate>,
+        val entryCreates: MutableList<EntryCreate>,
+        val supplementCreates: MutableList<SupplementCreate>,
+    )
+
+    /** Stubs every create endpoint to succeed with `srv-…` ids, capturing the payloads. */
+    private fun stubHappyApi(): ApiCaptures {
+        val foodCreates = mutableListOf<FoodCreate>()
+        val recipeCreates = mutableListOf<RecipeCreate>()
+        val entryCreates = mutableListOf<EntryCreate>()
+        val supplementCreates = mutableListOf<SupplementCreate>()
+        coEvery { api.createFood(capture(foodCreates)) } answers {
+            TestFixtures.food(id = "srv-food-${foodCreates.size}", name = foodCreates.last().name)
+        }
+        coEvery { api.createRecipe(capture(recipeCreates)) } answers {
+            recipeDetail(
+                id = "srv-recipe-${recipeCreates.size}",
+                foodId =
+                    recipeCreates
+                        .last()
+                        .ingredients
+                        .firstOrNull()
+                        ?.foodId ?: "srv-food-1",
+                name = recipeCreates.last().name,
+            )
+        }
+        coEvery { api.createEntry(capture(entryCreates)) } answers {
+            serverEntry(
+                id = "srv-entry-${entryCreates.size}",
+                foodId = entryCreates.last().foodId,
+                recipeId = entryCreates.last().recipeId,
+            )
+        }
+        coEvery { api.createWeightEntry(any()) } returns weightEntry("srv-weight-1")
+        coEvery { api.createSleepEntry(any()) } returns sleepEntry("srv-sleep-1")
+        coEvery { api.createSupplement(capture(supplementCreates)) } answers {
+            supplement(
+                id = "srv-supp-${supplementCreates.size}",
+                foodId =
+                    supplementCreates
+                        .last()
+                        .ingredients
+                        .firstOrNull()
+                        ?.foodId ?: "srv-food-1",
+            )
+        }
+        coEvery { api.logSupplement(any(), any()) } answers {
+            SupplementLog(
+                supplementId = firstArg(),
+                date = secondArg() ?: "2024-01-15",
+                takenAt = "2024-01-15T08:00:00Z",
+                entryIds = emptyList(),
+            )
+        }
+        coEvery { api.setGoals(any()) } answers { firstArg() }
+        coEvery { api.updatePreferences(any()) } returns preferences()
+        coEvery { api.setDayProperties(any(), any()) } answers { DayProperties(firstArg(), secondArg()) }
+        return ApiCaptures(foodCreates, recipeCreates, entryCreates, supplementCreates)
+    }
+
+    // -------------------------------------------------------------------------------
+    // Fixtures + row insertion (mirrors how the repositories cache rows)
+    // -------------------------------------------------------------------------------
+
+    private fun insertFood(food: Food) {
+        queries.insertFood(
+            id = food.id,
+            name = food.name,
+            brand = food.brand,
+            calories = food.calories,
+            protein = food.protein,
+            carbs = food.carbs,
+            fat = food.fat,
+            fiber = food.fiber,
+            isFavorite = if (food.isFavorite) 1L else 0L,
+            barcode = food.barcode,
+            jsonData = json.encodeToString(food),
+        )
+    }
+
+    private fun recipeDetail(
+        id: String,
+        foodId: String,
+        name: String = "Recipe",
+    ) = RecipeDetail(
+        id = id,
+        userId = "user-1",
+        name = name,
+        totalServings = 4.0,
+        isFavorite = false,
+        imageUrl = null,
+        calories = 100.0,
+        protein = 10.0,
+        carbs = 12.0,
+        fat = 5.0,
+        fiber = 2.0,
+        ingredients =
+            listOf(
+                RecipeIngredient(
+                    foodId = foodId,
+                    quantity = 100.0,
+                    servingUnit = RecipeIngredient.ServingUnit.g,
+                    sortOrder = 0,
+                ),
+            ),
+    )
+
+    private fun insertRecipe(recipe: RecipeDetail) {
+        queries.insertRecipe(
+            id = recipe.id,
+            name = recipe.name,
+            totalServings = recipe.totalServings,
+            isFavorite = if (recipe.isFavorite) 1L else 0L,
+            calories = recipe.calories,
+            protein = recipe.protein,
+            carbs = recipe.carbs,
+            fat = recipe.fat,
+            fiber = recipe.fiber,
+            jsonData = json.encodeToString(recipe),
+        )
+    }
+
+    private fun entry(
+        id: String,
+        foodId: String? = null,
+        recipeId: String? = null,
+        food: Food? = null,
+        recipe: RecipeDetail? = null,
+    ) = Entry(
+        id = id,
+        foodId = foodId,
+        recipeId = recipeId,
+        date = "2024-01-15",
+        mealType = "lunch",
+        servings = 1.0,
+        food = food,
+        recipe = recipe,
+    )
+
+    private fun serverEntry(
+        id: String,
+        foodId: String? = null,
+        recipeId: String? = null,
+    ) = Entry(
+        id = id,
+        userId = "user-1",
+        foodId = foodId,
+        recipeId = recipeId,
+        date = "2024-01-15",
+        mealType = "lunch",
+        servings = 1.0,
+        createdAt = "2024-01-15T12:00:00Z",
+        updatedAt = "2024-01-15T12:00:00Z",
+    )
+
+    private fun insertEntry(entry: Entry) {
+        queries.insertEntry(
+            id = entry.id,
+            date = entry.date,
+            mealType = entry.mealType,
+            servings = entry.servings,
+            foodId = entry.foodId,
+            recipeId = entry.recipeId,
+            foodName = entry.food?.name ?: entry.recipe?.name,
+            calories = 0.0,
+            protein = 0.0,
+            carbs = 0.0,
+            fat = 0.0,
+            fiber = 0.0,
+            jsonData = json.encodeToString(entry),
+        )
+    }
+
+    private fun weightEntry(id: String) =
+        WeightEntry(
+            id = id,
+            userId = "user-1",
+            weightKg = 80.0,
+            entryDate = "2024-01-15",
+            notes = null,
+            loggedAt = "2024-01-15T08:00:00Z",
+        )
+
+    private fun insertWeight(weight: WeightEntry) {
+        queries.insertWeightEntry(
+            id = weight.id,
+            entryDate = weight.entryDate,
+            weightKg = weight.weightKg,
+            loggedAt = weight.loggedAt,
+            jsonData = json.encodeToString(weight),
+        )
+    }
+
+    private fun sleepEntry(id: String) =
+        SleepEntry(
+            id = id,
+            userId = "user-1",
+            entryDate = "2024-01-15",
+            durationMinutes = 480,
+            quality = 4,
+            bedtime = null,
+            wakeTime = null,
+            wakeUps = null,
+            sleepLatencyMinutes = null,
+            deepSleepMinutes = null,
+            lightSleepMinutes = null,
+            remSleepMinutes = null,
+            source = null,
+            notes = null,
+            loggedAt = "2024-01-15T08:00:00Z",
+        )
+
+    private fun insertSleep(sleep: SleepEntry) {
+        queries.insertSleepEntry(
+            id = sleep.id,
+            entryDate = sleep.entryDate,
+            durationMinutes = sleep.durationMinutes.toLong(),
+            quality = sleep.quality.toLong(),
+            loggedAt = sleep.loggedAt,
+            jsonData = json.encodeToString(sleep),
+        )
+    }
+
+    private fun supplement(
+        id: String,
+        foodId: String,
+    ) = Supplement(
+        id = id,
+        userId = "user-1",
+        name = "Supp",
+        scheduleType = Supplement.ScheduleType.daily,
+        scheduleDays = null,
+        scheduleStartDate = null,
+        isActive = true,
+        sortOrder = 0,
+        timeOfDay = null,
+        ingredients =
+            listOf(
+                SupplementIngredient(
+                    id = "si-1",
+                    supplementId = id,
+                    foodId = foodId,
+                    servings = 1.0,
+                    sortOrder = 0,
+                    food =
+                        SupplementBackingFood(
+                            id = foodId,
+                            name = "Backing",
+                            brand = null,
+                            kind = SupplementBackingFood.Kind.supplement,
+                            servingSize = 1.0,
+                            servingUnit = "g",
+                            calories = 0.0,
+                            protein = 0.0,
+                            carbs = 0.0,
+                            fat = 0.0,
+                            fiber = 0.0,
+                        ),
+                ),
+            ),
+    )
+
+    private fun insertSupplement(supplement: Supplement) {
+        queries.insertSupplement(
+            id = supplement.id,
+            name = supplement.name,
+            isActive = if (supplement.isActive) 1L else 0L,
+            sortOrder = supplement.sortOrder.toLong(),
+            jsonData = json.encodeToString(supplement),
+        )
+    }
+
+    private fun insertSupplementLog(
+        supplementId: String,
+        date: String = "2024-01-15",
+    ) {
+        queries.insertSupplementLog(
+            id = "$supplementId-$date",
+            supplementId = supplementId,
+            date = date,
+            takenAt = "${date}T08:00:00Z",
+        )
+    }
+
+    private fun insertGoals() {
+        queries.insertGoals(2000.0, 150.0, 250.0, 65.0, 30.0)
+    }
+
+    private fun preferences() =
+        Preferences(
+            showChartWidget = true,
+            showFavoritesWidget = true,
+            showSupplementsWidget = false,
+            showWeightWidget = true,
+            showMealBreakdownWidget = true,
+            showTopFoodsWidget = false,
+            showSleepWidget = true,
+            widgetOrder = listOf("chart"),
+            mealOrder = listOf("breakfast", "lunch"),
+            startPage = "dashboard",
+            favoriteTapAction = "log",
+            favoriteMealAssignmentMode = "auto",
+            visibleNutrients = listOf("calories"),
+            locale = "en",
+            favoriteMealTimeframes = emptyList(),
+        )
+
+    private fun insertPreferences() {
+        queries.insertPreferences(json.encodeToString(preferences()))
+    }
+
+    private fun insertDayProperties(date: String = "2024-01-15") {
+        queries.upsertDayProperties(date, 1L)
+    }
+
+    private fun foodRecent(id: String) =
+        FoodRecent(
+            id = id,
+            userId = "user-1",
+            name = "Recent Food",
+            brand = null,
+            servingSize = 100.0,
+            servingUnit = FoodRecent.ServingUnit.g,
+            calories = 100.0,
+            protein = 10.0,
+            carbs = 10.0,
+            fat = 5.0,
+            fiber = 1.0,
+            barcode = null,
+            isFavorite = false,
+            imageUrl = null,
+        )
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/mode/AppModeManagerTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/mode/AppModeManagerTest.kt
@@ -1,0 +1,85 @@
+package com.bissbilanz.mode
+
+import com.bissbilanz.test.FakeKeyValueStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AppModeManagerTest {
+    @Test
+    fun modeIsNullBeforeInitialize() {
+        val manager = AppModeManager(FakeKeyValueStore())
+
+        assertNull(manager.mode.value)
+        assertFalse(manager.isLocal)
+    }
+
+    @Test
+    fun initializeLoadsNullWhenNothingPersisted() {
+        val manager = AppModeManager(FakeKeyValueStore())
+
+        manager.initialize()
+
+        assertNull(manager.mode.value)
+        assertFalse(manager.isLocal)
+    }
+
+    @Test
+    fun setModePersistsAndEmits() {
+        val store = FakeKeyValueStore()
+        val manager = AppModeManager(store)
+
+        manager.setMode(AppMode.LOCAL)
+
+        assertEquals(AppMode.LOCAL, manager.mode.value)
+        assertTrue(manager.isLocal)
+        assertEquals("LOCAL", store.values["app_mode"])
+    }
+
+    @Test
+    fun initializeLoadsPersistedMode() {
+        val store = FakeKeyValueStore()
+        AppModeManager(store).setMode(AppMode.SYNCED)
+
+        val fresh = AppModeManager(store)
+        fresh.initialize()
+
+        assertEquals(AppMode.SYNCED, fresh.mode.value)
+        assertFalse(fresh.isLocal)
+    }
+
+    @Test
+    fun initializeIgnoresUnknownPersistedValue() {
+        val store = FakeKeyValueStore()
+        store.save("app_mode", "SOMETHING_ELSE")
+
+        val manager = AppModeManager(store)
+        manager.initialize()
+
+        assertNull(manager.mode.value)
+    }
+
+    @Test
+    fun clearDeletesPersistedModeAndEmitsNull() {
+        val store = FakeKeyValueStore()
+        val manager = AppModeManager(store)
+        manager.setMode(AppMode.LOCAL)
+
+        manager.clear()
+
+        assertNull(manager.mode.value)
+        assertFalse(manager.isLocal)
+        assertNull(store.values["app_mode"])
+    }
+
+    @Test
+    fun syncedModeIsNotLocal() {
+        val manager = AppModeManager(FakeKeyValueStore())
+
+        manager.setMode(AppMode.SYNCED)
+
+        assertFalse(manager.isLocal)
+    }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/DayPropertiesRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/DayPropertiesRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.repository
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.DayProperties
@@ -10,6 +9,9 @@ import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -22,15 +24,15 @@ import kotlin.test.assertTrue
 
 class DayPropertiesRepositoryTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private val json = Json { ignoreUnknownKeys = true }
 
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
     }
 
     private fun repository(
@@ -40,6 +42,7 @@ class DayPropertiesRepositoryTest {
         EntryRepository(
             api,
             db,
+            cacheDb,
             mockk<HealthSyncService>(relaxed = true),
             syncQueue,
             json,
@@ -51,7 +54,7 @@ class DayPropertiesRepositoryTest {
     fun localModeSetGetDeleteRoundTripsViaCacheWithEmptyQueue() =
         runTest {
             val localMode = appModeManager(AppMode.LOCAL)
-            val syncQueue = SyncQueue(db, json, localMode)
+            val syncQueue = SyncQueue(cacheDb, json, localMode)
             val repo = repository(AppMode.LOCAL, syncQueue)
 
             // Strict api mock: any API call would fail the test.
@@ -70,7 +73,7 @@ class DayPropertiesRepositoryTest {
     @Test
     fun syncedSetEnqueuesSetDayProperties() =
         runTest {
-            val syncQueue = SyncQueue(db, json, appModeManager(AppMode.SYNCED))
+            val syncQueue = SyncQueue(cacheDb, json, appModeManager(AppMode.SYNCED))
             val repo = repository(AppMode.SYNCED, syncQueue)
 
             repo.setDayProperties("2024-01-15", isFastingDay = true)
@@ -84,7 +87,7 @@ class DayPropertiesRepositoryTest {
     @Test
     fun syncedDeleteEnqueuesDeleteDayProperties() =
         runTest {
-            val syncQueue = SyncQueue(db, json, appModeManager(AppMode.SYNCED))
+            val syncQueue = SyncQueue(cacheDb, json, appModeManager(AppMode.SYNCED))
             val repo = repository(AppMode.SYNCED, syncQueue)
 
             repo.deleteDayProperties("2024-01-15")
@@ -97,7 +100,7 @@ class DayPropertiesRepositoryTest {
     @Test
     fun syncedGetCachesApiResultAndFallsBackToCacheOnError() =
         runTest {
-            val syncQueue = SyncQueue(db, json, appModeManager(AppMode.SYNCED))
+            val syncQueue = SyncQueue(cacheDb, json, appModeManager(AppMode.SYNCED))
             val repo = repository(AppMode.SYNCED, syncQueue)
             coEvery { api.getDayProperties("2024-01-15") } returns
                 DayProperties(date = "2024-01-15", isFastingDay = true)

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/DayPropertiesRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/DayPropertiesRepositoryTest.kt
@@ -1,0 +1,112 @@
+package com.bissbilanz.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.HealthSyncService
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.DayProperties
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.sync.SyncOperation
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.appModeManager
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DayPropertiesRepositoryTest {
+    private lateinit var api: BissbilanzApi
+    private lateinit var db: BissbilanzDatabase
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @BeforeTest
+    fun setup() {
+        api = mockk()
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BissbilanzDatabase.Schema.create(driver)
+        db = BissbilanzDatabase(driver)
+    }
+
+    private fun repository(
+        mode: AppMode?,
+        syncQueue: SyncQueue,
+    ): EntryRepository =
+        EntryRepository(
+            api,
+            db,
+            mockk<HealthSyncService>(relaxed = true),
+            syncQueue,
+            json,
+            NoopErrorReporter(),
+            appModeManager(mode),
+        )
+
+    @Test
+    fun localModeSetGetDeleteRoundTripsViaCacheWithEmptyQueue() =
+        runTest {
+            val localMode = appModeManager(AppMode.LOCAL)
+            val syncQueue = SyncQueue(db, json, localMode)
+            val repo = repository(AppMode.LOCAL, syncQueue)
+
+            // Strict api mock: any API call would fail the test.
+            assertNull(repo.getDayProperties("2024-01-15"))
+
+            val set = repo.setDayProperties("2024-01-15", isFastingDay = true)
+            assertEquals(DayProperties(date = "2024-01-15", isFastingDay = true), set)
+            assertEquals(set, repo.getDayProperties("2024-01-15"))
+
+            repo.deleteDayProperties("2024-01-15")
+            assertNull(repo.getDayProperties("2024-01-15"))
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun syncedSetEnqueuesSetDayProperties() =
+        runTest {
+            val syncQueue = SyncQueue(db, json, appModeManager(AppMode.SYNCED))
+            val repo = repository(AppMode.SYNCED, syncQueue)
+
+            repo.setDayProperties("2024-01-15", isFastingDay = true)
+
+            val queued = syncQueue.findByAffected("day_properties", "2024-01-15")
+            val op = queued.single().operation as SyncOperation.SetDayProperties
+            assertEquals("2024-01-15", op.date)
+            assertTrue(op.isFastingDay)
+        }
+
+    @Test
+    fun syncedDeleteEnqueuesDeleteDayProperties() =
+        runTest {
+            val syncQueue = SyncQueue(db, json, appModeManager(AppMode.SYNCED))
+            val repo = repository(AppMode.SYNCED, syncQueue)
+
+            repo.deleteDayProperties("2024-01-15")
+
+            val queued = syncQueue.findByAffected("day_properties", "2024-01-15")
+            val op = queued.single().operation as SyncOperation.DeleteDayProperties
+            assertEquals("2024-01-15", op.date)
+        }
+
+    @Test
+    fun syncedGetCachesApiResultAndFallsBackToCacheOnError() =
+        runTest {
+            val syncQueue = SyncQueue(db, json, appModeManager(AppMode.SYNCED))
+            val repo = repository(AppMode.SYNCED, syncQueue)
+            coEvery { api.getDayProperties("2024-01-15") } returns
+                DayProperties(date = "2024-01-15", isFastingDay = true)
+
+            val fromApi = repo.getDayProperties("2024-01-15")
+            assertEquals(true, fromApi?.isFastingDay)
+
+            coEvery { api.getDayProperties("2024-01-15") } throws RuntimeException("offline")
+            val fromCache = repo.getDayProperties("2024-01-15")
+            assertEquals(true, fromCache?.isFastingDay)
+        }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/EntryRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/EntryRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.repository
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.EntryCreate
@@ -10,6 +9,9 @@ import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -22,7 +24,8 @@ import kotlin.test.assertTrue
 
 class EntryRepositoryTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private lateinit var healthSync: HealthSyncService
     private lateinit var syncQueue: SyncQueue
     private lateinit var repository: EntryRepository
@@ -31,12 +34,11 @@ class EntryRepositoryTest {
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
         healthSync = mockk(relaxed = true)
         syncQueue = mockk(relaxed = true)
-        repository = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
+        repository = EntryRepository(api, db, cacheDb, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
     }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/EntryRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/EntryRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
+import com.bissbilanz.test.appModeManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -35,7 +36,7 @@ class EntryRepositoryTest {
         db = BissbilanzDatabase(driver)
         healthSync = mockk(relaxed = true)
         syncQueue = mockk(relaxed = true)
-        repository = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter())
+        repository = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
     }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/EntryRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/EntryRepositoryTest.kt
@@ -76,6 +76,27 @@ class EntryRepositoryTest {
             val result = repository.createEntry(create)
 
             assertTrue(result.id.startsWith("temp_"))
-            coVerify { syncQueue.enqueue(match<SyncOperation> { it is SyncOperation.CreateEntry }) }
+            coVerify {
+                syncQueue.enqueue(
+                    match<SyncOperation> { it is SyncOperation.CreateEntry && it.localId == result.id },
+                )
+            }
+        }
+
+    @Test
+    fun deleteTempEntryRemovesQueuedCreateInsteadOfEnqueuingDelete() =
+        runTest {
+            repository.deleteEntry("temp_abc")
+
+            coVerify { syncQueue.removeByAffected("entries", "temp_abc") }
+            coVerify(exactly = 0) { syncQueue.enqueue(any()) }
+        }
+
+    @Test
+    fun deleteServerEntryEnqueuesDeleteOperation() =
+        runTest {
+            repository.deleteEntry("server-1")
+
+            coVerify { syncQueue.enqueue(match<SyncOperation> { it is SyncOperation.DeleteEntry && it.id == "server-1" }) }
         }
 }

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/FoodRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/FoodRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.repository
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.OpenFoodFactsClient
 import com.bissbilanz.api.generated.model.Food
@@ -12,6 +11,9 @@ import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -27,7 +29,8 @@ import kotlin.test.assertTrue
 
 class FoodRepositoryTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private lateinit var syncQueue: SyncQueue
     private lateinit var repository: FoodRepository
     private val json = Json { ignoreUnknownKeys = true }
@@ -35,14 +38,14 @@ class FoodRepositoryTest {
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
         syncQueue = mockk(relaxed = true)
         repository =
             FoodRepository(
                 api,
                 db,
+                cacheDb,
                 syncQueue,
                 json,
                 NoopErrorReporter(),
@@ -64,7 +67,7 @@ class FoodRepositoryTest {
 
             repository.refreshFoods()
 
-            val cached = db.bissbilanzDatabaseQueries.selectAllFoods().executeAsList()
+            val cached = db.userDataDatabaseQueries.selectAllFoods().executeAsList()
             assertEquals(2, cached.size)
         }
 
@@ -138,7 +141,7 @@ class FoodRepositoryTest {
             val result = repository.findByBarcode("123456")
 
             assertEquals("Milk", result?.name)
-            val cached = db.bissbilanzDatabaseQueries.selectFoodByBarcode("123456").executeAsOneOrNull()
+            val cached = db.userDataDatabaseQueries.selectFoodByBarcode("123456").executeAsOneOrNull()
             assertNull(cached)
         }
 
@@ -184,7 +187,7 @@ class FoodRepositoryTest {
 
             repository.findByBarcode("123456")
 
-            val cached = db.bissbilanzDatabaseQueries.selectFoodByBarcode("123456").executeAsOneOrNull()
+            val cached = db.userDataDatabaseQueries.selectFoodByBarcode("123456").executeAsOneOrNull()
             assertNotNull(cached)
             assertEquals("1", cached.id)
         }
@@ -197,7 +200,7 @@ class FoodRepositoryTest {
 
             repository.deleteFood("1")
 
-            val cached = db.bissbilanzDatabaseQueries.selectFoodById("1").executeAsOneOrNull()
+            val cached = db.userDataDatabaseQueries.selectFoodById("1").executeAsOneOrNull()
             assertNull(cached)
             coVerify { syncQueue.enqueue(match<SyncOperation> { it is SyncOperation.DeleteFood && it.id == "1" }) }
         }
@@ -208,7 +211,7 @@ class FoodRepositoryTest {
     }
 
     private fun seedFoodInCache(food: Food) {
-        db.bissbilanzDatabaseQueries.insertFood(
+        db.userDataDatabaseQueries.insertFood(
             id = food.id,
             name = food.name,
             brand = food.brand,

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/FoodRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/FoodRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.bissbilanz.repository
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.OpenFoodFactsClient
 import com.bissbilanz.api.generated.model.Food
 import com.bissbilanz.api.generated.model.FoodCreate
 import com.bissbilanz.api.generated.model.ServingUnit
@@ -10,6 +11,7 @@ import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
+import com.bissbilanz.test.appModeManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -37,7 +39,17 @@ class FoodRepositoryTest {
         BissbilanzDatabase.Schema.create(driver)
         db = BissbilanzDatabase(driver)
         syncQueue = mockk(relaxed = true)
-        repository = FoodRepository(api, db, syncQueue, json, NoopErrorReporter(), kotlinx.coroutines.Dispatchers.Unconfined)
+        repository =
+            FoodRepository(
+                api,
+                db,
+                syncQueue,
+                json,
+                NoopErrorReporter(),
+                appModeManager(),
+                mockk<OpenFoodFactsClient>(relaxed = true),
+                kotlinx.coroutines.Dispatchers.Unconfined,
+            )
     }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/FoodRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/FoodRepositoryTest.kt
@@ -101,7 +101,20 @@ class FoodRepositoryTest {
 
             assertEquals("Rice", result.name)
             assertTrue(result.id.startsWith("temp_"))
-            coVerify { syncQueue.enqueue(match<SyncOperation> { it is SyncOperation.CreateFood }) }
+            coVerify {
+                syncQueue.enqueue(
+                    match<SyncOperation> { it is SyncOperation.CreateFood && it.localId == result.id },
+                )
+            }
+        }
+
+    @Test
+    fun deleteTempFoodRemovesQueuedCreateInsteadOfEnqueuingDelete() =
+        runTest {
+            repository.deleteFood("temp_abc")
+
+            coVerify { syncQueue.removeByAffected("foods", "temp_abc") }
+            coVerify(exactly = 0) { syncQueue.enqueue(any()) }
         }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/GoalsRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/GoalsRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.bissbilanz.model.Goals
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.TestFixtures
+import com.bissbilanz.test.appModeManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -30,7 +31,7 @@ class GoalsRepositoryTest {
         BissbilanzDatabase.Schema.create(driver)
         db = BissbilanzDatabase(driver)
         syncQueue = mockk(relaxed = true)
-        repository = GoalsRepository(api, db, syncQueue, json)
+        repository = GoalsRepository(api, db, syncQueue, json, appModeManager())
     }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/GoalsRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/GoalsRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.repository
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.model.Goals
@@ -8,6 +7,9 @@ import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.TestFixtures
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -19,7 +21,8 @@ import kotlin.test.assertEquals
 
 class GoalsRepositoryTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private lateinit var syncQueue: SyncQueue
     private lateinit var repository: GoalsRepository
     private val json = Json { ignoreUnknownKeys = true }
@@ -27,11 +30,10 @@ class GoalsRepositoryTest {
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
         syncQueue = mockk(relaxed = true)
-        repository = GoalsRepository(api, db, syncQueue, json, appModeManager())
+        repository = GoalsRepository(api, db, cacheDb, syncQueue, json, appModeManager())
     }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/LocalModeGatingTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/LocalModeGatingTest.kt
@@ -1,0 +1,208 @@
+package com.bissbilanz.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.HealthSyncService
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.OpenFoodFactsClient
+import com.bissbilanz.api.generated.model.EntryCreate
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.model.Entry
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.TestFixtures
+import com.bissbilanz.test.appModeManager
+import com.bissbilanz.util.decodeOrNull
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that Local mode never touches the API: the SQLite cache is the primary
+ * store, refreshes no-op, reads are served from cache, and nothing is enqueued.
+ * The [BissbilanzApi] mock is strict (not relaxed), so any API call fails the test.
+ */
+class LocalModeGatingTest {
+    private lateinit var api: BissbilanzApi
+    private lateinit var db: BissbilanzDatabase
+    private lateinit var syncQueue: SyncQueue
+    private lateinit var entryRepository: EntryRepository
+    private lateinit var foodRepository: FoodRepository
+    private val json = Json { ignoreUnknownKeys = true }
+    private val localMode = appModeManager(AppMode.LOCAL)
+
+    @BeforeTest
+    fun setup() {
+        api = mockk()
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BissbilanzDatabase.Schema.create(driver)
+        db = BissbilanzDatabase(driver)
+        syncQueue = SyncQueue(db, json, localMode)
+        val healthSync = mockk<HealthSyncService>(relaxed = true)
+        entryRepository = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), localMode)
+        foodRepository =
+            FoodRepository(
+                api,
+                db,
+                syncQueue,
+                json,
+                NoopErrorReporter(),
+                localMode,
+                mockk<OpenFoodFactsClient>(relaxed = true),
+                Dispatchers.Unconfined,
+            )
+    }
+
+    @Test
+    fun entryRefreshDoesNotCallApi() =
+        runTest {
+            // Strict api mock: any call would throw a MockKException.
+            entryRepository.refresh("2024-01-15")
+        }
+
+    @Test
+    fun foodRefreshesDoNotCallApi() =
+        runTest {
+            foodRepository.refreshFoods()
+            foodRepository.refreshFavorites()
+            foodRepository.refreshRecentFoods()
+        }
+
+    @Test
+    fun getFoodReturnsCachedWithoutApi() =
+        runTest {
+            seedFood(TestFixtures.food(id = "f1", name = "Cached Oats"))
+
+            val food = foodRepository.getFood("f1")
+
+            assertEquals("Cached Oats", food.name)
+        }
+
+    @Test
+    fun searchFoodsQueriesCacheOnly() =
+        runTest {
+            seedFood(TestFixtures.food(id = "f1", name = "Apple"))
+            seedFood(TestFixtures.food(id = "f2", name = "Apple Pie"))
+
+            val results = foodRepository.searchFoods("Apple")
+
+            assertEquals(2, results.size)
+        }
+
+    @Test
+    fun findByBarcodeIsCacheOnly() =
+        runTest {
+            seedFood(TestFixtures.food(id = "f1", name = "Milk").copy(barcode = "123456"))
+
+            assertEquals("Milk", foodRepository.findByBarcode("123456")?.name)
+            assertNull(foodRepository.findByBarcode("000000"))
+        }
+
+    @Test
+    fun fetchFoodsPaginatedServesFromCache() =
+        runTest {
+            seedFood(TestFixtures.food(id = "f1", name = "Apple"))
+            seedFood(TestFixtures.food(id = "f2", name = "Banana"))
+            seedFood(TestFixtures.food(id = "f3", name = "Carrot"))
+
+            val page = foodRepository.fetchFoodsPaginated(limit = 2, offset = 1)
+
+            assertEquals(3, page.total)
+            assertEquals(listOf("Banana", "Carrot"), page.foods.map { it.name })
+        }
+
+    @Test
+    fun createEntryWritesCacheAndLeavesQueueEmpty() =
+        runTest {
+            val create =
+                EntryCreate(
+                    foodId = "f1",
+                    mealType = "lunch",
+                    servings = 1.0,
+                    date = "2024-01-15",
+                )
+
+            val result = entryRepository.createEntry(create)
+
+            assertTrue(result.id.startsWith("temp_"))
+            val cached = db.bissbilanzDatabaseQueries.selectEntriesByDate("2024-01-15").executeAsList()
+            assertEquals(1, cached.size)
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun recentFoodsAreDerivedFromCachedEntries() =
+        runTest {
+            seedFood(TestFixtures.food(id = "f1", name = "Older Food"))
+            seedFood(TestFixtures.food(id = "f2", name = "Newer Food"))
+            seedEntry(TestFixtures.entry(id = "e1", date = "2024-01-10").copy(foodId = "f1"))
+            seedEntry(TestFixtures.entry(id = "e2", date = "2024-01-15").copy(foodId = "f2"))
+
+            foodRepository.refreshRecentFoods()
+
+            assertEquals(listOf("Newer Food", "Older Food"), foodRepository.recentFoods.value.map { it.name })
+        }
+
+    @Test
+    fun calendarStatsAreComputedFromCache() =
+        runTest {
+            val statsRepository = StatsRepository(api, db, json, NoopErrorReporter(), localMode)
+            seedEntry(TestFixtures.entry(id = "e1", date = "2024-01-10"))
+            seedEntry(TestFixtures.entry(id = "e2", date = "2024-01-10"))
+            seedEntry(TestFixtures.entry(id = "e3", date = "2024-01-15"))
+            // Entry outside the requested month must be excluded.
+            seedEntry(TestFixtures.entry(id = "e4", date = "2024-02-01"))
+
+            val days = statsRepository.getCalendarStats("2024-01")
+
+            assertEquals(listOf("2024-01-10", "2024-01-15"), days.map { it.date })
+            assertTrue(days.all { it.hasEntries })
+            // TestFixtures.entry carries a food with 200 kcal and 1 serving.
+            assertEquals(400.0, days[0].calories)
+            assertEquals(200.0, days[1].calories)
+        }
+
+    private fun seedFood(food: Food) {
+        db.bissbilanzDatabaseQueries.insertFood(
+            id = food.id,
+            name = food.name,
+            brand = food.brand,
+            calories = food.calories,
+            protein = food.protein,
+            carbs = food.carbs,
+            fat = food.fat,
+            fiber = food.fiber,
+            isFavorite = if (food.isFavorite) 1L else 0L,
+            barcode = food.barcode,
+            jsonData = json.encodeToString(food),
+        )
+    }
+
+    private fun seedEntry(entry: Entry) {
+        db.bissbilanzDatabaseQueries.insertEntry(
+            id = entry.id,
+            date = entry.date,
+            mealType = entry.mealType,
+            servings = entry.servings,
+            foodId = entry.foodId,
+            recipeId = entry.recipeId,
+            foodName = entry.food?.name,
+            calories = entry.food?.calories ?: 0.0,
+            protein = entry.food?.protein ?: 0.0,
+            carbs = entry.food?.carbs ?: 0.0,
+            fat = entry.food?.fat ?: 0.0,
+            fiber = entry.food?.fiber ?: 0.0,
+            jsonData = json.encodeToString(entry),
+        )
+        // Sanity: the entry decodes back (guards against fixture drift).
+        checkNotNull(json.decodeOrNull<Entry>(json.encodeToString(entry)))
+    }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/LocalModeGatingTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/LocalModeGatingTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.repository
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.OpenFoodFactsClient
@@ -13,6 +12,9 @@ import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +34,8 @@ import kotlin.test.assertTrue
  */
 class LocalModeGatingTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private lateinit var syncQueue: SyncQueue
     private lateinit var entryRepository: EntryRepository
     private lateinit var foodRepository: FoodRepository
@@ -42,16 +45,16 @@ class LocalModeGatingTest {
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
-        syncQueue = SyncQueue(db, json, localMode)
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
+        syncQueue = SyncQueue(cacheDb, json, localMode)
         val healthSync = mockk<HealthSyncService>(relaxed = true)
-        entryRepository = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), localMode)
+        entryRepository = EntryRepository(api, db, cacheDb, healthSync, syncQueue, json, NoopErrorReporter(), localMode)
         foodRepository =
             FoodRepository(
                 api,
                 db,
+                cacheDb,
                 syncQueue,
                 json,
                 NoopErrorReporter(),
@@ -133,7 +136,7 @@ class LocalModeGatingTest {
             val result = entryRepository.createEntry(create)
 
             assertTrue(result.id.startsWith("temp_"))
-            val cached = db.bissbilanzDatabaseQueries.selectEntriesByDate("2024-01-15").executeAsList()
+            val cached = db.userDataDatabaseQueries.selectEntriesByDate("2024-01-15").executeAsList()
             assertEquals(1, cached.size)
             assertEquals(0, syncQueue.pendingCount())
         }
@@ -171,7 +174,7 @@ class LocalModeGatingTest {
         }
 
     private fun seedFood(food: Food) {
-        db.bissbilanzDatabaseQueries.insertFood(
+        db.userDataDatabaseQueries.insertFood(
             id = food.id,
             name = food.name,
             brand = food.brand,
@@ -187,7 +190,7 @@ class LocalModeGatingTest {
     }
 
     private fun seedEntry(entry: Entry) {
-        db.bissbilanzDatabaseQueries.insertEntry(
+        db.userDataDatabaseQueries.insertEntry(
             id = entry.id,
             date = entry.date,
             mealType = entry.mealType,

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/RecipeRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/RecipeRepositoryTest.kt
@@ -1,0 +1,206 @@
+package com.bissbilanz.repository
+
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.api.generated.model.RecipeCreate
+import com.bissbilanz.api.generated.model.RecipeDetail
+import com.bissbilanz.api.generated.model.RecipeIngredientInput
+import com.bissbilanz.api.generated.model.RecipeUpdate
+import com.bissbilanz.api.generated.model.ServingUnit
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Local-mode recipes: the cache is the primary store, so a created/edited recipe must
+ * keep its ingredients and carry per-serving macros computed the same way the server
+ * computes them (sum of food.macro * quantity / food.servingSize, / totalServings).
+ */
+class RecipeRepositoryTest {
+    private lateinit var api: BissbilanzApi
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
+    private lateinit var syncQueue: SyncQueue
+    private lateinit var repository: RecipeRepository
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @BeforeTest
+    fun setup() {
+        api = mockk()
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
+        val appMode = appModeManager(AppMode.LOCAL)
+        syncQueue = SyncQueue(cacheDb, json, appMode)
+        repository = RecipeRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appMode)
+    }
+
+    private fun insertLocalFood(
+        id: String,
+        calories: Double = 130.0,
+        protein: Double = 2.7,
+        carbs: Double = 28.0,
+        fat: Double = 0.3,
+        fiber: Double = 0.4,
+        servingSize: Double = 100.0,
+    ) {
+        val food =
+            Food(
+                id = id,
+                userId = "",
+                name = "Rice",
+                servingSize = servingSize,
+                servingUnit = Food.ServingUnit.g,
+                calories = calories,
+                protein = protein,
+                carbs = carbs,
+                fat = fat,
+                fiber = fiber,
+                brand = null,
+                barcode = null,
+                isFavorite = false,
+                nutriScore = null,
+                novaGroup = null,
+                additives = null,
+                ingredientsText = null,
+                imageUrl = null,
+            )
+        db.userDataDatabaseQueries.insertFood(
+            id = food.id,
+            name = food.name,
+            brand = null,
+            calories = food.calories,
+            protein = food.protein,
+            carbs = food.carbs,
+            fat = food.fat,
+            fiber = food.fiber,
+            isFavorite = 0L,
+            barcode = null,
+            jsonData = json.encodeToString(food),
+        )
+    }
+
+    @Test
+    fun localCreateCachesIngredientsAndPerServingMacros() =
+        runTest {
+            insertLocalFood("temp_f1")
+
+            val created =
+                repository.createRecipe(
+                    RecipeCreate(
+                        name = "Rice Bowl",
+                        totalServings = 4.0,
+                        ingredients = listOf(RecipeIngredientInput("temp_f1", 200.0, ServingUnit.g)),
+                    ),
+                )
+
+            // 130 kcal/100g * 200g = 260 kcal total, / 4 servings = 65 per serving.
+            assertEquals(65.0, created.calories)
+            assertEquals(1.35, created.protein)
+            assertEquals(14.0, created.carbs)
+            assertEquals(0.15, created.fat)
+            assertEquals(0.2, created.fiber)
+            assertEquals(listOf("temp_f1"), created.ingredients.map { it.foodId })
+
+            // The cached row round-trips the full detail, not an ingredient-less shell.
+            val row = db.userDataDatabaseQueries.selectRecipeById(created.id).executeAsOneOrNull()
+            assertNotNull(row)
+            assertEquals(65.0, row.calories)
+            val decoded = json.decodeFromString<RecipeDetail>(row.jsonData)
+            assertEquals(listOf("temp_f1"), decoded.ingredients.map { it.foodId })
+            assertEquals(listOf(200.0), decoded.ingredients.map { it.quantity })
+            assertEquals(65.0, decoded.calories)
+        }
+
+    @Test
+    fun localUpdateAppliesIngredientsAndRecomputesMacros() =
+        runTest {
+            insertLocalFood("temp_f1")
+            insertLocalFood("temp_f2", calories = 400.0, protein = 10.0, carbs = 50.0, fat = 20.0, fiber = 5.0)
+            val created =
+                repository.createRecipe(
+                    RecipeCreate(
+                        name = "Rice Bowl",
+                        totalServings = 4.0,
+                        ingredients = listOf(RecipeIngredientInput("temp_f1", 200.0, ServingUnit.g)),
+                    ),
+                )
+
+            val updated =
+                repository.updateRecipe(
+                    created.id,
+                    RecipeUpdate(
+                        totalServings = 2.0,
+                        ingredients = listOf(RecipeIngredientInput("temp_f2", 100.0, ServingUnit.g)),
+                    ),
+                )
+
+            // 400 kcal/100g * 100g = 400 total, / 2 servings = 200 per serving.
+            assertEquals(200.0, updated.calories)
+            assertEquals(5.0, updated.protein)
+            assertEquals(listOf("temp_f2"), updated.ingredients.map { it.foodId })
+
+            val decoded =
+                json.decodeFromString<RecipeDetail>(
+                    db.userDataDatabaseQueries
+                        .selectRecipeById(created.id)
+                        .executeAsOneOrNull()!!
+                        .jsonData,
+                )
+            assertEquals(listOf("temp_f2"), decoded.ingredients.map { it.foodId })
+            assertEquals(200.0, decoded.calories)
+            assertEquals(2.0, decoded.totalServings)
+        }
+
+    @Test
+    fun localUpdateWithoutIngredientsKeepsThemAndRescalesByServings() =
+        runTest {
+            insertLocalFood("temp_f1")
+            val created =
+                repository.createRecipe(
+                    RecipeCreate(
+                        name = "Rice Bowl",
+                        totalServings = 4.0,
+                        ingredients = listOf(RecipeIngredientInput("temp_f1", 200.0, ServingUnit.g)),
+                    ),
+                )
+
+            val updated = repository.updateRecipe(created.id, RecipeUpdate(totalServings = 2.0))
+
+            assertEquals(listOf("temp_f1"), updated.ingredients.map { it.foodId })
+            assertEquals(130.0, updated.calories)
+        }
+
+    @Test
+    fun getRecipeInLocalModeReturnsFullDetailFromCache() =
+        runTest {
+            insertLocalFood("temp_f1")
+            val created =
+                repository.createRecipe(
+                    RecipeCreate(
+                        name = "Rice Bowl",
+                        totalServings = 4.0,
+                        ingredients = listOf(RecipeIngredientInput("temp_f1", 200.0, ServingUnit.g)),
+                    ),
+                )
+
+            val fetched = repository.getRecipe(created.id)
+
+            assertEquals(created.ingredients, fetched.ingredients)
+            assertEquals(65.0, fetched.calories)
+            assertTrue(syncQueue.pendingCount() == 0L) // Local mode never queues uploads.
+        }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SleepRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SleepRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.repository
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.SleepCreate
 import com.bissbilanz.api.generated.model.SleepEntry
@@ -10,6 +9,9 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -23,7 +25,8 @@ import kotlin.test.assertTrue
 
 class SleepRepositoryTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private lateinit var syncQueue: SyncQueue
     private lateinit var repository: SleepRepository
     private val json = Json { ignoreUnknownKeys = true }
@@ -31,11 +34,10 @@ class SleepRepositoryTest {
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
         syncQueue = mockk(relaxed = true)
-        repository = SleepRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
+        repository = SleepRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appModeManager())
     }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SleepRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SleepRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.bissbilanz.api.generated.model.SleepUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.appModeManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -34,7 +35,7 @@ class SleepRepositoryTest {
         BissbilanzDatabase.Schema.create(driver)
         db = BissbilanzDatabase(driver)
         syncQueue = mockk(relaxed = true)
-        repository = SleepRepository(api, db, syncQueue, json, NoopErrorReporter())
+        repository = SleepRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
     }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SupplementRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SupplementRepositoryTest.kt
@@ -1,0 +1,200 @@
+package com.bissbilanz.repository
+
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.api.generated.model.FoodCreate
+import com.bissbilanz.api.generated.model.ServingUnit
+import com.bissbilanz.api.generated.model.Supplement
+import com.bissbilanz.api.generated.model.SupplementBackingFood
+import com.bissbilanz.api.generated.model.SupplementCreate
+import com.bissbilanz.api.generated.model.SupplementIngredientInput
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Local-mode supplements: the cache is the primary store, so a created/edited
+ * supplement must keep its ingredients (including inline-created backing foods) —
+ * they are what the migrator uploads on a later sign-in.
+ */
+class SupplementRepositoryTest {
+    private lateinit var api: BissbilanzApi
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
+    private lateinit var syncQueue: SyncQueue
+    private lateinit var repository: SupplementRepository
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @BeforeTest
+    fun setup() {
+        api = mockk()
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
+        val appMode = appModeManager(AppMode.LOCAL)
+        syncQueue = SyncQueue(cacheDb, json, appMode)
+        repository = SupplementRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appMode)
+    }
+
+    private fun inlineIngredient(
+        name: String,
+        ingredientsText: String,
+        sortOrder: Int = 0,
+    ) = SupplementIngredientInput(
+        food =
+            FoodCreate(
+                name = name,
+                servingSize = 1.0,
+                servingUnit = ServingUnit.g,
+                calories = 0.0,
+                protein = 0.0,
+                carbs = 0.0,
+                fat = 0.0,
+                fiber = 0.0,
+                ingredientsText = ingredientsText,
+            ),
+        servings = 1.0,
+        sortOrder = sortOrder,
+    )
+
+    @Test
+    fun localCreateCachesInlineIngredients() =
+        runTest {
+            val created =
+                repository.createSupplement(
+                    SupplementCreate(
+                        name = "Magnesium",
+                        scheduleType = SupplementCreate.ScheduleType.daily,
+                        ingredients = listOf(inlineIngredient("Magnesium", "400 mg")),
+                    ),
+                )
+
+            val ingredient = created.ingredients.single()
+            assertEquals("Magnesium", ingredient.food.name)
+            assertEquals("400 mg", ingredient.food.ingredientsText)
+            assertTrue(ingredient.foodId.startsWith("temp_"))
+
+            // The cached row round-trips the ingredients, not an empty shell.
+            val row = db.userDataDatabaseQueries.selectSupplementById(created.id).executeAsOneOrNull()
+            assertNotNull(row)
+            val decoded = json.decodeFromString<Supplement>(row.jsonData)
+            assertEquals(
+                "Magnesium",
+                decoded.ingredients
+                    .single()
+                    .food.name,
+            )
+            assertEquals(
+                "400 mg",
+                decoded.ingredients
+                    .single()
+                    .food.ingredientsText,
+            )
+        }
+
+    @Test
+    fun localCreateResolvesFoodIdIngredientsFromLocalFoods() =
+        runTest {
+            val food =
+                Food(
+                    id = "temp_f1",
+                    userId = "",
+                    name = "Vitamin D Drops",
+                    servingSize = 1.0,
+                    servingUnit = Food.ServingUnit.ml,
+                    calories = 9.0,
+                    protein = 0.0,
+                    carbs = 0.0,
+                    fat = 1.0,
+                    fiber = 0.0,
+                    brand = null,
+                    barcode = null,
+                    isFavorite = false,
+                    nutriScore = null,
+                    novaGroup = null,
+                    additives = null,
+                    ingredientsText = null,
+                    imageUrl = null,
+                )
+            db.userDataDatabaseQueries.insertFood(
+                id = food.id,
+                name = food.name,
+                brand = null,
+                calories = food.calories,
+                protein = food.protein,
+                carbs = food.carbs,
+                fat = food.fat,
+                fiber = food.fiber,
+                isFavorite = 0L,
+                barcode = null,
+                jsonData = json.encodeToString(food),
+            )
+
+            val created =
+                repository.createSupplement(
+                    SupplementCreate(
+                        name = "Vitamin D",
+                        scheduleType = SupplementCreate.ScheduleType.daily,
+                        ingredients = listOf(SupplementIngredientInput(foodId = "temp_f1", servings = 2.0, sortOrder = 0)),
+                    ),
+                )
+
+            val ingredient = created.ingredients.single()
+            assertEquals("temp_f1", ingredient.foodId)
+            assertEquals(2.0, ingredient.servings)
+            assertEquals("Vitamin D Drops", ingredient.food.name)
+            assertEquals(SupplementBackingFood.Kind.food, ingredient.food.kind)
+        }
+
+    @Test
+    fun localUpdateAppliesNewIngredientsToTheCache() =
+        runTest {
+            val created =
+                repository.createSupplement(
+                    SupplementCreate(
+                        name = "Magnesium",
+                        scheduleType = SupplementCreate.ScheduleType.daily,
+                        ingredients = listOf(inlineIngredient("Magnesium", "400 mg")),
+                    ),
+                )
+
+            repository.updateSupplement(
+                created.id,
+                SupplementCreate(
+                    name = "Magnesium Complex",
+                    scheduleType = SupplementCreate.ScheduleType.daily,
+                    ingredients =
+                        listOf(
+                            inlineIngredient("Magnesium Citrate", "200 mg", sortOrder = 0),
+                            inlineIngredient("Magnesium Glycinate", "200 mg", sortOrder = 1),
+                        ),
+                ),
+            )
+
+            val decoded =
+                json.decodeFromString<Supplement>(
+                    db.userDataDatabaseQueries
+                        .selectSupplementById(created.id)
+                        .executeAsOneOrNull()!!
+                        .jsonData,
+                )
+            assertEquals("Magnesium Complex", decoded.name)
+            assertEquals(
+                listOf("Magnesium Citrate", "Magnesium Glycinate"),
+                decoded.ingredients.map { it.food.name },
+            )
+        }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncManagerTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncManagerTest.kt
@@ -5,13 +5,23 @@ import com.bissbilanz.api.ApiException
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.UnauthorizedException
 import com.bissbilanz.api.generated.model.DayProperties
+import com.bissbilanz.api.generated.model.EntryCreate
 import com.bissbilanz.api.generated.model.FoodCreate
+import com.bissbilanz.api.generated.model.RecipeCreate
+import com.bissbilanz.api.generated.model.RecipeDetail
+import com.bissbilanz.api.generated.model.RecipeIngredient
+import com.bissbilanz.api.generated.model.RecipeIngredientInput
 import com.bissbilanz.api.generated.model.ServingUnit
+import com.bissbilanz.api.generated.model.Supplement
+import com.bissbilanz.api.generated.model.SupplementCreate
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppMode
+import com.bissbilanz.model.Entry
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -23,11 +33,14 @@ import kotlinx.serialization.json.Json
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SyncManagerTest {
     private lateinit var api: BissbilanzApi
     private lateinit var db: BissbilanzDatabase
+    private lateinit var userDb: UserDataDatabase
     private lateinit var syncQueue: SyncQueue
     private lateinit var connectivityProvider: ConnectivityProvider
     private lateinit var manager: SyncManager
@@ -40,10 +53,11 @@ class SyncManagerTest {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         BissbilanzDatabase.Schema.create(driver)
         db = BissbilanzDatabase(driver)
+        userDb = inMemoryUserDataDatabase()
         syncQueue = SyncQueue(db, json, appModeManager())
         connectivityProvider = mockk()
         every { connectivityProvider.isOnline } returns isOnline
-        manager = SyncManager(syncQueue, connectivityProvider, api, json, NoopErrorReporter(), appModeManager())
+        manager = SyncManager(syncQueue, connectivityProvider, api, userDb, json, NoopErrorReporter(), appModeManager())
     }
 
     @Test
@@ -146,6 +160,7 @@ class SyncManagerTest {
                     syncQueue,
                     connectivityProvider,
                     api,
+                    userDb,
                     json,
                     NoopErrorReporter(),
                     appModeManager(AppMode.LOCAL),
@@ -184,6 +199,254 @@ class SyncManagerTest {
             assertEquals(0, syncQueue.pendingCount())
             coVerify { api.deleteDayProperties("2024-01-15") }
         }
+
+    // ------------------------------------------------------------------------------
+    // Temp-id remapping when creates drain (offline create → reference chains)
+    // ------------------------------------------------------------------------------
+
+    /** Inserts directly with an explicit timestamp so drain order is deterministic. */
+    private fun enqueueAt(
+        operation: SyncOperation,
+        createdAt: Long,
+    ) {
+        db.bissbilanzDatabaseQueries.insertSyncQueueItem(
+            operation = json.encodeToString(SyncOperation.serializer(), operation),
+            createdAt = createdAt,
+            affectedTable = operation.affectedTable,
+            affectedId = operation.affectedId,
+        )
+    }
+
+    @Test
+    fun offlineCreateFoodThenEntryChainDrainsWithServerFoodId() =
+        runTest {
+            enqueueAt(SyncOperation.CreateFood(json.encodeToString(foodCreate()), localId = "temp_f1"), createdAt = 1)
+            enqueueAt(
+                SyncOperation.CreateEntry(
+                    json.encodeToString(
+                        EntryCreate(mealType = "lunch", servings = 1.0, date = "2024-01-15", foodId = "temp_f1"),
+                    ),
+                    localId = "temp_e1",
+                ),
+                createdAt = 2,
+            )
+            coEvery { api.createFood(any()) } returns TestFixtures.food(id = "srv-food-1")
+            val entryCreates = mutableListOf<EntryCreate>()
+            coEvery { api.createEntry(capture(entryCreates)) } returns serverEntry("srv-entry-1", foodId = "srv-food-1")
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(2, synced)
+            assertEquals(0, syncQueue.pendingCount())
+            // The entry was posted with the SERVER food id, not the temp id.
+            assertEquals("srv-food-1", entryCreates.single().foodId)
+            assertTrue(
+                manager.state.value.errors
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun createFoodDrainReplacesLocalTempRowWithServerRecord() =
+        runTest {
+            userDb.userDataDatabaseQueries.insertFood(
+                id = "temp_f1",
+                name = "Rice",
+                brand = null,
+                calories = 130.0,
+                protein = 2.7,
+                carbs = 28.0,
+                fat = 0.3,
+                fiber = 0.4,
+                isFavorite = 0L,
+                barcode = null,
+                jsonData = json.encodeToString(TestFixtures.food(id = "temp_f1", name = "Rice")),
+            )
+            syncQueue.enqueue(SyncOperation.CreateFood(json.encodeToString(foodCreate()), localId = "temp_f1"))
+            coEvery { api.createFood(any()) } returns TestFixtures.food(id = "srv-food-1", name = "Rice")
+
+            manager.syncPendingQueue()
+
+            assertNull(userDb.userDataDatabaseQueries.selectFoodById("temp_f1").executeAsOneOrNull())
+            val server = userDb.userDataDatabaseQueries.selectFoodById("srv-food-1").executeAsOneOrNull()
+            assertNotNull(server)
+            assertEquals("srv-food-1", json.decodeFromString<com.bissbilanz.api.generated.model.Food>(server.jsonData).id)
+        }
+
+    @Test
+    fun createFoodDrainRemapsQueuedUpdateDeleteAndRecipeIngredientReferences() =
+        runTest {
+            enqueueAt(SyncOperation.CreateFood(json.encodeToString(foodCreate()), localId = "temp_f1"), createdAt = 1)
+            enqueueAt(SyncOperation.UpdateFood("temp_f1", json.encodeToString(foodCreate(name = "Brown Rice"))), createdAt = 2)
+            enqueueAt(SyncOperation.DeleteFood("temp_f1"), createdAt = 3)
+            enqueueAt(
+                SyncOperation.CreateRecipe(
+                    json.encodeToString(
+                        RecipeCreate(
+                            name = "Bowl",
+                            totalServings = 2.0,
+                            ingredients = listOf(RecipeIngredientInput("temp_f1", 100.0, ServingUnit.g)),
+                        ),
+                    ),
+                    localId = "temp_r1",
+                ),
+                createdAt = 4,
+            )
+            coEvery { api.createFood(any()) } returns TestFixtures.food(id = "srv-food-1")
+            coEvery { api.updateFood(any(), any()) } returns TestFixtures.food(id = "srv-food-1", name = "Brown Rice")
+            coEvery { api.deleteFood(any()) } returns Unit
+            val recipeCreates = mutableListOf<RecipeCreate>()
+            coEvery { api.createRecipe(capture(recipeCreates)) } returns recipeDetail("srv-recipe-1", foodId = "srv-food-1")
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(4, synced)
+            assertEquals(0, syncQueue.pendingCount())
+            coVerify { api.updateFood("srv-food-1", match { it.name == "Brown Rice" }) }
+            coVerify { api.deleteFood("srv-food-1") }
+            assertEquals(listOf("srv-food-1"), recipeCreates.single().ingredients.map { it.foodId })
+        }
+
+    @Test
+    fun createSupplementDrainRemapsQueuedLogAndLocalLogRows() =
+        runTest {
+            userDb.userDataDatabaseQueries.insertSupplementLog(
+                id = "temp_s1-2024-01-15",
+                supplementId = "temp_s1",
+                date = "2024-01-15",
+                takenAt = "2024-01-15T08:00:00Z",
+            )
+            enqueueAt(
+                SyncOperation.CreateSupplement(
+                    json.encodeToString(
+                        SupplementCreate(
+                            name = "Magnesium",
+                            scheduleType = SupplementCreate.ScheduleType.daily,
+                            ingredients = emptyList(),
+                        ),
+                    ),
+                    localId = "temp_s1",
+                ),
+                createdAt = 1,
+            )
+            enqueueAt(SyncOperation.LogSupplement("temp_s1", "2024-01-15"), createdAt = 2)
+            coEvery { api.createSupplement(any()) } returns supplement("srv-supp-1")
+            coEvery { api.logSupplement(any(), any()) } returns
+                com.bissbilanz.api.generated.model.SupplementLog(
+                    supplementId = "srv-supp-1",
+                    date = "2024-01-15",
+                    takenAt = "2024-01-15T08:00:00Z",
+                    entryIds = emptyList(),
+                )
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(2, synced)
+            coVerify { api.logSupplement("srv-supp-1", "2024-01-15") }
+            // Local log rows were re-keyed onto the server supplement id.
+            val logs = userDb.userDataDatabaseQueries.selectAllSupplementLogs().executeAsList()
+            assertEquals(listOf("srv-supp-1-2024-01-15"), logs.map { it.id })
+            assertEquals(listOf("srv-supp-1"), logs.map { it.supplementId })
+        }
+
+    @Test
+    fun remappedReferencesArePersistedForRetriesAcrossSyncRuns() =
+        runTest {
+            enqueueAt(SyncOperation.CreateFood(json.encodeToString(foodCreate()), localId = "temp_f1"), createdAt = 1)
+            enqueueAt(
+                SyncOperation.CreateEntry(
+                    json.encodeToString(
+                        EntryCreate(mealType = "lunch", servings = 1.0, date = "2024-01-15", foodId = "temp_f1"),
+                    ),
+                    localId = "temp_e1",
+                ),
+                createdAt = 2,
+            )
+            coEvery { api.createFood(any()) } returns TestFixtures.food(id = "srv-food-1")
+            coEvery { api.createEntry(any()) } throws ApiException("server error", 500)
+
+            assertEquals(1, manager.syncPendingQueue())
+
+            // The queued entry row itself was rewritten, so the retry succeeds even
+            // though the in-memory remap of the first run is gone.
+            val queuedEntry = syncQueue.all().single().operation as SyncOperation.CreateEntry
+            assertEquals("srv-food-1", json.decodeFromString<EntryCreate>(queuedEntry.body).foodId)
+
+            val entryCreates = mutableListOf<EntryCreate>()
+            coEvery { api.createEntry(capture(entryCreates)) } returns serverEntry("srv-entry-1", foodId = "srv-food-1")
+
+            assertEquals(1, manager.syncPendingQueue())
+            assertEquals(0, syncQueue.pendingCount())
+            assertEquals("srv-food-1", entryCreates.single().foodId)
+        }
+
+    @Test
+    fun remapRewritesAffectedIdSoCoalescingKeysStayConsistent() =
+        runTest {
+            enqueueAt(SyncOperation.CreateFood(json.encodeToString(foodCreate()), localId = "temp_f1"), createdAt = 1)
+            enqueueAt(SyncOperation.UpdateFood("temp_f1", json.encodeToString(foodCreate(name = "Brown Rice"))), createdAt = 2)
+            coEvery { api.createFood(any()) } returns TestFixtures.food(id = "srv-food-1")
+            coEvery { api.updateFood(any(), any()) } throws ApiException("server error", 500)
+
+            manager.syncPendingQueue()
+
+            val remaining = syncQueue.findByAffected("foods", "srv-food-1")
+            assertEquals(1, remaining.size)
+            assertEquals("srv-food-1", (remaining.single().operation as SyncOperation.UpdateFood).id)
+            assertTrue(syncQueue.findByAffected("foods", "temp_f1").isEmpty())
+        }
+
+    private fun serverEntry(
+        id: String,
+        foodId: String? = null,
+    ) = Entry(
+        id = id,
+        userId = "user-1",
+        foodId = foodId,
+        date = "2024-01-15",
+        mealType = "lunch",
+        servings = 1.0,
+    )
+
+    private fun recipeDetail(
+        id: String,
+        foodId: String,
+    ) = RecipeDetail(
+        id = id,
+        userId = "user-1",
+        name = "Bowl",
+        totalServings = 2.0,
+        isFavorite = false,
+        imageUrl = null,
+        calories = 100.0,
+        protein = 10.0,
+        carbs = 12.0,
+        fat = 5.0,
+        fiber = 2.0,
+        ingredients =
+            listOf(
+                RecipeIngredient(
+                    foodId = foodId,
+                    quantity = 100.0,
+                    servingUnit = RecipeIngredient.ServingUnit.g,
+                    sortOrder = 0,
+                ),
+            ),
+    )
+
+    private fun supplement(id: String) =
+        Supplement(
+            id = id,
+            userId = "user-1",
+            name = "Magnesium",
+            scheduleType = Supplement.ScheduleType.daily,
+            scheduleDays = null,
+            scheduleStartDate = null,
+            isActive = true,
+            sortOrder = 0,
+            timeOfDay = null,
+            ingredients = emptyList(),
+        )
 
     private fun foodCreate(name: String = "Rice") =
         FoodCreate(

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncManagerTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncManagerTest.kt
@@ -1,0 +1,147 @@
+package com.bissbilanz.sync
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.api.ApiException
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.UnauthorizedException
+import com.bissbilanz.api.generated.model.FoodCreate
+import com.bissbilanz.api.generated.model.ServingUnit
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.TestFixtures
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyncManagerTest {
+    private lateinit var api: BissbilanzApi
+    private lateinit var db: BissbilanzDatabase
+    private lateinit var syncQueue: SyncQueue
+    private lateinit var connectivityProvider: ConnectivityProvider
+    private lateinit var manager: SyncManager
+    private val json = Json { ignoreUnknownKeys = true }
+    private val isOnline = MutableStateFlow(true)
+
+    @BeforeTest
+    fun setup() {
+        api = mockk()
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BissbilanzDatabase.Schema.create(driver)
+        db = BissbilanzDatabase(driver)
+        syncQueue = SyncQueue(db, json)
+        connectivityProvider = mockk()
+        every { connectivityProvider.isOnline } returns isOnline
+        manager = SyncManager(syncQueue, connectivityProvider, api, json, NoopErrorReporter())
+    }
+
+    @Test
+    fun syncDrainsQueueAndExecutesEachOperation() =
+        runTest {
+            syncQueue.enqueue(SyncOperation.CreateFood(json.encodeToString(foodCreate()), localId = "temp_1"))
+            syncQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+            coEvery { api.createFood(any()) } returns TestFixtures.food()
+            coEvery { api.deleteEntry("e1") } returns Unit
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(2, synced)
+            assertEquals(0, syncQueue.pendingCount())
+            coVerify { api.createFood(match { it.name == "Rice" }) }
+            coVerify { api.deleteEntry("e1") }
+            assertTrue(
+                manager.state.value.errors
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun clientErrorDropsOperationAndRecordsError() =
+        runTest {
+            syncQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+            coEvery { api.deleteEntry("e1") } throws ApiException("bad request", 400)
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(1, synced)
+            assertEquals(0, syncQueue.pendingCount())
+            assertTrue(
+                manager.state.value.errors
+                    .single()
+                    .contains("HTTP 400"),
+            )
+        }
+
+    @Test
+    fun serverErrorReleasesForRetryAndGivesUpAfterThreeRetries() =
+        runTest {
+            syncQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+            coEvery { api.deleteEntry("e1") } throws ApiException("server error", 500)
+
+            assertEquals(0, manager.syncPendingQueue())
+            assertEquals(1, syncQueue.pendingCount())
+            assertEquals(0, manager.syncPendingQueue())
+            assertEquals(1, syncQueue.pendingCount())
+            val third = manager.syncPendingQueue()
+
+            assertEquals(1, third)
+            assertEquals(0, syncQueue.pendingCount())
+            assertTrue(
+                manager.state.value.errors
+                    .single()
+                    .contains("Gave up"),
+            )
+            coVerify(exactly = 3) { api.deleteEntry("e1") }
+        }
+
+    @Test
+    fun unauthorizedReleasesOperationsAndStopsSyncing() =
+        runTest {
+            syncQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+            syncQueue.enqueue(SyncOperation.DeleteEntry("e2"))
+            coEvery { api.deleteEntry(any()) } throws UnauthorizedException()
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(0, synced)
+            assertEquals(2, syncQueue.pendingCount())
+            coVerify(exactly = 1) { api.deleteEntry(any()) }
+            assertTrue(
+                manager.state.value.errors
+                    .single()
+                    .contains("Session expired"),
+            )
+        }
+
+    @Test
+    fun offlineSkipsSyncAndKeepsQueue() =
+        runTest {
+            isOnline.value = false
+            syncQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(0, synced)
+            assertEquals(1, syncQueue.pendingCount())
+        }
+
+    private fun foodCreate(name: String = "Rice") =
+        FoodCreate(
+            name = name,
+            servingSize = 100.0,
+            servingUnit = ServingUnit.g,
+            calories = 130.0,
+            protein = 2.7,
+            carbs = 28.0,
+            fat = 0.3,
+            fiber = 0.4,
+        )
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncManagerTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncManagerTest.kt
@@ -4,11 +4,14 @@ import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.api.ApiException
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.UnauthorizedException
+import com.bissbilanz.api.generated.model.DayProperties
 import com.bissbilanz.api.generated.model.FoodCreate
 import com.bissbilanz.api.generated.model.ServingUnit
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppMode
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.TestFixtures
+import com.bissbilanz.test.appModeManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -37,10 +40,10 @@ class SyncManagerTest {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         BissbilanzDatabase.Schema.create(driver)
         db = BissbilanzDatabase(driver)
-        syncQueue = SyncQueue(db, json)
+        syncQueue = SyncQueue(db, json, appModeManager())
         connectivityProvider = mockk()
         every { connectivityProvider.isOnline } returns isOnline
-        manager = SyncManager(syncQueue, connectivityProvider, api, json, NoopErrorReporter())
+        manager = SyncManager(syncQueue, connectivityProvider, api, json, NoopErrorReporter(), appModeManager())
     }
 
     @Test
@@ -131,6 +134,55 @@ class SyncManagerTest {
 
             assertEquals(0, synced)
             assertEquals(1, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun localModeReturnsZeroWithoutTouchingApiOrQueue() =
+        runTest {
+            // Pre-existing queued op (e.g. enqueued before switching to Local mode).
+            syncQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+            val localManager =
+                SyncManager(
+                    syncQueue,
+                    connectivityProvider,
+                    api,
+                    json,
+                    NoopErrorReporter(),
+                    appModeManager(AppMode.LOCAL),
+                )
+
+            val synced = localManager.syncPendingQueue()
+
+            assertEquals(0, synced)
+            assertEquals(1, syncQueue.pendingCount())
+            coVerify(exactly = 0) { api.deleteEntry(any()) }
+        }
+
+    @Test
+    fun executesSetDayPropertiesViaApi() =
+        runTest {
+            syncQueue.enqueue(SyncOperation.SetDayProperties("2024-01-15", isFastingDay = true))
+            coEvery { api.setDayProperties("2024-01-15", true) } returns
+                DayProperties(date = "2024-01-15", isFastingDay = true)
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(1, synced)
+            assertEquals(0, syncQueue.pendingCount())
+            coVerify { api.setDayProperties("2024-01-15", true) }
+        }
+
+    @Test
+    fun executesDeleteDayPropertiesViaApi() =
+        runTest {
+            syncQueue.enqueue(SyncOperation.DeleteDayProperties("2024-01-15"))
+            coEvery { api.deleteDayProperties("2024-01-15") } returns Unit
+
+            val synced = manager.syncPendingQueue()
+
+            assertEquals(1, synced)
+            assertEquals(0, syncQueue.pendingCount())
+            coVerify { api.deleteDayProperties("2024-01-15") }
         }
 
     private fun foodCreate(name: String = "Rice") =

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncQueueTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncQueueTest.kt
@@ -2,6 +2,8 @@ package com.bissbilanz.sync
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.test.appModeManager
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.BeforeTest
@@ -19,7 +21,7 @@ class SyncQueueTest {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         BissbilanzDatabase.Schema.create(driver)
         db = BissbilanzDatabase(driver)
-        queue = SyncQueue(db, json)
+        queue = SyncQueue(db, json, appModeManager())
     }
 
     @Test
@@ -134,6 +136,29 @@ class SyncQueueTest {
             assertEquals(1, queue.pendingCount())
             val remaining = queue.drain().single().operation as SyncOperation.CreateFood
             assertEquals("temp_2", remaining.localId)
+        }
+
+    @Test
+    fun enqueueIsNoOpInLocalMode() =
+        runTest {
+            // In Local mode the DB is the primary store; the login migrator uploads
+            // cache state, so queued ops would double-apply.
+            val localQueue = SyncQueue(db, json, appModeManager(AppMode.LOCAL))
+
+            localQueue.enqueue(SyncOperation.CreateFood("{}", localId = "temp_1"))
+
+            assertEquals(0, localQueue.pendingCount())
+            assertTrue(localQueue.drain().isEmpty())
+        }
+
+    @Test
+    fun enqueueWorksWhenModeIsSynced() =
+        runTest {
+            val syncedQueue = SyncQueue(db, json, appModeManager(AppMode.SYNCED))
+
+            syncedQueue.enqueue(SyncOperation.DeleteEntry("e1"))
+
+            assertEquals(1, syncedQueue.pendingCount())
         }
 
     @Test

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncQueueTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/SyncQueueTest.kt
@@ -1,0 +1,155 @@
+package com.bissbilanz.sync
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.cache.BissbilanzDatabase
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyncQueueTest {
+    private lateinit var db: BissbilanzDatabase
+    private lateinit var queue: SyncQueue
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @BeforeTest
+    fun setup() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BissbilanzDatabase.Schema.create(driver)
+        db = BissbilanzDatabase(driver)
+        queue = SyncQueue(db, json)
+    }
+
+    @Test
+    fun enqueueAndDrainReturnsQueuedOperations() =
+        runTest {
+            queue.enqueue(SyncOperation.CreateFood("""{"name":"Rice"}""", localId = "temp_1"))
+            queue.enqueue(SyncOperation.DeleteEntry("e1"))
+
+            val drained = queue.drain()
+
+            assertEquals(2, drained.size)
+            val create = drained[0].operation as SyncOperation.CreateFood
+            assertEquals("""{"name":"Rice"}""", create.body)
+            assertEquals("temp_1", create.localId)
+            val delete = drained[1].operation as SyncOperation.DeleteEntry
+            assertEquals("e1", delete.id)
+        }
+
+    @Test
+    fun drainExcludesInProgressItems() =
+        runTest {
+            queue.enqueue(SyncOperation.DeleteFood("f1"))
+
+            val first = queue.drain()
+            val second = queue.drain()
+
+            assertEquals(1, first.size)
+            assertTrue(second.isEmpty())
+        }
+
+    @Test
+    fun releaseForRetryMakesItemDrainableAgain() =
+        runTest {
+            queue.enqueue(SyncOperation.DeleteFood("f1"))
+            val first = queue.drain().single()
+
+            queue.releaseForRetry(first.id)
+
+            assertEquals(1, queue.drain().size)
+        }
+
+    @Test
+    fun removeDeletesItem() =
+        runTest {
+            queue.enqueue(SyncOperation.DeleteFood("f1"))
+            val drained = queue.drain().single()
+
+            queue.remove(drained.id)
+
+            assertEquals(0, queue.pendingCount())
+            assertTrue(queue.drain().isEmpty())
+        }
+
+    @Test
+    fun incrementAndGetRetryCountIncrements() =
+        runTest {
+            queue.enqueue(SyncOperation.DeleteFood("f1"))
+            val id = queue.drain().single().id
+
+            assertEquals(1, queue.incrementAndGetRetryCount(id))
+            assertEquals(2, queue.incrementAndGetRetryCount(id))
+            assertEquals(3, queue.incrementAndGetRetryCount(id))
+        }
+
+    @Test
+    fun findByAffectedReturnsOnlyMatchingItems() =
+        runTest {
+            queue.enqueue(SyncOperation.CreateFood("""{"name":"Rice"}""", localId = "temp_1"))
+            queue.enqueue(SyncOperation.CreateFood("""{"name":"Oats"}""", localId = "temp_2"))
+            // Same id but different table must not match.
+            queue.enqueue(SyncOperation.UpdateEntry("temp_1", "{}"))
+
+            val matches = queue.findByAffected("foods", "temp_1")
+
+            assertEquals(1, matches.size)
+            val op = matches.single().operation as SyncOperation.CreateFood
+            assertEquals("""{"name":"Rice"}""", op.body)
+        }
+
+    @Test
+    fun findByAffectedReturnsEmptyListWhenNothingMatches() =
+        runTest {
+            queue.enqueue(SyncOperation.CreateFood("{}", localId = "temp_1"))
+
+            assertTrue(queue.findByAffected("foods", "temp_2").isEmpty())
+        }
+
+    @Test
+    fun replaceOperationRewritesStoredOperation() =
+        runTest {
+            queue.enqueue(SyncOperation.CreateFood("""{"name":"Rice"}""", localId = "temp_1"))
+            val queued = queue.findByAffected("foods", "temp_1").single()
+
+            queue.replaceOperation(
+                queued.id,
+                SyncOperation.CreateFood("""{"name":"Brown Rice"}""", localId = "temp_1"),
+            )
+
+            val drained = queue.drain().single().operation as SyncOperation.CreateFood
+            assertEquals("""{"name":"Brown Rice"}""", drained.body)
+            assertEquals("temp_1", drained.localId)
+        }
+
+    @Test
+    fun removeByAffectedDeletesMatchingItems() =
+        runTest {
+            queue.enqueue(SyncOperation.CreateFood("{}", localId = "temp_1"))
+            queue.enqueue(SyncOperation.CreateFood("{}", localId = "temp_2"))
+
+            queue.removeByAffected("foods", "temp_1")
+
+            assertEquals(1, queue.pendingCount())
+            val remaining = queue.drain().single().operation as SyncOperation.CreateFood
+            assertEquals("temp_2", remaining.localId)
+        }
+
+    @Test
+    fun createOperationWithoutLocalIdDecodesFromLegacyJson() =
+        runTest {
+            // Old queued rows were serialized before localId existed.
+            val legacy = """{"type":"create_food","body":"{}"}"""
+            db.bissbilanzDatabaseQueries.insertSyncQueueItem(
+                operation = legacy,
+                createdAt = 0,
+                affectedTable = "foods",
+                affectedId = null,
+            )
+
+            val drained = queue.drain().single().operation as SyncOperation.CreateFood
+
+            assertEquals(null, drained.localId)
+        }
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
@@ -1,0 +1,355 @@
+package com.bissbilanz.sync
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.HealthSyncService
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.EntryCreate
+import com.bissbilanz.api.generated.model.EntryUpdate
+import com.bissbilanz.api.generated.model.FoodCreate
+import com.bissbilanz.api.generated.model.RecipeCreate
+import com.bissbilanz.api.generated.model.RecipeUpdate
+import com.bissbilanz.api.generated.model.ServingUnit
+import com.bissbilanz.api.generated.model.SleepCreate
+import com.bissbilanz.api.generated.model.SleepUpdate
+import com.bissbilanz.api.generated.model.SupplementCreate
+import com.bissbilanz.api.generated.model.WeightCreate
+import com.bissbilanz.api.generated.model.WeightUpdate
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.repository.EntryRepository
+import com.bissbilanz.repository.FoodRepository
+import com.bissbilanz.repository.RecipeRepository
+import com.bissbilanz.repository.SleepRepository
+import com.bissbilanz.repository.SupplementRepository
+import com.bissbilanz.repository.WeightRepository
+import com.bissbilanz.test.NoopErrorReporter
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that editing or deleting a record that only exists locally (a `temp_` id)
+ * rewrites or removes the queued Create operation instead of leaving the original
+ * payload to be uploaded.
+ */
+class TempIdCoalescingTest {
+    private lateinit var api: BissbilanzApi
+    private lateinit var db: BissbilanzDatabase
+    private lateinit var syncQueue: SyncQueue
+    private lateinit var healthSync: HealthSyncService
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @BeforeTest
+    fun setup() {
+        api = mockk()
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BissbilanzDatabase.Schema.create(driver)
+        db = BissbilanzDatabase(driver)
+        syncQueue = SyncQueue(db, json)
+        healthSync = mockk(relaxed = true)
+    }
+
+    private fun entryRepository() = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter())
+
+    private fun foodRepository() = FoodRepository(api, db, syncQueue, json, NoopErrorReporter(), Dispatchers.Unconfined)
+
+    private fun recipeRepository() = RecipeRepository(api, db, syncQueue, json, NoopErrorReporter())
+
+    private fun weightRepository() = WeightRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter())
+
+    private fun sleepRepository() = SleepRepository(api, db, syncQueue, json, NoopErrorReporter())
+
+    private fun supplementRepository() = SupplementRepository(api, db, syncQueue, json, NoopErrorReporter())
+
+    // Entries
+
+    @Test
+    fun entryCreateThenUpdateRewritesQueuedCreateBody() =
+        runTest {
+            val repo = entryRepository()
+            val temp =
+                repo.createEntry(
+                    EntryCreate(mealType = "lunch", servings = 1.0, date = "2024-01-15", foodId = "f1"),
+                )
+
+            repo.updateEntry(temp.id, EntryUpdate(servings = 2.5, notes = "more rice"))
+
+            val create = syncQueue.drain().single().operation as SyncOperation.CreateEntry
+            assertEquals(temp.id, create.localId)
+            val body = json.decodeFromString<EntryCreate>(create.body)
+            assertEquals(2.5, body.servings)
+            assertEquals("more rice", body.notes)
+            assertEquals("lunch", body.mealType)
+            assertEquals("f1", body.foodId)
+            assertEquals("2024-01-15", body.date)
+        }
+
+    @Test
+    fun entryCreateThenDeleteLeavesQueueEmpty() =
+        runTest {
+            val repo = entryRepository()
+            val temp = repo.createEntry(EntryCreate(mealType = "lunch", servings = 1.0, date = "2024-01-15"))
+
+            repo.deleteEntry(temp.id)
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun entryUpdateOfTempIdWithNoQueuedCreateSkipsEnqueue() =
+        runTest {
+            val repo = entryRepository()
+            val temp = repo.createEntry(EntryCreate(mealType = "lunch", servings = 1.0, date = "2024-01-15"))
+            // Simulate the create having already been drained and synced.
+            syncQueue.remove(syncQueue.drain().single().id)
+
+            repo.updateEntry(temp.id, EntryUpdate(servings = 3.0))
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun entryUpdateAndDeleteOfServerIdsEnqueueOperationsAsBefore() =
+        runTest {
+            val repo = entryRepository()
+
+            repo.updateEntry("server-1", EntryUpdate(servings = 2.0))
+            repo.deleteEntry("server-2")
+
+            val ops = syncQueue.drain().map { it.operation }
+            assertTrue(ops.any { it is SyncOperation.UpdateEntry && it.id == "server-1" })
+            assertTrue(ops.any { it is SyncOperation.DeleteEntry && it.id == "server-2" })
+        }
+
+    // Foods
+
+    @Test
+    fun foodCreateThenUpdateReplacesQueuedCreateBody() =
+        runTest {
+            val repo = foodRepository()
+            val temp = repo.createFood(foodCreate(name = "Rice"))
+
+            repo.updateFood(temp.id, foodCreate(name = "Brown Rice", calories = 111.0))
+
+            val create = syncQueue.drain().single().operation as SyncOperation.CreateFood
+            assertEquals(temp.id, create.localId)
+            val body = json.decodeFromString<FoodCreate>(create.body)
+            assertEquals("Brown Rice", body.name)
+            assertEquals(111.0, body.calories)
+        }
+
+    @Test
+    fun foodCreateThenDeleteLeavesQueueEmpty() =
+        runTest {
+            val repo = foodRepository()
+            val temp = repo.createFood(foodCreate())
+
+            repo.deleteFood(temp.id)
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun foodUpdateAndDeleteOfServerIdsEnqueueOperationsAsBefore() =
+        runTest {
+            val repo = foodRepository()
+
+            repo.updateFood("server-1", foodCreate(name = "Updated"))
+            repo.deleteFood("server-2")
+
+            val ops = syncQueue.drain().map { it.operation }
+            assertTrue(ops.any { it is SyncOperation.UpdateFood && it.id == "server-1" })
+            assertTrue(ops.any { it is SyncOperation.DeleteFood && it.id == "server-2" })
+        }
+
+    // Recipes
+
+    @Test
+    fun recipeCreateThenUpdateRewritesQueuedCreateBody() =
+        runTest {
+            val repo = recipeRepository()
+            val temp = repo.createRecipe(RecipeCreate(name = "Soup", totalServings = 4.0, ingredients = emptyList()))
+
+            repo.updateRecipe(temp.id, RecipeUpdate(name = "Hot Soup"))
+
+            val create = syncQueue.drain().single().operation as SyncOperation.CreateRecipe
+            assertEquals(temp.id, create.localId)
+            val body = json.decodeFromString<RecipeCreate>(create.body)
+            assertEquals("Hot Soup", body.name)
+            assertEquals(4.0, body.totalServings)
+        }
+
+    @Test
+    fun recipeCreateThenDeleteLeavesQueueEmpty() =
+        runTest {
+            val repo = recipeRepository()
+            val temp = repo.createRecipe(RecipeCreate(name = "Soup", totalServings = 4.0, ingredients = emptyList()))
+
+            repo.deleteRecipe(temp.id)
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun recipeUpdateAndDeleteOfServerIdsEnqueueOperationsAsBefore() =
+        runTest {
+            val repo = recipeRepository()
+
+            repo.updateRecipe("server-1", RecipeUpdate(name = "Updated"))
+            repo.deleteRecipe("server-2")
+
+            val ops = syncQueue.drain().map { it.operation }
+            assertTrue(ops.any { it is SyncOperation.UpdateRecipe && it.id == "server-1" })
+            assertTrue(ops.any { it is SyncOperation.DeleteRecipe && it.id == "server-2" })
+        }
+
+    // Weight
+
+    @Test
+    fun weightCreateThenUpdateRewritesQueuedCreateBody() =
+        runTest {
+            val repo = weightRepository()
+            val temp = repo.createEntry(WeightCreate(weightKg = 80.0, entryDate = "2024-01-15", notes = "morning"))
+
+            repo.updateEntry(temp.id, WeightUpdate(weightKg = 79.5))
+
+            val create = syncQueue.drain().single().operation as SyncOperation.CreateWeight
+            assertEquals(temp.id, create.localId)
+            val body = json.decodeFromString<WeightCreate>(create.body)
+            assertEquals(79.5, body.weightKg)
+            assertEquals("2024-01-15", body.entryDate)
+            assertEquals("morning", body.notes)
+        }
+
+    @Test
+    fun weightCreateThenDeleteLeavesQueueEmpty() =
+        runTest {
+            val repo = weightRepository()
+            val temp = repo.createEntry(WeightCreate(weightKg = 80.0, entryDate = "2024-01-15"))
+
+            repo.deleteEntry(temp.id)
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun weightUpdateAndDeleteOfServerIdsEnqueueOperationsAsBefore() =
+        runTest {
+            val repo = weightRepository()
+
+            repo.updateEntry("server-1", WeightUpdate(weightKg = 81.0))
+            repo.deleteEntry("server-2")
+
+            val ops = syncQueue.drain().map { it.operation }
+            assertTrue(ops.any { it is SyncOperation.UpdateWeight && it.id == "server-1" })
+            assertTrue(ops.any { it is SyncOperation.DeleteWeight && it.id == "server-2" })
+        }
+
+    // Sleep
+
+    @Test
+    fun sleepCreateThenUpdateRewritesQueuedCreateBody() =
+        runTest {
+            val repo = sleepRepository()
+            val temp = repo.createEntry(SleepCreate(durationMinutes = 480, quality = 7, entryDate = "2024-01-15"))
+
+            repo.updateEntry(temp.id, SleepUpdate(quality = 9, notes = "slept well"))
+
+            val create = syncQueue.drain().single().operation as SyncOperation.CreateSleep
+            assertEquals(temp.id, create.localId)
+            val body = json.decodeFromString<SleepCreate>(create.body)
+            assertEquals(9, body.quality)
+            assertEquals(480, body.durationMinutes)
+            assertEquals("2024-01-15", body.entryDate)
+            assertEquals("slept well", body.notes)
+        }
+
+    @Test
+    fun sleepCreateThenDeleteLeavesQueueEmpty() =
+        runTest {
+            val repo = sleepRepository()
+            val temp = repo.createEntry(SleepCreate(durationMinutes = 480, quality = 7, entryDate = "2024-01-15"))
+
+            repo.deleteEntry(temp.id)
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun sleepUpdateAndDeleteOfServerIdsEnqueueOperationsAsBefore() =
+        runTest {
+            val repo = sleepRepository()
+
+            repo.updateEntry("server-1", SleepUpdate(quality = 8))
+            repo.deleteEntry("server-2")
+
+            val ops = syncQueue.drain().map { it.operation }
+            assertTrue(ops.any { it is SyncOperation.UpdateSleep && it.id == "server-1" })
+            assertTrue(ops.any { it is SyncOperation.DeleteSleep && it.id == "server-2" })
+        }
+
+    // Supplements
+
+    @Test
+    fun supplementCreateThenUpdateReplacesQueuedCreateBody() =
+        runTest {
+            val repo = supplementRepository()
+            val temp = repo.createSupplement(supplementCreate(name = "Magnesium"))
+
+            repo.updateSupplement(temp.id, supplementCreate(name = "Magnesium Citrate"))
+
+            val create = syncQueue.drain().single().operation as SyncOperation.CreateSupplement
+            assertEquals(temp.id, create.localId)
+            val body = json.decodeFromString<SupplementCreate>(create.body)
+            assertEquals("Magnesium Citrate", body.name)
+        }
+
+    @Test
+    fun supplementCreateThenDeleteLeavesQueueEmpty() =
+        runTest {
+            val repo = supplementRepository()
+            val temp = repo.createSupplement(supplementCreate())
+
+            repo.deleteSupplement(temp.id)
+
+            assertEquals(0, syncQueue.pendingCount())
+        }
+
+    @Test
+    fun supplementUpdateAndDeleteOfServerIdsEnqueueOperationsAsBefore() =
+        runTest {
+            val repo = supplementRepository()
+
+            repo.updateSupplement("server-1", supplementCreate(name = "Updated"))
+            repo.deleteSupplement("server-2")
+
+            val ops = syncQueue.drain().map { it.operation }
+            assertTrue(ops.any { it is SyncOperation.UpdateSupplement && it.id == "server-1" })
+            assertTrue(ops.any { it is SyncOperation.DeleteSupplement && it.id == "server-2" })
+        }
+
+    private fun foodCreate(
+        name: String = "Rice",
+        calories: Double = 130.0,
+    ) = FoodCreate(
+        name = name,
+        servingSize = 100.0,
+        servingUnit = ServingUnit.g,
+        calories = calories,
+        protein = 2.7,
+        carbs = 28.0,
+        fat = 0.3,
+        fiber = 0.4,
+    )
+
+    private fun supplementCreate(name: String = "Magnesium") =
+        SupplementCreate(
+            name = name,
+            scheduleType = SupplementCreate.ScheduleType.daily,
+            ingredients = emptyList(),
+        )
+}

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
@@ -3,6 +3,7 @@ package com.bissbilanz.sync
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.OpenFoodFactsClient
 import com.bissbilanz.api.generated.model.EntryCreate
 import com.bissbilanz.api.generated.model.EntryUpdate
 import com.bissbilanz.api.generated.model.FoodCreate
@@ -22,6 +23,7 @@ import com.bissbilanz.repository.SleepRepository
 import com.bissbilanz.repository.SupplementRepository
 import com.bissbilanz.repository.WeightRepository
 import com.bissbilanz.test.NoopErrorReporter
+import com.bissbilanz.test.appModeManager
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -49,21 +51,31 @@ class TempIdCoalescingTest {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         BissbilanzDatabase.Schema.create(driver)
         db = BissbilanzDatabase(driver)
-        syncQueue = SyncQueue(db, json)
+        syncQueue = SyncQueue(db, json, appModeManager())
         healthSync = mockk(relaxed = true)
     }
 
-    private fun entryRepository() = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter())
+    private fun entryRepository() = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
 
-    private fun foodRepository() = FoodRepository(api, db, syncQueue, json, NoopErrorReporter(), Dispatchers.Unconfined)
+    private fun foodRepository() =
+        FoodRepository(
+            api,
+            db,
+            syncQueue,
+            json,
+            NoopErrorReporter(),
+            appModeManager(),
+            mockk<OpenFoodFactsClient>(relaxed = true),
+            Dispatchers.Unconfined,
+        )
 
-    private fun recipeRepository() = RecipeRepository(api, db, syncQueue, json, NoopErrorReporter())
+    private fun recipeRepository() = RecipeRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
 
-    private fun weightRepository() = WeightRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter())
+    private fun weightRepository() = WeightRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
 
-    private fun sleepRepository() = SleepRepository(api, db, syncQueue, json, NoopErrorReporter())
+    private fun sleepRepository() = SleepRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
 
-    private fun supplementRepository() = SupplementRepository(api, db, syncQueue, json, NoopErrorReporter())
+    private fun supplementRepository() = SupplementRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
 
     // Entries
 

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
@@ -1,6 +1,5 @@
 package com.bissbilanz.sync
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.OpenFoodFactsClient
@@ -24,6 +23,9 @@ import com.bissbilanz.repository.SupplementRepository
 import com.bissbilanz.repository.WeightRepository
 import com.bissbilanz.test.NoopErrorReporter
 import com.bissbilanz.test.appModeManager
+import com.bissbilanz.test.inMemoryCacheDatabase
+import com.bissbilanz.test.inMemoryUserDataDatabase
+import com.bissbilanz.userdata.UserDataDatabase
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -40,7 +42,8 @@ import kotlin.test.assertTrue
  */
 class TempIdCoalescingTest {
     private lateinit var api: BissbilanzApi
-    private lateinit var db: BissbilanzDatabase
+    private lateinit var db: UserDataDatabase
+    private lateinit var cacheDb: BissbilanzDatabase
     private lateinit var syncQueue: SyncQueue
     private lateinit var healthSync: HealthSyncService
     private val json = Json { ignoreUnknownKeys = true }
@@ -48,19 +51,19 @@ class TempIdCoalescingTest {
     @BeforeTest
     fun setup() {
         api = mockk()
-        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        BissbilanzDatabase.Schema.create(driver)
-        db = BissbilanzDatabase(driver)
-        syncQueue = SyncQueue(db, json, appModeManager())
+        db = inMemoryUserDataDatabase()
+        cacheDb = inMemoryCacheDatabase()
+        syncQueue = SyncQueue(cacheDb, json, appModeManager())
         healthSync = mockk(relaxed = true)
     }
 
-    private fun entryRepository() = EntryRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
+    private fun entryRepository() = EntryRepository(api, db, cacheDb, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
 
     private fun foodRepository() =
         FoodRepository(
             api,
             db,
+            cacheDb,
             syncQueue,
             json,
             NoopErrorReporter(),
@@ -69,13 +72,13 @@ class TempIdCoalescingTest {
             Dispatchers.Unconfined,
         )
 
-    private fun recipeRepository() = RecipeRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
+    private fun recipeRepository() = RecipeRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appModeManager())
 
-    private fun weightRepository() = WeightRepository(api, db, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
+    private fun weightRepository() = WeightRepository(api, db, cacheDb, healthSync, syncQueue, json, NoopErrorReporter(), appModeManager())
 
-    private fun sleepRepository() = SleepRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
+    private fun sleepRepository() = SleepRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appModeManager())
 
-    private fun supplementRepository() = SupplementRepository(api, db, syncQueue, json, NoopErrorReporter(), appModeManager())
+    private fun supplementRepository() = SupplementRepository(api, db, cacheDb, syncQueue, json, NoopErrorReporter(), appModeManager())
 
     // Entries
 

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/test/FakeKeyValueStore.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/test/FakeKeyValueStore.kt
@@ -1,0 +1,25 @@
+package com.bissbilanz.test
+
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
+import com.bissbilanz.storage.KeyValueStore
+
+class FakeKeyValueStore : KeyValueStore {
+    val values = mutableMapOf<String, String>()
+
+    override fun save(
+        key: String,
+        value: String,
+    ) {
+        values[key] = value
+    }
+
+    override fun load(key: String): String? = values[key]
+
+    override fun delete(key: String) {
+        values.remove(key)
+    }
+}
+
+/** AppModeManager backed by an in-memory store. `null` mode = not chosen (sync allowed). */
+fun appModeManager(mode: AppMode? = null): AppModeManager = AppModeManager(FakeKeyValueStore()).apply { mode?.let { setMode(it) } }

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/test/TestDatabases.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/test/TestDatabases.kt
@@ -1,0 +1,19 @@
+package com.bissbilanz.test
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.userdata.UserDataDatabase
+
+/** Fresh in-memory user-data database (userdata.db equivalent). */
+fun inMemoryUserDataDatabase(): UserDataDatabase {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    UserDataDatabase.Schema.create(driver)
+    return UserDataDatabase(driver)
+}
+
+/** Fresh in-memory cache database (bissbilanz.db equivalent: sync queue + meta). */
+fun inMemoryCacheDatabase(): BissbilanzDatabase {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    BissbilanzDatabase.Schema.create(driver)
+    return BissbilanzDatabase(driver)
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/OpenFoodFactsClient.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/OpenFoodFactsClient.kt
@@ -1,0 +1,167 @@
+package com.bissbilanz.api
+
+import com.bissbilanz.api.generated.model.OpenFoodFactsProduct
+import com.bissbilanz.createHttpEngine
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlin.math.round
+
+/**
+ * Direct Open Food Facts v2 client used in Local mode, where the app has no backend
+ * to proxy through. Replicates the field selection and mapping of the SvelteKit
+ * server proxy (`src/lib/server/openfoodfacts.ts`) so the result matches the
+ * generated [OpenFoodFactsProduct] model returned by `/api/openfoodfacts/{barcode}`.
+ */
+class OpenFoodFactsClient(
+    engine: HttpClientEngine = createHttpEngine(),
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val client =
+        HttpClient(engine) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 10_000
+            }
+        }
+
+    suspend fun fetchProduct(barcode: String): OpenFoodFactsProduct? {
+        val response =
+            client.get("$API_BASE/$barcode.json") {
+                parameter("fields", FIELDS)
+                header(HttpHeaders.UserAgent, USER_AGENT)
+                accept(ContentType.Application.Json)
+            }
+        if (!response.status.isSuccess()) return null
+
+        val root =
+            try {
+                json.parseToJsonElement(response.bodyAsText()).jsonObject
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                return null
+            }
+        if ((root["status"] as? JsonPrimitive)?.intOrNull != 1) return null
+        val product = root["product"] as? JsonObject ?: return null
+        return mapProduct(product, barcode)
+    }
+
+    private fun mapProduct(
+        product: JsonObject,
+        barcode: String,
+    ): OpenFoodFactsProduct {
+        val nutriments = product["nutriments"] as? JsonObject ?: JsonObject(emptyMap())
+
+        return OpenFoodFactsProduct(
+            // The server proxy has no separate id; the barcode identifies the product.
+            id = barcode,
+            name = product.stringOrNull("product_name") ?: "",
+            brand = product.stringOrNull("brands") ?: "",
+            barcode = barcode,
+            imageUrl = product.stringOrNull("image_front_url"),
+            nutriScore =
+                product.stringOrNull("nutriscore_grade")?.let { grade ->
+                    OpenFoodFactsProduct.NutriScore.entries.firstOrNull { it.value == grade }
+                },
+            novaGroup = nutrimentNumber(product, "nova_group")?.takeIf { it in 1.0..4.0 },
+            servingSize = 100.0,
+            servingUnit = "g",
+            calories = nutrimentNumber(nutriments, "energy-kcal_100g") ?: 0.0,
+            protein = nutrimentNumber(nutriments, "proteins_100g") ?: 0.0,
+            carbs = nutrimentNumber(nutriments, "carbohydrates_100g") ?: 0.0,
+            fat = nutrimentNumber(nutriments, "fat_100g") ?: 0.0,
+            fiber = nutrimentNumber(nutriments, "fiber_100g") ?: 0.0,
+            additives =
+                (product["additives_tags"] as? JsonArray)
+                    ?.mapNotNull { (it as? JsonPrimitive)?.takeIf { p -> p.isString }?.content }
+                    ?: emptyList(),
+            ingredientsText = product.stringOrNull("ingredients_text"),
+            saturatedFat = extractNutrient(nutriments, "saturated-fat_100g"),
+            monounsaturatedFat = extractNutrient(nutriments, "monounsaturated-fat_100g"),
+            polyunsaturatedFat = extractNutrient(nutriments, "polyunsaturated-fat_100g"),
+            transFat = extractNutrient(nutriments, "trans-fat_100g"),
+            cholesterol = extractNutrient(nutriments, "cholesterol_100g", G_TO_MG),
+            omega3 = extractNutrient(nutriments, "omega-3-fat_100g"),
+            omega6 = extractNutrient(nutriments, "omega-6-fat_100g"),
+            sugar = extractNutrient(nutriments, "sugars_100g"),
+            addedSugars = extractNutrient(nutriments, "added-sugars_100g"),
+            sugarAlcohols = extractNutrient(nutriments, "sugar-alcohols_100g"),
+            starch = extractNutrient(nutriments, "starch_100g"),
+            sodium = extractNutrient(nutriments, "sodium_100g", G_TO_MG),
+            potassium = extractNutrient(nutriments, "potassium_100g", G_TO_MG),
+            calcium = extractNutrient(nutriments, "calcium_100g", G_TO_MG),
+            iron = extractNutrient(nutriments, "iron_100g", G_TO_MG),
+            magnesium = extractNutrient(nutriments, "magnesium_100g", G_TO_MG),
+            phosphorus = extractNutrient(nutriments, "phosphorus_100g", G_TO_MG),
+            zinc = extractNutrient(nutriments, "zinc_100g", G_TO_MG),
+            copper = extractNutrient(nutriments, "copper_100g", G_TO_MG),
+            manganese = extractNutrient(nutriments, "manganese_100g", G_TO_MG),
+            selenium = extractNutrient(nutriments, "selenium_100g", G_TO_UG),
+            iodine = extractNutrient(nutriments, "iodine_100g", G_TO_UG),
+            fluoride = extractNutrient(nutriments, "fluoride_100g", G_TO_MG),
+            chromium = extractNutrient(nutriments, "chromium_100g", G_TO_UG),
+            molybdenum = extractNutrient(nutriments, "molybdenum_100g", G_TO_UG),
+            chloride = extractNutrient(nutriments, "chloride_100g", G_TO_MG),
+            vitaminA = extractNutrient(nutriments, "vitamin-a_100g", G_TO_UG),
+            vitaminC = extractNutrient(nutriments, "vitamin-c_100g", G_TO_MG),
+            vitaminD = extractNutrient(nutriments, "vitamin-d_100g", G_TO_UG),
+            vitaminE = extractNutrient(nutriments, "vitamin-e_100g", G_TO_MG),
+            vitaminK = extractNutrient(nutriments, "vitamin-k_100g", G_TO_UG),
+            vitaminB1 = extractNutrient(nutriments, "vitamin-b1_100g", G_TO_MG),
+            vitaminB2 = extractNutrient(nutriments, "vitamin-b2_100g", G_TO_MG),
+            vitaminB3 = extractNutrient(nutriments, "vitamin-b3_100g", G_TO_MG),
+            vitaminB5 = extractNutrient(nutriments, "vitamin-b5_100g", G_TO_MG),
+            vitaminB6 = extractNutrient(nutriments, "vitamin-b6_100g", G_TO_MG),
+            vitaminB7 = extractNutrient(nutriments, "vitamin-b7_100g", G_TO_UG),
+            vitaminB9 = extractNutrient(nutriments, "vitamin-b9_100g", G_TO_UG),
+            vitaminB12 = extractNutrient(nutriments, "vitamin-b12_100g", G_TO_UG),
+            caffeine = extractNutrient(nutriments, "caffeine_100g", G_TO_MG),
+            alcohol = extractNutrient(nutriments, "alcohol_100g"),
+            water = extractNutrient(nutriments, "water_100g"),
+            salt = extractNutrient(nutriments, "salt_100g"),
+        )
+    }
+
+    private fun JsonObject.stringOrNull(key: String): String? = (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
+
+    /** OFF nutriment values may be numbers or numeric strings. */
+    private fun nutrimentNumber(
+        obj: JsonObject,
+        key: String,
+    ): Double? = (obj[key] as? JsonPrimitive)?.doubleOrNull?.takeIf { !it.isNaN() }
+
+    /**
+     * Mirrors the server proxy's `extractNutrient`: optional unit conversion and
+     * rounding to 2 decimal places, null when missing or not numeric.
+     */
+    private fun extractNutrient(
+        nutriments: JsonObject,
+        offKey: String,
+        conversion: Double = 1.0,
+    ): Double? = nutrimentNumber(nutriments, offKey)?.let { round(it * conversion * 100) / 100 }
+
+    fun close() {
+        client.close()
+    }
+
+    companion object {
+        private const val API_BASE = "https://world.openfoodfacts.org/api/v2/product"
+        private const val USER_AGENT = "Bissbilanz/1.0 (https://bissbilanz.orellbuehler.ch)"
+        private const val FIELDS =
+            "product_name,brands,nutriscore_grade,nova_group,additives_tags," +
+                "ingredients_text,image_front_url,nutriments"
+        private const val G_TO_MG = 1_000.0
+        private const val G_TO_UG = 1_000_000.0
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
@@ -3,5 +3,9 @@ package com.bissbilanz.cache
 import app.cash.sqldelight.db.SqlDriver
 
 expect class DatabaseDriverFactory {
+    /** Driver for BissbilanzDatabase (bissbilanz.db): sync queue + server cache. */
     fun createDriver(): SqlDriver
+
+    /** Driver for UserDataDatabase (userdata.db): the user's own data. */
+    fun createUserDataDriver(): SqlDriver
 }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/cache/LegacyUserDataMigration.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/cache/LegacyUserDataMigration.kt
@@ -1,0 +1,227 @@
+package com.bissbilanz.cache
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import com.bissbilanz.userdata.UserDataDatabase
+
+/**
+ * One-time copy of the user-data tables out of the legacy single-database file
+ * (bissbilanz.db) into the dedicated user-data database (userdata.db).
+ *
+ * Before the database split every table lived in bissbilanz.db, which is excluded
+ * from Android Auto Backup. Existing installs therefore have their user data inside
+ * the cache file; on the first open of userdata.db this routine copies all rows over
+ * and then drops the legacy tables (BissbilanzDatabase.Schema no longer creates
+ * them, so they stay gone).
+ *
+ * Idempotency / crash-safety:
+ * - The copy and the [MARKER_KEY] row in the target's LocalMeta table are committed
+ *   in ONE transaction on the target. A crash mid-copy rolls everything back and the
+ *   copy simply reruns on the next open; a present marker means the copy committed.
+ * - Dropping the legacy tables in the source happens only after the marker is known
+ *   to be committed, and uses DROP TABLE IF EXISTS, so a crash between commit and
+ *   drop is healed on the next run.
+ * - Fresh installs have no legacy tables (missing tables are skipped); the marker is
+ *   still written so nothing reruns. A userdata.db restored via Auto Backup carries
+ *   the marker with it, which correctly prevents re-copying from the (empty) cache
+ *   database on the new device.
+ */
+object LegacyUserDataMigration {
+    internal const val MARKER_KEY = "legacy_userdata_copied"
+
+    /** Copies user data from [source] (legacy bissbilanz.db) into [target] (userdata.db). */
+    fun run(
+        source: SqlDriver,
+        target: SqlDriver,
+    ) {
+        if (!isCopied(target)) {
+            UserDataDatabase(target).userDataDatabaseQueries.transaction {
+                for (table in legacyTables) {
+                    if (tableExists(source, table.name)) copyTable(source, target, table)
+                }
+                target.execute(
+                    identifier = null,
+                    sql = "INSERT OR REPLACE INTO LocalMeta(key, value) VALUES ('$MARKER_KEY', '1')",
+                    parameters = 0,
+                )
+            }
+        }
+        // Only reached once the copy (from this or an earlier run) has committed, so
+        // removing the legacy tables is always safe — and idempotent via IF EXISTS.
+        for (table in legacyTables) {
+            source.execute(identifier = null, sql = "DROP TABLE IF EXISTS ${table.name}", parameters = 0)
+        }
+    }
+
+    /** True when the marker row is present, i.e. the copy has committed before. */
+    internal fun isCopied(target: SqlDriver): Boolean =
+        target
+            .executeQuery(
+                identifier = null,
+                sql = "SELECT 1 FROM LocalMeta WHERE key = '$MARKER_KEY'",
+                mapper = { cursor -> QueryResult.Value(cursor.next().value) },
+                parameters = 0,
+            ).value
+
+    internal fun tableExists(
+        driver: SqlDriver,
+        name: String,
+    ): Boolean =
+        driver
+            .executeQuery(
+                identifier = null,
+                sql = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '$name'",
+                mapper = { cursor -> QueryResult.Value(cursor.next().value) },
+                parameters = 0,
+            ).value
+
+    private fun copyTable(
+        source: SqlDriver,
+        target: SqlDriver,
+        table: Table,
+    ) {
+        val columns = table.columns.joinToString(", ") { it.name }
+        val placeholders = table.columns.joinToString(", ") { "?" }
+        source
+            .executeQuery(
+                identifier = null,
+                sql = "SELECT $columns FROM ${table.name}",
+                mapper = { cursor ->
+                    while (cursor.next().value) {
+                        target.execute(
+                            identifier = null,
+                            sql = "INSERT OR REPLACE INTO ${table.name}($columns) VALUES ($placeholders)",
+                            parameters = table.columns.size,
+                        ) {
+                            table.columns.forEachIndexed { index, column ->
+                                when (column.type) {
+                                    ColumnType.TEXT -> bindString(index, cursor.getString(index))
+                                    ColumnType.REAL -> bindDouble(index, cursor.getDouble(index))
+                                    ColumnType.INTEGER -> bindLong(index, cursor.getLong(index))
+                                }
+                            }
+                        }
+                    }
+                    QueryResult.Unit
+                },
+                parameters = 0,
+            ).value
+    }
+
+    private enum class ColumnType { TEXT, REAL, INTEGER }
+
+    private class Column(
+        val name: String,
+        val type: ColumnType,
+    )
+
+    private class Table(
+        val name: String,
+        vararg val columns: Column,
+    )
+
+    private fun text(name: String) = Column(name, ColumnType.TEXT)
+
+    private fun real(name: String) = Column(name, ColumnType.REAL)
+
+    private fun integer(name: String) = Column(name, ColumnType.INTEGER)
+
+    /** The user-data tables exactly as they existed in the legacy bissbilanz.db schema. */
+    private val legacyTables =
+        listOf(
+            Table(
+                "CachedEntry",
+                text("id"),
+                text("date"),
+                text("mealType"),
+                real("servings"),
+                text("foodId"),
+                text("recipeId"),
+                text("foodName"),
+                real("calories"),
+                real("protein"),
+                real("carbs"),
+                real("fat"),
+                real("fiber"),
+                text("jsonData"),
+            ),
+            Table(
+                "CachedFood",
+                text("id"),
+                text("name"),
+                text("brand"),
+                real("calories"),
+                real("protein"),
+                real("carbs"),
+                real("fat"),
+                real("fiber"),
+                integer("isFavorite"),
+                text("barcode"),
+                text("jsonData"),
+            ),
+            Table(
+                "CachedGoals",
+                integer("id"),
+                real("calorieGoal"),
+                real("proteinGoal"),
+                real("carbGoal"),
+                real("fatGoal"),
+                real("fiberGoal"),
+            ),
+            Table(
+                "CachedRecipe",
+                text("id"),
+                text("name"),
+                real("totalServings"),
+                integer("isFavorite"),
+                real("calories"),
+                real("protein"),
+                real("carbs"),
+                real("fat"),
+                real("fiber"),
+                text("jsonData"),
+            ),
+            Table(
+                "CachedSupplement",
+                text("id"),
+                text("name"),
+                integer("isActive"),
+                integer("sortOrder"),
+                text("jsonData"),
+            ),
+            Table(
+                "CachedSupplementLog",
+                text("id"),
+                text("supplementId"),
+                text("date"),
+                text("takenAt"),
+            ),
+            Table(
+                "CachedWeightEntry",
+                text("id"),
+                text("entryDate"),
+                real("weightKg"),
+                text("loggedAt"),
+                text("jsonData"),
+            ),
+            Table(
+                "CachedSleepEntry",
+                text("id"),
+                text("entryDate"),
+                integer("durationMinutes"),
+                integer("quality"),
+                text("loggedAt"),
+                text("jsonData"),
+            ),
+            Table(
+                "CachedPreferences",
+                integer("id"),
+                text("jsonData"),
+            ),
+            Table(
+                "CachedDayProperties",
+                text("date"),
+                integer("isFastingDay"),
+            ),
+        )
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/cache/LocalDataWiper.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/cache/LocalDataWiper.kt
@@ -1,0 +1,46 @@
+package com.bissbilanz.cache
+
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+/**
+ * Wipes every piece of locally stored user data: all user-data tables, the sync queue,
+ * all sync metadata (including the one-shot `migration_normalized` marker) and the
+ * meal-type cache. Used on deliberate logout — leftover rows would leak into the next
+ * account or be re-uploaded as "local data" — and by "start fresh" during migration.
+ *
+ * The `LocalMeta` table is deliberately kept: it only holds the one-time structural
+ * "legacy data copied out of bissbilanz.db" marker, not user data.
+ */
+class LocalDataWiper(
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
+    private val syncQueue: SyncQueue,
+) {
+    suspend fun wipeAll() {
+        withContext(Dispatchers.IO) {
+            syncQueue.clear()
+            val queries = db.userDataDatabaseQueries
+            queries.transaction {
+                queries.clearAllData()
+                queries.clearAllFoods()
+                queries.clearAllGoals()
+                queries.clearAllRecipes()
+                queries.clearAllSupplements()
+                queries.clearAllSupplementLogs()
+                queries.clearAllWeightEntries()
+                queries.clearAllSleepEntries()
+                queries.clearAllPreferences()
+                queries.clearAllDayProperties()
+            }
+            val cacheQueries = cacheDb.bissbilanzDatabaseQueries
+            cacheQueries.transaction {
+                cacheQueries.clearAllMealTypes()
+                cacheQueries.clearAllSyncMeta()
+            }
+        }
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
@@ -11,6 +11,7 @@ import com.bissbilanz.repository.*
 import com.bissbilanz.storage.PlainStorage
 import com.bissbilanz.sync.SyncManager
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import kotlinx.serialization.json.Json
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -21,11 +22,15 @@ val sharedModule =
         single { BissbilanzApi(get<String>(named("baseUrl")), get()) }
         single { OpenFoodFactsClient() }
         single { AppModeManager(get<PlainStorage>()) }
+        // Two database files: bissbilanz.db (sync queue + server cache, excluded from
+        // Android Auto Backup) and userdata.db (the user's data, included in backups).
         single { BissbilanzDatabase(get<DatabaseDriverFactory>().createDriver()) }
+        single { UserDataDatabase(get<DatabaseDriverFactory>().createUserDataDriver()) }
         single { SyncQueue(get(), get(), get()) }
         single {
             LocalDataMigrator(
                 db = get(),
+                cacheDb = get(),
                 api = get(),
                 json = get(),
                 appModeManager = get(),
@@ -50,14 +55,14 @@ val sharedModule =
                 isLenient = true
             }
         }
-        single { FoodRepository(get(), get(), get(), get(), get(), get(), get()) }
-        single { EntryRepository(get(), get(), get(), get(), get(), get(), get()) }
-        single { RecipeRepository(get(), get(), get(), get(), get(), get()) }
-        single { GoalsRepository(get(), get(), get(), get(), get()) }
-        single { WeightRepository(get(), get(), get(), get(), get(), get(), get()) }
-        single { SupplementRepository(get(), get(), get(), get(), get(), get()) }
+        single { FoodRepository(get(), get(), get(), get(), get(), get(), get(), get()) }
+        single { EntryRepository(get(), get(), get(), get(), get(), get(), get(), get()) }
+        single { RecipeRepository(get(), get(), get(), get(), get(), get(), get()) }
+        single { GoalsRepository(get(), get(), get(), get(), get(), get()) }
+        single { WeightRepository(get(), get(), get(), get(), get(), get(), get(), get()) }
+        single { SupplementRepository(get(), get(), get(), get(), get(), get(), get()) }
         single { StatsRepository(get(), get(), get(), get(), get()) }
-        single { SleepRepository(get(), get(), get(), get(), get(), get()) }
-        single { PreferencesRepository(get(), get(), get(), get(), get()) }
+        single { SleepRepository(get(), get(), get(), get(), get(), get(), get()) }
+        single { PreferencesRepository(get(), get(), get(), get(), get(), get()) }
         single { AnalyticsRepository(get(), get()) }
     }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
@@ -5,6 +5,7 @@ import com.bissbilanz.api.OpenFoodFactsClient
 import com.bissbilanz.auth.AuthManager
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.cache.DatabaseDriverFactory
+import com.bissbilanz.migration.LocalDataMigrator
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.repository.*
 import com.bissbilanz.storage.PlainStorage
@@ -22,6 +23,16 @@ val sharedModule =
         single { AppModeManager(get<PlainStorage>()) }
         single { BissbilanzDatabase(get<DatabaseDriverFactory>().createDriver()) }
         single { SyncQueue(get(), get(), get()) }
+        single {
+            LocalDataMigrator(
+                db = get(),
+                api = get(),
+                json = get(),
+                appModeManager = get(),
+                syncQueue = get(),
+                errorReporter = get(),
+            )
+        }
         single {
             SyncManager(
                 syncQueue = get(),

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
@@ -1,10 +1,13 @@
 package com.bissbilanz.di
 
 import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.OpenFoodFactsClient
 import com.bissbilanz.auth.AuthManager
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.cache.DatabaseDriverFactory
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.repository.*
+import com.bissbilanz.storage.PlainStorage
 import com.bissbilanz.sync.SyncManager
 import com.bissbilanz.sync.SyncQueue
 import kotlinx.serialization.json.Json
@@ -15,8 +18,10 @@ val sharedModule =
     module {
         single { AuthManager(get<String>(named("baseUrl")), get()) }
         single { BissbilanzApi(get<String>(named("baseUrl")), get()) }
+        single { OpenFoodFactsClient() }
+        single { AppModeManager(get<PlainStorage>()) }
         single { BissbilanzDatabase(get<DatabaseDriverFactory>().createDriver()) }
-        single { SyncQueue(get(), get()) }
+        single { SyncQueue(get(), get(), get()) }
         single {
             SyncManager(
                 syncQueue = get(),
@@ -24,6 +29,7 @@ val sharedModule =
                 api = get(),
                 json = get(),
                 errorReporter = get(),
+                appModeManager = get(),
             )
         }
         single {
@@ -33,14 +39,14 @@ val sharedModule =
                 isLenient = true
             }
         }
-        single { FoodRepository(get(), get(), get(), get(), get()) }
-        single { EntryRepository(get(), get(), get(), get(), get(), get()) }
-        single { RecipeRepository(get(), get(), get(), get(), get()) }
-        single { GoalsRepository(get(), get(), get(), get()) }
-        single { WeightRepository(get(), get(), get(), get(), get(), get()) }
-        single { SupplementRepository(get(), get(), get(), get(), get()) }
-        single { StatsRepository(get(), get(), get(), get()) }
-        single { SleepRepository(get(), get(), get(), get(), get()) }
-        single { PreferencesRepository(get(), get(), get(), get()) }
+        single { FoodRepository(get(), get(), get(), get(), get(), get(), get()) }
+        single { EntryRepository(get(), get(), get(), get(), get(), get(), get()) }
+        single { RecipeRepository(get(), get(), get(), get(), get(), get()) }
+        single { GoalsRepository(get(), get(), get(), get(), get()) }
+        single { WeightRepository(get(), get(), get(), get(), get(), get(), get()) }
+        single { SupplementRepository(get(), get(), get(), get(), get(), get()) }
+        single { StatsRepository(get(), get(), get(), get(), get()) }
+        single { SleepRepository(get(), get(), get(), get(), get(), get()) }
+        single { PreferencesRepository(get(), get(), get(), get(), get()) }
         single { AnalyticsRepository(get(), get()) }
     }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
@@ -5,6 +5,7 @@ import com.bissbilanz.api.OpenFoodFactsClient
 import com.bissbilanz.auth.AuthManager
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.cache.DatabaseDriverFactory
+import com.bissbilanz.cache.LocalDataWiper
 import com.bissbilanz.migration.LocalDataMigrator
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.repository.*
@@ -27,6 +28,7 @@ val sharedModule =
         single { BissbilanzDatabase(get<DatabaseDriverFactory>().createDriver()) }
         single { UserDataDatabase(get<DatabaseDriverFactory>().createUserDataDriver()) }
         single { SyncQueue(get(), get(), get()) }
+        single { LocalDataWiper(db = get(), cacheDb = get(), syncQueue = get()) }
         single {
             LocalDataMigrator(
                 db = get(),
@@ -36,6 +38,7 @@ val sharedModule =
                 appModeManager = get(),
                 syncQueue = get(),
                 errorReporter = get(),
+                localDataWiper = get(),
             )
         }
         single {
@@ -43,6 +46,7 @@ val sharedModule =
                 syncQueue = get(),
                 connectivityProvider = get(),
                 api = get(),
+                db = get(),
                 json = get(),
                 errorReporter = get(),
                 appModeManager = get(),

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/migration/LocalDataMigrator.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/migration/LocalDataMigrator.kt
@@ -15,11 +15,14 @@ import com.bissbilanz.api.generated.model.ServingUnit
 import com.bissbilanz.api.generated.model.SleepCreate
 import com.bissbilanz.api.generated.model.SleepEntry
 import com.bissbilanz.api.generated.model.Supplement
+import com.bissbilanz.api.generated.model.SupplementBackingFood
 import com.bissbilanz.api.generated.model.SupplementCreate
+import com.bissbilanz.api.generated.model.SupplementIngredient
 import com.bissbilanz.api.generated.model.SupplementIngredientInput
 import com.bissbilanz.api.generated.model.WeightCreate
 import com.bissbilanz.api.generated.model.WeightEntry
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.cache.LocalDataWiper
 import com.bissbilanz.mode.AppMode
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.Entry
@@ -90,7 +93,8 @@ sealed class MigrationState {
  *    a failed run resumable. Normalization runs once per migration attempt cycle — a
  *    marker row in `SyncMeta` skips it on retries so rows that already received server
  *    ids from a partial run are not re-keyed (and re-uploaded) again. The marker is
- *    cleared on success and by [discardLocalData].
+ *    cleared on success, by [discardLocalData] and by [resetNormalization] (called when
+ *    an attempt cycle is abandoned).
  * 3. Upload in dependency order — foods, recipes, entries, weights, sleep, supplements,
  *    supplement logs, goals, preferences, day properties. After every successful create
  *    the local row is immediately replaced with the server record and all local
@@ -115,6 +119,7 @@ class LocalDataMigrator(
     private val appModeManager: AppModeManager,
     private val syncQueue: SyncQueue,
     private val errorReporter: ErrorReporter,
+    private val localDataWiper: LocalDataWiper,
 ) {
     private val _state = MutableStateFlow<MigrationState>(MigrationState.Idle)
     val state: StateFlow<MigrationState> = _state.asStateFlow()
@@ -160,29 +165,22 @@ class LocalDataMigrator(
      * then flips the mode to [AppMode.SYNCED].
      */
     suspend fun discardLocalData() {
-        syncQueue.clear()
-        queries.transaction {
-            queries.clearAllData()
-            queries.clearAllFoods()
-            queries.clearAllGoals()
-            queries.clearAllRecipes()
-            queries.clearAllSupplements()
-            queries.clearAllSupplementLogs()
-            queries.clearAllWeightEntries()
-            queries.clearAllSleepEntries()
-            queries.clearAllPreferences()
-            queries.clearAllDayProperties()
-        }
-        cacheQueries.transaction {
-            cacheQueries.clearAllMealTypes()
-            cacheQueries.clearAllSyncMeta()
-        }
+        localDataWiper.wipeAll()
         appModeManager.setMode(AppMode.SYNCED)
     }
 
+    /**
+     * Clears the one-shot normalization marker. Must be called when a migration attempt
+     * cycle is abandoned (e.g. the user cancels back to Local mode) — a stale marker
+     * would make a later migration skip re-keying rows it has never seen.
+     */
+    fun resetNormalization() {
+        cacheQueries.deleteSyncMeta(NORMALIZED_MARKER)
+    }
+
     private suspend fun runMigration() {
-        val total = plan().total
         try {
+            val total = plan().total
             _state.value = MigrationState.Running(0, total, STEP_PREPARE)
             syncQueue.clear()
             normalizeOnce()
@@ -515,21 +513,30 @@ class LocalDataMigrator(
             val cached =
                 json.decodeOrNull<RecipeDetail>(row.jsonData)
                     ?: throw IllegalStateException("Could not read local recipe \"${row.name}\"")
+            val ingredients =
+                cached.ingredients
+                    // Dangling food references (food deleted locally) are dropped.
+                    .filterNot { it.foodId.startsWith(TEMP_PREFIX) }
+                    .map {
+                        RecipeIngredientInput(
+                            foodId = it.foodId,
+                            quantity = it.quantity,
+                            servingUnit = ServingUnit.valueOf(it.servingUnit.name),
+                        )
+                    }
+            if (ingredients.isEmpty()) {
+                // The server rejects ingredient-less recipes (min 1). Nothing usable is
+                // left of this recipe — drop it locally instead of failing the whole
+                // migration with a 400 forever. Its entries fall back to quick entries.
+                queries.deleteRecipe(row.id)
+                progress(++done, total, STEP_RECIPES)
+                continue
+            }
             val create =
                 RecipeCreate(
                     name = cached.name,
                     totalServings = cached.totalServings,
-                    ingredients =
-                        cached.ingredients
-                            // Dangling food references (food deleted locally) are dropped.
-                            .filterNot { it.foodId.startsWith(TEMP_PREFIX) }
-                            .map {
-                                RecipeIngredientInput(
-                                    foodId = it.foodId,
-                                    quantity = it.quantity,
-                                    servingUnit = ServingUnit.valueOf(it.servingUnit.name),
-                                )
-                            },
+                    ingredients = ingredients,
                     isFavorite = cached.isFavorite,
                     imageUrl = cached.imageUrl,
                 )
@@ -659,21 +666,20 @@ class LocalDataMigrator(
             val cached =
                 json.decodeOrNull<Supplement>(row.jsonData)
                     ?: throw IllegalStateException("Could not read local supplement \"${row.name}\"")
+            val ingredients = cached.ingredients.mapNotNull { it.toIngredientInput() }
+            if (ingredients.isEmpty()) {
+                // The server rejects ingredient-less supplements (min 1). Drop the shell
+                // locally instead of failing the whole migration with a 400 forever; its
+                // logs are removed by the orphan handling in uploadSupplementLogs.
+                queries.deleteSupplement(row.id)
+                progress(++done, total, STEP_SUPPLEMENTS)
+                continue
+            }
             val create =
                 SupplementCreate(
                     name = cached.name,
                     scheduleType = SupplementCreate.ScheduleType.valueOf(cached.scheduleType.name),
-                    ingredients =
-                        cached.ingredients
-                            // Dangling food references (food deleted locally) are dropped.
-                            .filterNot { it.foodId.startsWith(TEMP_PREFIX) }
-                            .map {
-                                SupplementIngredientInput(
-                                    foodId = it.foodId,
-                                    servings = it.servings,
-                                    sortOrder = it.sortOrder,
-                                )
-                            },
+                    ingredients = ingredients,
                     scheduleDays = cached.scheduleDays,
                     scheduleStartDate = cached.scheduleStartDate,
                     isActive = cached.isActive,
@@ -774,6 +780,36 @@ class LocalDataMigrator(
     // ---------------------------------------------------------------------------------
     // Model mapping
     // ---------------------------------------------------------------------------------
+
+    /**
+     * An ingredient whose `foodId` already carries a server id references that food.
+     * A still-`temp_` foodId has no uploaded food row behind it — either the backing
+     * food was created inline with the supplement (it never exists as a local food row)
+     * or the food was deleted locally. In both cases the embedded backing food is
+     * recreated inline, mirroring what the original create request sent to the server.
+     * Returns null only when nothing usable is left (blank backing food name).
+     */
+    private fun SupplementIngredient.toIngredientInput(): SupplementIngredientInput? {
+        if (!foodId.startsWith(TEMP_PREFIX)) {
+            return SupplementIngredientInput(foodId = foodId, servings = servings, sortOrder = sortOrder)
+        }
+        if (food.name.isBlank()) return null
+        return SupplementIngredientInput(food = food.toFoodCreate(), servings = servings, sortOrder = sortOrder)
+    }
+
+    private fun SupplementBackingFood.toFoodCreate(): FoodCreate =
+        FoodCreate(
+            name = name,
+            servingSize = servingSize,
+            servingUnit = ServingUnit.entries.firstOrNull { it.value == servingUnit } ?: ServingUnit.g,
+            calories = calories,
+            protein = protein,
+            carbs = carbs,
+            fat = fat,
+            fiber = fiber,
+            brand = brand,
+            ingredientsText = ingredientsText,
+        )
 
     private fun Food.toFoodCreate(): FoodCreate =
         FoodCreate(

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/migration/LocalDataMigrator.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/migration/LocalDataMigrator.kt
@@ -1,0 +1,917 @@
+package com.bissbilanz.migration
+
+import com.bissbilanz.ErrorReporter
+import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.FavoriteMealTimeframeInput
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.api.generated.model.FoodCreate
+import com.bissbilanz.api.generated.model.Goals
+import com.bissbilanz.api.generated.model.Preferences
+import com.bissbilanz.api.generated.model.PreferencesUpdate
+import com.bissbilanz.api.generated.model.RecipeCreate
+import com.bissbilanz.api.generated.model.RecipeDetail
+import com.bissbilanz.api.generated.model.RecipeIngredientInput
+import com.bissbilanz.api.generated.model.ServingUnit
+import com.bissbilanz.api.generated.model.SleepCreate
+import com.bissbilanz.api.generated.model.SleepEntry
+import com.bissbilanz.api.generated.model.Supplement
+import com.bissbilanz.api.generated.model.SupplementCreate
+import com.bissbilanz.api.generated.model.SupplementIngredientInput
+import com.bissbilanz.api.generated.model.WeightCreate
+import com.bissbilanz.api.generated.model.WeightEntry
+import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.cache.CachedEntry
+import com.bissbilanz.mode.AppMode
+import com.bissbilanz.mode.AppModeManager
+import com.bissbilanz.model.Entry
+import com.bissbilanz.model.EntryCreate
+import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.util.decodeOrNull
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.datetime.Clock
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/** What would be uploaded by [LocalDataMigrator.migrate], counted from the local cache. */
+data class MigrationPlan(
+    val foods: Int,
+    val recipes: Int,
+    val entries: Int,
+    val weights: Int,
+    val sleepEntries: Int,
+    val supplements: Int,
+    val supplementLogs: Int,
+    val dayProperties: Int,
+    val hasGoals: Boolean,
+    val hasPreferences: Boolean,
+) {
+    val total: Int
+        get() =
+            foods + recipes + entries + weights + sleepEntries + supplements +
+                supplementLogs + dayProperties + (if (hasGoals) 1 else 0) + (if (hasPreferences) 1 else 0)
+}
+
+sealed class MigrationState {
+    data object Idle : MigrationState()
+
+    /** [step] is a stable key (see LocalDataMigrator.STEP_*) so the UI can localize labels. */
+    data class Running(
+        val done: Int,
+        val total: Int,
+        val step: String,
+    ) : MigrationState()
+
+    data object Completed : MigrationState()
+
+    data class Failed(
+        val message: String,
+    ) : MigrationState()
+}
+
+/**
+ * One-shot upload of the local (anonymous) cache state to a freshly logged-in account.
+ *
+ * Algorithm:
+ * 1. Defensively clear the sync queue (it must already be empty in Local mode; queued
+ *    ops would double-apply what this migrator uploads from the cache state).
+ * 2. Normalize: every local row whose id does NOT start with `temp_` is re-keyed to a
+ *    fresh `temp_` UUID. Such rows are stale leftovers from an earlier synced session
+ *    (logout does not wipe the cache) but they are still the user's local data.
+ *    References are rewritten together with the row: `CachedEntry.foodId/recipeId`
+ *    (column AND the embedded ids inside `jsonData`), recipe ingredient `foodId`s,
+ *    supplement ingredient `foodId`s and supplement log `supplementId`s. After this
+ *    pass the invariant "`temp_` prefix == not yet uploaded" holds, which is what makes
+ *    a failed run resumable. Normalization runs once per migration attempt cycle — a
+ *    marker row in `SyncMeta` skips it on retries so rows that already received server
+ *    ids from a partial run are not re-keyed (and re-uploaded) again. The marker is
+ *    cleared on success and by [discardLocalData].
+ * 3. Upload in dependency order — foods, recipes, entries, weights, sleep, supplements,
+ *    supplement logs, goals, preferences, day properties. After every successful create
+ *    the local row is immediately replaced with the server record and all local
+ *    references to the old temp id are rewritten to the server id. Recipe/supplement
+ *    ingredients and entry food/recipe references therefore always point at server ids
+ *    by the time their owning row is uploaded, even when resuming a failed run.
+ *    Dangling references (e.g. an entry whose food was deleted locally) still carry a
+ *    `temp_` id at upload time: entries fall back to a quick entry built from the
+ *    cached display values, recipe/supplement ingredients are dropped.
+ * 4. Only after everything succeeded the mode flips to [AppMode.SYNCED] and the state
+ *    becomes [MigrationState.Completed].
+ * 5. Any failure aborts the run ([MigrationState.Failed]) with all partial progress
+ *    preserved locally — already-uploaded rows have server ids, so calling [migrate]
+ *    again resumes by uploading only the remaining `temp_` rows. Goals, preferences and
+ *    day properties have no ids; they are idempotent set-calls and simply re-run.
+ */
+class LocalDataMigrator(
+    private val db: BissbilanzDatabase,
+    private val api: BissbilanzApi,
+    private val json: Json,
+    private val appModeManager: AppModeManager,
+    private val syncQueue: SyncQueue,
+    private val errorReporter: ErrorReporter,
+) {
+    private val _state = MutableStateFlow<MigrationState>(MigrationState.Idle)
+    val state: StateFlow<MigrationState> = _state.asStateFlow()
+
+    private val migrateMutex = Mutex()
+
+    private val queries get() = db.bissbilanzDatabaseQueries
+
+    /** Counts the local rows that [migrate] would upload. */
+    fun plan(): MigrationPlan =
+        MigrationPlan(
+            foods = queries.selectAllFoods().executeAsList().size,
+            recipes = queries.selectAllRecipes().executeAsList().size,
+            entries = queries.selectAllEntries().executeAsList().size,
+            weights = queries.selectAllWeightEntries().executeAsList().size,
+            sleepEntries = queries.selectAllSleepEntries().executeAsList().size,
+            supplements = queries.selectAllSupplements().executeAsList().size,
+            supplementLogs = queries.selectAllSupplementLogs().executeAsList().size,
+            dayProperties = queries.selectAllDayProperties().executeAsList().size,
+            hasGoals = queries.selectGoals().executeAsOneOrNull() != null,
+            hasPreferences = queries.selectPreferences().executeAsOneOrNull() != null,
+        )
+
+    /** True when the account already has foods or logged entries (cheap API checks). */
+    suspend fun serverHasData(): Boolean {
+        if (api.getFoodsPaginated(limit = 1, offset = 0).total > 0) return true
+        return api.getRecentFoods(limit = 1).isNotEmpty()
+    }
+
+    /** Uploads the local cache state to the account. Safe to call again after a failure. */
+    suspend fun migrate() {
+        if (!migrateMutex.tryLock()) return
+        try {
+            runMigration()
+        } finally {
+            migrateMutex.unlock()
+        }
+    }
+
+    /**
+     * Wipes all local user data and the sync queue (the user chose "start fresh"),
+     * then flips the mode to [AppMode.SYNCED].
+     */
+    suspend fun discardLocalData() {
+        syncQueue.clear()
+        queries.transaction {
+            queries.clearAllData()
+            queries.clearAllFoods()
+            queries.clearAllGoals()
+            queries.clearAllRecipes()
+            queries.clearAllSupplements()
+            queries.clearAllSupplementLogs()
+            queries.clearAllWeightEntries()
+            queries.clearAllSleepEntries()
+            queries.clearAllPreferences()
+            queries.clearAllMealTypes()
+            queries.clearAllDayProperties()
+            queries.clearAllSyncMeta()
+        }
+        appModeManager.setMode(AppMode.SYNCED)
+    }
+
+    private suspend fun runMigration() {
+        val total = plan().total
+        try {
+            _state.value = MigrationState.Running(0, total, STEP_PREPARE)
+            syncQueue.clear()
+            normalizeOnce()
+            var done = uploadedCount()
+            done = uploadFoods(done, total)
+            done = uploadRecipes(done, total)
+            done = uploadEntries(done, total)
+            done = uploadWeights(done, total)
+            done = uploadSleep(done, total)
+            done = uploadSupplements(done, total)
+            done = uploadSupplementLogs(done, total)
+            done = uploadGoals(done, total)
+            done = uploadPreferences(done, total)
+            uploadDayProperties(done, total)
+            queries.deleteSyncMeta(NORMALIZED_MARKER)
+            appModeManager.setMode(AppMode.SYNCED)
+            _state.value = MigrationState.Completed
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            errorReporter.captureException(e)
+            _state.value = MigrationState.Failed(e.message ?: "Migration failed")
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Normalization
+    // ---------------------------------------------------------------------------------
+
+    private fun normalizeOnce() {
+        if (queries.selectSyncMeta(NORMALIZED_MARKER).executeAsOneOrNull() != null) return
+        queries.transaction {
+            normalizeFoods()
+            normalizeRecipes()
+            normalizeSupplements()
+            normalizeEntries()
+            normalizeWeights()
+            normalizeSleep()
+            queries.upsertSyncMeta(NORMALIZED_MARKER, Clock.System.now().toString())
+        }
+    }
+
+    private fun normalizeFoods() {
+        for (row in queries.selectAllFoods().executeAsList()) {
+            if (row.id.startsWith(TEMP_PREFIX)) continue
+            val newId = newTempId()
+            val food = json.decodeOrNull<Food>(row.jsonData)?.copy(id = newId)
+            queries.deleteFood(row.id)
+            queries.insertFood(
+                id = newId,
+                name = row.name,
+                brand = row.brand,
+                calories = row.calories,
+                protein = row.protein,
+                carbs = row.carbs,
+                fat = row.fat,
+                fiber = row.fiber,
+                isFavorite = row.isFavorite,
+                barcode = row.barcode,
+                jsonData = food?.let { json.encodeToString(it) } ?: row.jsonData,
+            )
+            remapFoodReferences(row.id, newId)
+        }
+    }
+
+    private fun normalizeRecipes() {
+        for (row in queries.selectAllRecipes().executeAsList()) {
+            if (row.id.startsWith(TEMP_PREFIX)) continue
+            val newId = newTempId()
+            val recipe = json.decodeOrNull<RecipeDetail>(row.jsonData)?.copy(id = newId)
+            queries.deleteRecipe(row.id)
+            queries.insertRecipe(
+                id = newId,
+                name = row.name,
+                totalServings = row.totalServings,
+                isFavorite = row.isFavorite,
+                calories = row.calories,
+                protein = row.protein,
+                carbs = row.carbs,
+                fat = row.fat,
+                fiber = row.fiber,
+                jsonData = recipe?.let { json.encodeToString(it) } ?: row.jsonData,
+            )
+            remapRecipeReferences(row.id, newId)
+        }
+    }
+
+    private fun normalizeSupplements() {
+        for (row in queries.selectAllSupplements().executeAsList()) {
+            if (row.id.startsWith(TEMP_PREFIX)) continue
+            val newId = newTempId()
+            val supplement = json.decodeOrNull<Supplement>(row.jsonData)?.copy(id = newId)
+            queries.deleteSupplement(row.id)
+            queries.insertSupplement(
+                id = newId,
+                name = row.name,
+                isActive = row.isActive,
+                sortOrder = row.sortOrder,
+                jsonData = supplement?.let { json.encodeToString(it) } ?: row.jsonData,
+            )
+            remapSupplementReferences(row.id, newId, rekeyLogIds = true)
+        }
+    }
+
+    private fun normalizeEntries() {
+        for (row in queries.selectAllEntries().executeAsList()) {
+            if (row.id.startsWith(TEMP_PREFIX)) continue
+            val newId = newTempId()
+            val entry = json.decodeOrNull<Entry>(row.jsonData)?.copy(id = newId)
+            queries.deleteEntry(row.id)
+            insertEntryRow(row, id = newId, jsonData = entry?.let { json.encodeToString(it) } ?: row.jsonData)
+        }
+    }
+
+    private fun normalizeWeights() {
+        for (row in queries.selectAllWeightEntries().executeAsList()) {
+            if (row.id.startsWith(TEMP_PREFIX)) continue
+            val newId = newTempId()
+            val entry = json.decodeOrNull<WeightEntry>(row.jsonData)?.copy(id = newId)
+            queries.deleteWeightEntry(row.id)
+            queries.insertWeightEntry(
+                id = newId,
+                entryDate = row.entryDate,
+                weightKg = row.weightKg,
+                loggedAt = row.loggedAt,
+                jsonData = entry?.let { json.encodeToString(it) } ?: row.jsonData,
+            )
+        }
+    }
+
+    private fun normalizeSleep() {
+        for (row in queries.selectAllSleepEntries().executeAsList()) {
+            if (row.id.startsWith(TEMP_PREFIX)) continue
+            val newId = newTempId()
+            val entry = json.decodeOrNull<SleepEntry>(row.jsonData)?.copy(id = newId)
+            queries.deleteSleepEntry(row.id)
+            queries.insertSleepEntry(
+                id = newId,
+                entryDate = row.entryDate,
+                durationMinutes = row.durationMinutes,
+                quality = row.quality,
+                loggedAt = row.loggedAt,
+                jsonData = entry?.let { json.encodeToString(it) } ?: row.jsonData,
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Reference rewriting
+    // ---------------------------------------------------------------------------------
+
+    /** Rewrites entry, recipe-ingredient and supplement-ingredient references to a food id. */
+    private fun remapFoodReferences(
+        oldId: String,
+        newId: String,
+    ) {
+        for (row in queries.selectEntriesByFoodId(oldId).executeAsList()) {
+            val entry = json.decodeOrNull<Entry>(row.jsonData)
+            val updated = entry?.copy(foodId = newId, food = entry.food?.copy(id = newId))
+            insertEntryRow(
+                row,
+                foodId = newId,
+                jsonData = updated?.let { json.encodeToString(it) } ?: row.jsonData,
+            )
+        }
+        for (row in queries.selectAllRecipes().executeAsList()) {
+            val recipe = json.decodeOrNull<RecipeDetail>(row.jsonData) ?: continue
+            if (recipe.ingredients.none { it.foodId == oldId }) continue
+            val updated =
+                recipe.copy(
+                    ingredients = recipe.ingredients.map { if (it.foodId == oldId) it.copy(foodId = newId) else it },
+                )
+            queries.insertRecipe(
+                id = row.id,
+                name = row.name,
+                totalServings = row.totalServings,
+                isFavorite = row.isFavorite,
+                calories = row.calories,
+                protein = row.protein,
+                carbs = row.carbs,
+                fat = row.fat,
+                fiber = row.fiber,
+                jsonData = json.encodeToString(updated),
+            )
+        }
+        for (row in queries.selectAllSupplements().executeAsList()) {
+            val supplement = json.decodeOrNull<Supplement>(row.jsonData) ?: continue
+            if (supplement.ingredients.none { it.foodId == oldId }) continue
+            val updated =
+                supplement.copy(
+                    ingredients = supplement.ingredients.map { if (it.foodId == oldId) it.copy(foodId = newId) else it },
+                )
+            queries.insertSupplement(
+                id = row.id,
+                name = row.name,
+                isActive = row.isActive,
+                sortOrder = row.sortOrder,
+                jsonData = json.encodeToString(updated),
+            )
+        }
+    }
+
+    private fun remapRecipeReferences(
+        oldId: String,
+        newId: String,
+    ) {
+        for (row in queries.selectEntriesByRecipeId(oldId).executeAsList()) {
+            val entry = json.decodeOrNull<Entry>(row.jsonData)
+            val updated = entry?.copy(recipeId = newId, recipe = entry.recipe?.copy(id = newId))
+            insertEntryRow(
+                row,
+                recipeId = newId,
+                jsonData = updated?.let { json.encodeToString(it) } ?: row.jsonData,
+            )
+        }
+    }
+
+    /**
+     * Rewrites supplement log references. The synthesized log row id
+     * (`"<supplementId>-<date>"`) doubles as the uploaded-marker: it is only re-keyed
+     * during normalization ([rekeyLogIds] = true) or after the log itself was uploaded —
+     * NOT when the owning supplement gets its server id, so a `temp_`-prefixed log id
+     * still means "this log has not been uploaded yet".
+     */
+    private fun remapSupplementReferences(
+        oldId: String,
+        newId: String,
+        rekeyLogIds: Boolean,
+    ) {
+        for (row in queries.selectSupplementLogsBySupplementId(oldId).executeAsList()) {
+            queries.deleteSupplementLogById(row.id)
+            queries.insertSupplementLog(
+                id = if (rekeyLogIds) "$newId-${row.date}" else row.id,
+                supplementId = newId,
+                date = row.date,
+                takenAt = row.takenAt,
+            )
+        }
+    }
+
+    /** Re-inserts an entry row keeping all cached display columns unless overridden. */
+    private fun insertEntryRow(
+        row: CachedEntry,
+        id: String = row.id,
+        foodId: String? = row.foodId,
+        recipeId: String? = row.recipeId,
+        jsonData: String = row.jsonData,
+    ) {
+        queries.insertEntry(
+            id = id,
+            date = row.date,
+            mealType = row.mealType,
+            servings = row.servings,
+            foodId = foodId,
+            recipeId = recipeId,
+            foodName = row.foodName,
+            calories = row.calories,
+            protein = row.protein,
+            carbs = row.carbs,
+            fat = row.fat,
+            fiber = row.fiber,
+            jsonData = jsonData,
+        )
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Upload steps
+    // ---------------------------------------------------------------------------------
+
+    /** Items already carrying server ids from a previous partial run. */
+    private fun uploadedCount(): Int =
+        queries.selectAllFoods().executeAsList().count { !it.id.startsWith(TEMP_PREFIX) } +
+            queries.selectAllRecipes().executeAsList().count { !it.id.startsWith(TEMP_PREFIX) } +
+            queries.selectAllEntries().executeAsList().count { !it.id.startsWith(TEMP_PREFIX) } +
+            queries.selectAllWeightEntries().executeAsList().count { !it.id.startsWith(TEMP_PREFIX) } +
+            queries.selectAllSleepEntries().executeAsList().count { !it.id.startsWith(TEMP_PREFIX) } +
+            queries.selectAllSupplements().executeAsList().count { !it.id.startsWith(TEMP_PREFIX) } +
+            queries.selectAllSupplementLogs().executeAsList().count { !it.id.startsWith(TEMP_PREFIX) }
+
+    private fun progress(
+        done: Int,
+        total: Int,
+        step: String,
+    ) {
+        _state.value = MigrationState.Running(done, total, step)
+    }
+
+    private suspend fun uploadFoods(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_FOODS)
+        for (row in queries.selectAllFoods().executeAsList().filter { it.id.startsWith(TEMP_PREFIX) }) {
+            val cached =
+                json.decodeOrNull<Food>(row.jsonData)
+                    ?: throw IllegalStateException("Could not read local food \"${row.name}\"")
+            val server = api.createFood(cached.toFoodCreate())
+            queries.transaction {
+                queries.deleteFood(row.id)
+                queries.insertFood(
+                    id = server.id,
+                    name = server.name,
+                    brand = server.brand,
+                    calories = server.calories,
+                    protein = server.protein,
+                    carbs = server.carbs,
+                    fat = server.fat,
+                    fiber = server.fiber,
+                    isFavorite = if (server.isFavorite) 1L else 0L,
+                    barcode = server.barcode,
+                    jsonData = json.encodeToString(server),
+                )
+                remapFoodReferences(row.id, server.id)
+            }
+            progress(++done, total, STEP_FOODS)
+        }
+        return done
+    }
+
+    private suspend fun uploadRecipes(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_RECIPES)
+        for (row in queries.selectAllRecipes().executeAsList().filter { it.id.startsWith(TEMP_PREFIX) }) {
+            val cached =
+                json.decodeOrNull<RecipeDetail>(row.jsonData)
+                    ?: throw IllegalStateException("Could not read local recipe \"${row.name}\"")
+            val create =
+                RecipeCreate(
+                    name = cached.name,
+                    totalServings = cached.totalServings,
+                    ingredients =
+                        cached.ingredients
+                            // Dangling food references (food deleted locally) are dropped.
+                            .filterNot { it.foodId.startsWith(TEMP_PREFIX) }
+                            .map {
+                                RecipeIngredientInput(
+                                    foodId = it.foodId,
+                                    quantity = it.quantity,
+                                    servingUnit = ServingUnit.valueOf(it.servingUnit.name),
+                                )
+                            },
+                    isFavorite = cached.isFavorite,
+                    imageUrl = cached.imageUrl,
+                )
+            val server = api.createRecipe(create)
+            queries.transaction {
+                queries.deleteRecipe(row.id)
+                queries.insertRecipe(
+                    id = server.id,
+                    name = server.name,
+                    totalServings = server.totalServings,
+                    isFavorite = if (server.isFavorite) 1L else 0L,
+                    calories = server.calories,
+                    protein = server.protein,
+                    carbs = server.carbs,
+                    fat = server.fat,
+                    fiber = server.fiber,
+                    jsonData = json.encodeToString(server),
+                )
+                remapRecipeReferences(row.id, server.id)
+            }
+            progress(++done, total, STEP_RECIPES)
+        }
+        return done
+    }
+
+    private suspend fun uploadEntries(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_ENTRIES)
+        for (row in queries.selectAllEntries().executeAsList().filter { it.id.startsWith(TEMP_PREFIX) }) {
+            val cached =
+                json.decodeOrNull<Entry>(row.jsonData)
+                    ?: throw IllegalStateException("Could not read local entry from ${row.date}")
+            val server = api.createEntry(cached.toEntryCreate())
+            val updated =
+                cached.copy(
+                    id = server.id,
+                    userId = server.userId,
+                    createdAt = server.createdAt ?: cached.createdAt,
+                    updatedAt = server.updatedAt,
+                )
+            queries.transaction {
+                queries.deleteEntry(row.id)
+                insertEntryRow(row, id = server.id, jsonData = json.encodeToString(updated))
+            }
+            progress(++done, total, STEP_ENTRIES)
+        }
+        return done
+    }
+
+    private suspend fun uploadWeights(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_WEIGHTS)
+        for (row in queries.selectAllWeightEntries().executeAsList().filter { it.id.startsWith(TEMP_PREFIX) }) {
+            val cached =
+                json.decodeOrNull<WeightEntry>(row.jsonData)
+                    ?: throw IllegalStateException("Could not read local weight entry from ${row.entryDate}")
+            val server =
+                api.createWeightEntry(
+                    WeightCreate(weightKg = cached.weightKg, entryDate = cached.entryDate, notes = cached.notes),
+                )
+            queries.transaction {
+                queries.deleteWeightEntry(row.id)
+                queries.insertWeightEntry(
+                    id = server.id,
+                    entryDate = server.entryDate,
+                    weightKg = server.weightKg,
+                    loggedAt = server.loggedAt ?: row.loggedAt,
+                    jsonData = json.encodeToString(server),
+                )
+            }
+            progress(++done, total, STEP_WEIGHTS)
+        }
+        return done
+    }
+
+    private suspend fun uploadSleep(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_SLEEP)
+        for (row in queries.selectAllSleepEntries().executeAsList().filter { it.id.startsWith(TEMP_PREFIX) }) {
+            val cached =
+                json.decodeOrNull<SleepEntry>(row.jsonData)
+                    ?: throw IllegalStateException("Could not read local sleep entry from ${row.entryDate}")
+            val server =
+                api.createSleepEntry(
+                    SleepCreate(
+                        durationMinutes = cached.durationMinutes,
+                        quality = cached.quality,
+                        entryDate = cached.entryDate,
+                        bedtime = cached.bedtime,
+                        wakeTime = cached.wakeTime,
+                        wakeUps = cached.wakeUps,
+                        notes = cached.notes,
+                    ),
+                )
+            queries.transaction {
+                queries.deleteSleepEntry(row.id)
+                queries.insertSleepEntry(
+                    id = server.id,
+                    entryDate = server.entryDate,
+                    durationMinutes = server.durationMinutes.toLong(),
+                    quality = server.quality.toLong(),
+                    loggedAt = server.loggedAt ?: row.loggedAt,
+                    jsonData = json.encodeToString(server),
+                )
+            }
+            progress(++done, total, STEP_SLEEP)
+        }
+        return done
+    }
+
+    private suspend fun uploadSupplements(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_SUPPLEMENTS)
+        for (row in queries.selectAllSupplements().executeAsList().filter { it.id.startsWith(TEMP_PREFIX) }) {
+            val cached =
+                json.decodeOrNull<Supplement>(row.jsonData)
+                    ?: throw IllegalStateException("Could not read local supplement \"${row.name}\"")
+            val create =
+                SupplementCreate(
+                    name = cached.name,
+                    scheduleType = SupplementCreate.ScheduleType.valueOf(cached.scheduleType.name),
+                    ingredients =
+                        cached.ingredients
+                            // Dangling food references (food deleted locally) are dropped.
+                            .filterNot { it.foodId.startsWith(TEMP_PREFIX) }
+                            .map {
+                                SupplementIngredientInput(
+                                    foodId = it.foodId,
+                                    servings = it.servings,
+                                    sortOrder = it.sortOrder,
+                                )
+                            },
+                    scheduleDays = cached.scheduleDays,
+                    scheduleStartDate = cached.scheduleStartDate,
+                    isActive = cached.isActive,
+                    sortOrder = cached.sortOrder,
+                    timeOfDay = cached.timeOfDay?.let { SupplementCreate.TimeOfDay.valueOf(it.name) },
+                )
+            val server = api.createSupplement(create)
+            queries.transaction {
+                queries.deleteSupplement(row.id)
+                queries.insertSupplement(
+                    id = server.id,
+                    name = server.name,
+                    isActive = if (server.isActive) 1L else 0L,
+                    sortOrder = server.sortOrder.toLong(),
+                    jsonData = json.encodeToString(server),
+                )
+                remapSupplementReferences(row.id, server.id, rekeyLogIds = false)
+            }
+            progress(++done, total, STEP_SUPPLEMENTS)
+        }
+        return done
+    }
+
+    private suspend fun uploadSupplementLogs(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_SUPPLEMENT_LOGS)
+        for (row in queries.selectAllSupplementLogs().executeAsList().filter { it.id.startsWith(TEMP_PREFIX) }) {
+            if (row.supplementId.startsWith(TEMP_PREFIX)) {
+                // Orphan log (supplement deleted locally) — nothing to log it against.
+                queries.deleteSupplementLogById(row.id)
+                progress(++done, total, STEP_SUPPLEMENT_LOGS)
+                continue
+            }
+            api.logSupplement(row.supplementId, row.date)
+            queries.transaction {
+                queries.deleteSupplementLogById(row.id)
+                queries.insertSupplementLog(
+                    id = "${row.supplementId}-${row.date}",
+                    supplementId = row.supplementId,
+                    date = row.date,
+                    takenAt = row.takenAt,
+                )
+            }
+            progress(++done, total, STEP_SUPPLEMENT_LOGS)
+        }
+        return done
+    }
+
+    private suspend fun uploadGoals(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        val row = queries.selectGoals().executeAsOneOrNull() ?: return done
+        progress(done, total, STEP_GOALS)
+        api.setGoals(
+            Goals(
+                calorieGoal = row.calorieGoal,
+                proteinGoal = row.proteinGoal,
+                carbGoal = row.carbGoal,
+                fatGoal = row.fatGoal,
+                fiberGoal = row.fiberGoal,
+            ),
+        )
+        progress(++done, total, STEP_GOALS)
+        return done
+    }
+
+    private suspend fun uploadPreferences(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        val row = queries.selectPreferences().executeAsOneOrNull() ?: return done
+        val prefs = json.decodeOrNull<Preferences>(row.jsonData) ?: return done
+        progress(done, total, STEP_PREFERENCES)
+        api.updatePreferences(prefs.toPreferencesUpdate())
+        progress(++done, total, STEP_PREFERENCES)
+        return done
+    }
+
+    private suspend fun uploadDayProperties(
+        startDone: Int,
+        total: Int,
+    ): Int {
+        var done = startDone
+        progress(done, total, STEP_DAY_PROPERTIES)
+        for (row in queries.selectAllDayProperties().executeAsList()) {
+            api.setDayProperties(row.date, row.isFastingDay != 0L)
+            progress(++done, total, STEP_DAY_PROPERTIES)
+        }
+        return done
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Model mapping
+    // ---------------------------------------------------------------------------------
+
+    private fun Food.toFoodCreate(): FoodCreate =
+        FoodCreate(
+            name = name,
+            servingSize = servingSize,
+            servingUnit = ServingUnit.valueOf(servingUnit.name),
+            calories = calories,
+            protein = protein,
+            carbs = carbs,
+            fat = fat,
+            fiber = fiber,
+            brand = brand,
+            saturatedFat = saturatedFat,
+            monounsaturatedFat = monounsaturatedFat,
+            polyunsaturatedFat = polyunsaturatedFat,
+            transFat = transFat,
+            cholesterol = cholesterol,
+            omega3 = omega3,
+            omega6 = omega6,
+            sugar = sugar,
+            addedSugars = addedSugars,
+            sugarAlcohols = sugarAlcohols,
+            starch = starch,
+            sodium = sodium,
+            potassium = potassium,
+            calcium = calcium,
+            iron = iron,
+            magnesium = magnesium,
+            phosphorus = phosphorus,
+            zinc = zinc,
+            copper = copper,
+            manganese = manganese,
+            selenium = selenium,
+            iodine = iodine,
+            fluoride = fluoride,
+            chromium = chromium,
+            molybdenum = molybdenum,
+            chloride = chloride,
+            vitaminA = vitaminA,
+            vitaminC = vitaminC,
+            vitaminD = vitaminD,
+            vitaminE = vitaminE,
+            vitaminK = vitaminK,
+            vitaminB1 = vitaminB1,
+            vitaminB2 = vitaminB2,
+            vitaminB3 = vitaminB3,
+            vitaminB5 = vitaminB5,
+            vitaminB6 = vitaminB6,
+            vitaminB7 = vitaminB7,
+            vitaminB9 = vitaminB9,
+            vitaminB12 = vitaminB12,
+            caffeine = caffeine,
+            alcohol = alcohol,
+            water = water,
+            salt = salt,
+            barcode = barcode,
+            isFavorite = isFavorite,
+            nutriScore = nutriScore?.let { score -> FoodCreate.NutriScore.entries.firstOrNull { it.value == score } },
+            novaGroup = novaGroup,
+            additives = additives,
+            ingredientsText = ingredientsText,
+            imageUrl = imageUrl,
+        )
+
+    /**
+     * copyEntries-style mapping. Food/recipe references that are still unresolved
+     * (`temp_` id with no matching food/recipe row) fall back to a quick entry built
+     * from the cached display values so the log line survives the migration.
+     */
+    private fun Entry.toEntryCreate(): EntryCreate {
+        val resolvedFoodId = foodId?.takeUnless { it.startsWith(TEMP_PREFIX) }
+        val resolvedRecipeId = recipeId?.takeUnless { it.startsWith(TEMP_PREFIX) }
+        val orphan = (foodId != null && resolvedFoodId == null) || (recipeId != null && resolvedRecipeId == null)
+        return EntryCreate(
+            mealType = mealType,
+            servings = servings,
+            date = date,
+            foodId = resolvedFoodId,
+            recipeId = resolvedRecipeId,
+            notes = notes,
+            quickName = quickName ?: if (orphan) food?.name ?: recipe?.name ?: foodName else null,
+            quickCalories = quickCalories ?: if (orphan) food?.calories ?: recipe?.calories ?: calories else null,
+            quickProtein = quickProtein ?: if (orphan) food?.protein ?: recipe?.protein ?: protein else null,
+            quickCarbs = quickCarbs ?: if (orphan) food?.carbs ?: recipe?.carbs ?: carbs else null,
+            quickFat = quickFat ?: if (orphan) food?.fat ?: recipe?.fat ?: fat else null,
+            quickFiber = quickFiber ?: if (orphan) food?.fiber ?: recipe?.fiber ?: fiber else null,
+            eatenAt = eatenAt,
+        )
+    }
+
+    /**
+     * Builds the update from the cached preferences. Empty lists are sent as `null`
+     * (server default wins) because the local default state is indistinguishable from
+     * "user cleared everything".
+     */
+    private fun Preferences.toPreferencesUpdate(): PreferencesUpdate =
+        PreferencesUpdate(
+            showChartWidget = showChartWidget,
+            showFavoritesWidget = showFavoritesWidget,
+            showSupplementsWidget = showSupplementsWidget,
+            showWeightWidget = showWeightWidget,
+            showMealBreakdownWidget = showMealBreakdownWidget,
+            showTopFoodsWidget = showTopFoodsWidget,
+            showSleepWidget = showSleepWidget,
+            widgetOrder =
+                widgetOrder
+                    .mapNotNull { value -> PreferencesUpdate.WidgetOrder.entries.firstOrNull { it.value == value } }
+                    .takeIf { it.isNotEmpty() },
+            startPage = PreferencesUpdate.StartPage.entries.firstOrNull { it.value == startPage },
+            favoriteTapAction = PreferencesUpdate.FavoriteTapAction.entries.firstOrNull { it.value == favoriteTapAction },
+            favoriteMealAssignmentMode =
+                PreferencesUpdate.FavoriteMealAssignmentMode.entries
+                    .firstOrNull { it.value == favoriteMealAssignmentMode },
+            favoriteMealTimeframes =
+                favoriteMealTimeframes
+                    .map {
+                        FavoriteMealTimeframeInput(
+                            mealType = it.mealType,
+                            startTime = it.startTime,
+                            endTime = it.endTime,
+                            customMealTypeId = it.customMealTypeId,
+                        )
+                    }.takeIf { it.isNotEmpty() },
+            mealOrder = mealOrder.takeIf { it.isNotEmpty() },
+            visibleNutrients = visibleNutrients.takeIf { it.isNotEmpty() },
+            locale = locale?.let { value -> PreferencesUpdate.Locale.entries.firstOrNull { it.value == value } },
+            caloricLagDaysOverride = caloricLagDaysOverride,
+        )
+
+    @OptIn(ExperimentalUuidApi::class)
+    private fun newTempId(): String = "$TEMP_PREFIX${Uuid.random()}"
+
+    companion object {
+        private const val TEMP_PREFIX = "temp_"
+        private const val NORMALIZED_MARKER = "migration_normalized"
+
+        const val STEP_PREPARE = "prepare"
+        const val STEP_FOODS = "foods"
+        const val STEP_RECIPES = "recipes"
+        const val STEP_ENTRIES = "entries"
+        const val STEP_WEIGHTS = "weights"
+        const val STEP_SLEEP = "sleep"
+        const val STEP_SUPPLEMENTS = "supplements"
+        const val STEP_SUPPLEMENT_LOGS = "supplement_logs"
+        const val STEP_GOALS = "goals"
+        const val STEP_PREFERENCES = "preferences"
+        const val STEP_DAY_PROPERTIES = "day_properties"
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/migration/LocalDataMigrator.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/migration/LocalDataMigrator.kt
@@ -20,12 +20,13 @@ import com.bissbilanz.api.generated.model.SupplementIngredientInput
 import com.bissbilanz.api.generated.model.WeightCreate
 import com.bissbilanz.api.generated.model.WeightEntry
 import com.bissbilanz.cache.BissbilanzDatabase
-import com.bissbilanz.cache.CachedEntry
 import com.bissbilanz.mode.AppMode
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.Entry
 import com.bissbilanz.model.EntryCreate
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.CachedEntry
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -107,7 +108,8 @@ sealed class MigrationState {
  *    day properties have no ids; they are idempotent set-calls and simply re-run.
  */
 class LocalDataMigrator(
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val api: BissbilanzApi,
     private val json: Json,
     private val appModeManager: AppModeManager,
@@ -119,7 +121,8 @@ class LocalDataMigrator(
 
     private val migrateMutex = Mutex()
 
-    private val queries get() = db.bissbilanzDatabaseQueries
+    private val queries get() = db.userDataDatabaseQueries
+    private val cacheQueries get() = cacheDb.bissbilanzDatabaseQueries
 
     /** Counts the local rows that [migrate] would upload. */
     fun plan(): MigrationPlan =
@@ -168,9 +171,11 @@ class LocalDataMigrator(
             queries.clearAllWeightEntries()
             queries.clearAllSleepEntries()
             queries.clearAllPreferences()
-            queries.clearAllMealTypes()
             queries.clearAllDayProperties()
-            queries.clearAllSyncMeta()
+        }
+        cacheQueries.transaction {
+            cacheQueries.clearAllMealTypes()
+            cacheQueries.clearAllSyncMeta()
         }
         appModeManager.setMode(AppMode.SYNCED)
     }
@@ -192,7 +197,7 @@ class LocalDataMigrator(
             done = uploadGoals(done, total)
             done = uploadPreferences(done, total)
             uploadDayProperties(done, total)
-            queries.deleteSyncMeta(NORMALIZED_MARKER)
+            cacheQueries.deleteSyncMeta(NORMALIZED_MARKER)
             appModeManager.setMode(AppMode.SYNCED)
             _state.value = MigrationState.Completed
         } catch (e: Exception) {
@@ -207,7 +212,7 @@ class LocalDataMigrator(
     // ---------------------------------------------------------------------------------
 
     private fun normalizeOnce() {
-        if (queries.selectSyncMeta(NORMALIZED_MARKER).executeAsOneOrNull() != null) return
+        if (cacheQueries.selectSyncMeta(NORMALIZED_MARKER).executeAsOneOrNull() != null) return
         queries.transaction {
             normalizeFoods()
             normalizeRecipes()
@@ -215,8 +220,11 @@ class LocalDataMigrator(
             normalizeEntries()
             normalizeWeights()
             normalizeSleep()
-            queries.upsertSyncMeta(NORMALIZED_MARKER, Clock.System.now().toString())
         }
+        // The marker lives in the cache DB, so it cannot be committed atomically with
+        // the normalization above. Written only after the commit: a crash in between
+        // re-runs normalization, which is a no-op for rows that already carry temp_ ids.
+        cacheQueries.upsertSyncMeta(NORMALIZED_MARKER, Clock.System.now().toString())
     }
 
     private fun normalizeFoods() {

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/mode/AppMode.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/mode/AppMode.kt
@@ -1,0 +1,55 @@
+package com.bissbilanz.mode
+
+import com.bissbilanz.storage.KeyValueStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * How the app stores and syncs data.
+ *
+ * - [LOCAL]: anonymous, no backend. The local SQLite database is the primary store;
+ *   nothing is ever enqueued for sync and refresh calls are no-ops.
+ * - [SYNCED]: logged in. The backend is the source of truth; the local database is an
+ *   offline cache and writes are queued for upload.
+ */
+enum class AppMode {
+    LOCAL,
+    SYNCED,
+}
+
+/**
+ * Holds the persisted app mode. A `null` mode means the user has not chosen yet —
+ * this is also the state for existing logged-in installs after an upgrade, which must
+ * keep behaving exactly as before. Therefore anything other than [AppMode.LOCAL]
+ * (including `null`) is treated as "sync allowed".
+ */
+class AppModeManager(
+    private val storage: KeyValueStore,
+) {
+    private val _mode = MutableStateFlow<AppMode?>(null)
+    val mode: StateFlow<AppMode?> = _mode.asStateFlow()
+
+    val isLocal: Boolean get() = mode.value == AppMode.LOCAL
+
+    /** Loads the persisted mode. Call once at app startup, before any sync starts. */
+    fun initialize() {
+        val stored = storage.load(KEY_APP_MODE)
+        _mode.value = AppMode.entries.firstOrNull { it.name == stored }
+    }
+
+    fun setMode(mode: AppMode) {
+        storage.save(KEY_APP_MODE, mode.name)
+        _mode.value = mode
+    }
+
+    /** Clears the persisted mode (used on logout) and emits `null`. */
+    fun clear() {
+        storage.delete(KEY_APP_MODE)
+        _mode.value = null
+    }
+
+    companion object {
+        private const val KEY_APP_MODE = "app_mode"
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
@@ -59,7 +59,7 @@ class EntryRepository(
         val tempEntry = entryCreateToEntry(entry, food, recipe)
         cacheEntry(tempEntry)
         syncNutritionForCurrentDate()
-        syncQueue.enqueue(SyncOperation.CreateEntry(json.encodeToString(entry)))
+        syncQueue.enqueue(SyncOperation.CreateEntry(json.encodeToString(entry), localId = tempEntry.id))
         onEntryChanged?.invoke()
         return tempEntry
     }
@@ -88,7 +88,9 @@ class EntryRepository(
                 )
             }
         syncNutritionForCurrentDate()
-        if (!id.startsWith("temp_")) {
+        if (id.startsWith("temp_")) {
+            coalesceQueuedCreate(id, entry)
+        } else {
             syncQueue.enqueue(SyncOperation.UpdateEntry(id, json.encodeToString(entry)))
         }
         onEntryChanged?.invoke()
@@ -98,10 +100,29 @@ class EntryRepository(
     suspend fun deleteEntry(id: String) {
         db.bissbilanzDatabaseQueries.deleteEntry(id)
         syncNutritionForCurrentDate()
-        if (!id.startsWith("temp_")) {
+        if (id.startsWith("temp_")) {
+            syncQueue.removeByAffected("entries", id)
+        } else {
             syncQueue.enqueue(SyncOperation.DeleteEntry(id))
         }
         onEntryChanged?.invoke()
+    }
+
+    /**
+     * Rewrites the still-queued Create operation for a temp-id entry so the eventual
+     * upload carries the edited values. If the create has already been drained (no
+     * queued op found), the update is skipped, matching the previous behavior.
+     */
+    private suspend fun coalesceQueuedCreate(
+        tempId: String,
+        update: EntryUpdate,
+    ) {
+        for (req in syncQueue.findByAffected("entries", tempId)) {
+            val create = req.operation as? SyncOperation.CreateEntry ?: continue
+            val body = json.decodeOrNull<EntryCreate>(create.body) ?: continue
+            val merged = applyUpdate(body, update)
+            syncQueue.replaceOperation(req.id, create.copy(body = json.encodeToString(merged)))
+        }
     }
 
     suspend fun getDayProperties(date: String) = api.getDayProperties(date)
@@ -218,6 +239,26 @@ class EntryRepository(
             createdAt = Clock.System.now().toString(),
             food = food,
             recipe = recipe,
+        )
+
+    private fun applyUpdate(
+        existing: EntryCreate,
+        update: EntryUpdate,
+    ): EntryCreate =
+        existing.copy(
+            foodId = update.foodId ?: existing.foodId,
+            recipeId = update.recipeId ?: existing.recipeId,
+            mealType = update.mealType ?: existing.mealType,
+            servings = update.servings ?: existing.servings,
+            date = update.date ?: existing.date,
+            notes = update.notes ?: existing.notes,
+            quickName = update.quickName ?: existing.quickName,
+            quickCalories = update.quickCalories ?: existing.quickCalories,
+            quickProtein = update.quickProtein ?: existing.quickProtein,
+            quickCarbs = update.quickCarbs ?: existing.quickCarbs,
+            quickFat = update.quickFat ?: existing.quickFat,
+            quickFiber = update.quickFiber ?: existing.quickFiber,
+            eatenAt = update.eatenAt ?: existing.eatenAt,
         )
 
     private fun applyUpdate(

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
@@ -10,6 +10,7 @@ import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.*
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.totalMacros
 import kotlinx.coroutines.Dispatchers
@@ -24,7 +25,8 @@ import kotlin.uuid.Uuid
 
 class EntryRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val healthSync: HealthSyncService,
     private val syncQueue: SyncQueue,
     private val json: Json,
@@ -35,14 +37,14 @@ class EntryRepository(
     var onEntryChanged: (suspend () -> Unit)? = null
 
     fun entriesByDate(date: String): Flow<List<Entry>> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectEntriesByDate(date)
             .asFlow()
             .mapToList(Dispatchers.IO)
             .map { rows -> rows.mapNotNull { json.decodeOrNull<Entry>(it.jsonData) } }
 
     suspend fun entriesByDateOnce(date: String): List<Entry> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectEntriesByDate(date)
             .executeAsList()
             .mapNotNull { json.decodeOrNull<Entry>(it.jsonData) }
@@ -73,7 +75,7 @@ class EntryRepository(
         entry: EntryUpdate,
     ): Entry {
         val cached =
-            db.bissbilanzDatabaseQueries
+            db.userDataDatabaseQueries
                 .selectEntriesByDate(currentDate ?: entry.date ?: "")
                 .executeAsList()
         val existing = cached.mapNotNull { json.decodeOrNull<Entry>(it.jsonData) }.find { it.id == id }
@@ -102,7 +104,7 @@ class EntryRepository(
     }
 
     suspend fun deleteEntry(id: String) {
-        db.bissbilanzDatabaseQueries.deleteEntry(id)
+        db.userDataDatabaseQueries.deleteEntry(id)
         syncNutritionForCurrentDate()
         if (id.startsWith("temp_")) {
             syncQueue.removeByAffected("entries", id)
@@ -140,7 +142,7 @@ class EntryRepository(
             if (props != null) {
                 cacheDayProperties(props)
             } else {
-                db.bissbilanzDatabaseQueries.deleteDayProperties(date)
+                db.userDataDatabaseQueries.deleteDayProperties(date)
             }
             props
         } catch (e: Exception) {
@@ -163,20 +165,20 @@ class EntryRepository(
     }
 
     suspend fun deleteDayProperties(date: String) {
-        db.bissbilanzDatabaseQueries.deleteDayProperties(date)
+        db.userDataDatabaseQueries.deleteDayProperties(date)
         if (!appModeManager.isLocal) {
             syncQueue.enqueue(SyncOperation.DeleteDayProperties(date))
         }
     }
 
     private fun cachedDayProperties(date: String): DayProperties? =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectDayProperties(date)
             .executeAsOneOrNull()
             ?.let { DayProperties(date = it.date, isFastingDay = it.isFastingDay != 0L) }
 
     private fun cacheDayProperties(props: DayProperties) {
-        db.bissbilanzDatabaseQueries.upsertDayProperties(
+        db.userDataDatabaseQueries.upsertDayProperties(
             date = props.date,
             isFastingDay = if (props.isFastingDay) 1L else 0L,
         )
@@ -214,7 +216,7 @@ class EntryRepository(
     private suspend fun syncNutritionForCurrentDate() {
         val date = currentDate ?: return
         try {
-            val cached = db.bissbilanzDatabaseQueries.selectEntriesByDate(date).executeAsList()
+            val cached = db.userDataDatabaseQueries.selectEntriesByDate(date).executeAsList()
             val entries = cached.mapNotNull { json.decodeOrNull<Entry>(it.jsonData) }
             val totals = entries.totalMacros()
             healthSync.syncNutrition(date, totals)
@@ -231,7 +233,7 @@ class EntryRepository(
         val carbs = entry.food?.carbs ?: entry.carbs ?: entry.quickCarbs ?: 0.0
         val fat = entry.food?.fat ?: entry.fat ?: entry.quickFat ?: 0.0
         val fiber = entry.food?.fiber ?: entry.fiber ?: entry.quickFiber ?: 0.0
-        db.bissbilanzDatabaseQueries.insertEntry(
+        db.userDataDatabaseQueries.insertEntry(
             id = entry.id,
             date = entry.date,
             mealType = entry.mealType,
@@ -252,14 +254,15 @@ class EntryRepository(
         date: String,
         entries: List<Entry>,
     ) {
-        db.bissbilanzDatabaseQueries.transaction {
-            db.bissbilanzDatabaseQueries.deleteEntriesByDate(date)
+        db.userDataDatabaseQueries.transaction {
+            db.userDataDatabaseQueries.deleteEntriesByDate(date)
             entries.forEach { entry -> cacheEntry(entry.copy(date = date)) }
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "entries:$date",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
         }
+        // SyncMeta lives in the cache database; written after the user-data commit.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "entries:$date",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/EntryRepository.kt
@@ -6,6 +6,7 @@ import com.bissbilanz.ErrorReporter
 import com.bissbilanz.HealthSyncService
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.*
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
@@ -28,6 +29,7 @@ class EntryRepository(
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) {
     private var currentDate: String? = null
     var onEntryChanged: (suspend () -> Unit)? = null
@@ -47,6 +49,8 @@ class EntryRepository(
 
     suspend fun refresh(date: String) {
         currentDate = date
+        // In Local mode the cache is the primary store; there is nothing to refresh.
+        if (appModeManager.isLocal) return
         val entries = api.getEntries(date)
         cacheEntries(date, entries)
     }
@@ -125,14 +129,58 @@ class EntryRepository(
         }
     }
 
-    suspend fun getDayProperties(date: String) = api.getDayProperties(date)
+    /**
+     * Cache-first day properties. In Local mode the cache is authoritative; in Synced
+     * mode the API result is cached and the cache serves as offline fallback.
+     */
+    suspend fun getDayProperties(date: String): DayProperties? {
+        if (appModeManager.isLocal) return cachedDayProperties(date)
+        return try {
+            val props = api.getDayProperties(date)
+            if (props != null) {
+                cacheDayProperties(props)
+            } else {
+                db.bissbilanzDatabaseQueries.deleteDayProperties(date)
+            }
+            props
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            errorReporter.captureException(e)
+            cachedDayProperties(date)
+        }
+    }
 
     suspend fun setDayProperties(
         date: String,
         isFastingDay: Boolean,
-    ) = api.setDayProperties(date, isFastingDay)
+    ): DayProperties {
+        val props = DayProperties(date = date, isFastingDay = isFastingDay)
+        cacheDayProperties(props)
+        if (!appModeManager.isLocal) {
+            syncQueue.enqueue(SyncOperation.SetDayProperties(date, isFastingDay))
+        }
+        return props
+    }
 
-    suspend fun deleteDayProperties(date: String) = api.deleteDayProperties(date)
+    suspend fun deleteDayProperties(date: String) {
+        db.bissbilanzDatabaseQueries.deleteDayProperties(date)
+        if (!appModeManager.isLocal) {
+            syncQueue.enqueue(SyncOperation.DeleteDayProperties(date))
+        }
+    }
+
+    private fun cachedDayProperties(date: String): DayProperties? =
+        db.bissbilanzDatabaseQueries
+            .selectDayProperties(date)
+            .executeAsOneOrNull()
+            ?.let { DayProperties(date = it.date, isFastingDay = it.isFastingDay != 0L) }
+
+    private fun cacheDayProperties(props: DayProperties) {
+        db.bissbilanzDatabaseQueries.upsertDayProperties(
+            date = props.date,
+            isFastingDay = if (props.isFastingDay) 1L else 0L,
+        )
+    }
 
     suspend fun copyEntries(
         fromDate: String,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
@@ -13,6 +13,7 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.mergeOpenFoodFactsOntoFood
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +33,8 @@ import kotlin.uuid.Uuid
 
 class FoodRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
@@ -45,14 +47,14 @@ class FoodRepository(
     val recentFoods: StateFlow<List<Food>> = _recentFoods.asStateFlow()
 
     fun allFoods(): Flow<List<Food>> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectAllFoods()
             .asFlow()
             .mapToList(Dispatchers.IO)
             .map { rows -> rows.mapNotNull { json.decodeOrNull<Food>(it.jsonData) } }
 
     fun favorites(): Flow<List<Food>> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectFavorites()
             .asFlow()
             .mapToList(Dispatchers.IO)
@@ -64,7 +66,7 @@ class FoodRepository(
     ): FoodsListResponse {
         if (appModeManager.isLocal) {
             val all =
-                db.bissbilanzDatabaseQueries
+                db.userDataDatabaseQueries
                     .selectAllFoods()
                     .executeAsList()
                     .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
@@ -94,7 +96,7 @@ class FoodRepository(
         if (appModeManager.isLocal) {
             // Derive recents from the local entry log so the add-food flow still works.
             _recentFoods.value =
-                db.bissbilanzDatabaseQueries
+                db.userDataDatabaseQueries
                     .selectRecentFoods(limit.toLong())
                     .executeAsList()
                     .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
@@ -136,13 +138,13 @@ class FoodRepository(
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
-            val cached = db.bissbilanzDatabaseQueries.selectFoodById(id).executeAsOneOrNull()
+            val cached = db.userDataDatabaseQueries.selectFoodById(id).executeAsOneOrNull()
             cached?.let { json.decodeOrNull<Food>(it.jsonData) } ?: throw e
         }
     }
 
     fun getFoodCached(id: String): Food? {
-        val cached = db.bissbilanzDatabaseQueries.selectFoodById(id).executeAsOneOrNull()
+        val cached = db.userDataDatabaseQueries.selectFoodById(id).executeAsOneOrNull()
         return cached?.let { json.decodeOrNull<Food>(it.jsonData) }
     }
 
@@ -170,7 +172,7 @@ class FoodRepository(
     }
 
     suspend fun deleteFood(id: String) {
-        db.bissbilanzDatabaseQueries.deleteFood(id)
+        db.userDataDatabaseQueries.deleteFood(id)
         if (id.startsWith("temp_")) {
             syncQueue.removeByAffected("foods", id)
         } else {
@@ -208,7 +210,7 @@ class FoodRepository(
 
     private fun searchFoodsCached(query: String): List<Food> {
         val pattern = "%$query%"
-        return db.bissbilanzDatabaseQueries
+        return db.userDataDatabaseQueries
             .searchFoods(pattern, pattern, 50)
             .executeAsList()
             .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
@@ -254,7 +256,7 @@ class FoodRepository(
 
     suspend fun findByBarcode(barcode: String): Food? {
         if (appModeManager.isLocal) {
-            return db.bissbilanzDatabaseQueries
+            return db.userDataDatabaseQueries
                 .selectFoodByBarcode(barcode)
                 .executeAsOneOrNull()
                 ?.let { json.decodeOrNull<Food>(it.jsonData) }
@@ -272,7 +274,7 @@ class FoodRepository(
                 }
             val cacheResult =
                 async(ioDispatcher) {
-                    db.bissbilanzDatabaseQueries
+                    db.userDataDatabaseQueries
                         .selectFoodByBarcode(barcode)
                         .executeAsOneOrNull()
                         ?.let { json.decodeOrNull<Food>(it.jsonData) }
@@ -291,7 +293,7 @@ class FoodRepository(
     }
 
     private fun cacheFood(food: Food) {
-        db.bissbilanzDatabaseQueries.insertFood(
+        db.userDataDatabaseQueries.insertFood(
             id = food.id,
             name = food.name,
             brand = food.brand,
@@ -307,13 +309,14 @@ class FoodRepository(
     }
 
     private fun cacheFoods(foods: List<Food>) {
-        db.bissbilanzDatabaseQueries.transaction {
+        db.userDataDatabaseQueries.transaction {
             foods.forEach { food -> cacheFood(food) }
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "foods",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
         }
+        // SyncMeta lives in the cache database; written after the user-data commit.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "foods",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
@@ -4,10 +4,13 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.OpenFoodFactsClient
 import com.bissbilanz.api.generated.model.Food
 import com.bissbilanz.api.generated.model.FoodCreate
 import com.bissbilanz.api.generated.model.FoodsListResponse
+import com.bissbilanz.api.generated.model.OpenFoodFactsProduct
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.util.decodeOrNull
@@ -33,6 +36,8 @@ class FoodRepository(
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
+    private val openFoodFactsClient: OpenFoodFactsClient,
     private val ioDispatcher: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.IO,
 ) {
     var onFoodChanged: (suspend () -> Unit)? = null
@@ -57,6 +62,14 @@ class FoodRepository(
         limit: Int = 20,
         offset: Int = 0,
     ): FoodsListResponse {
+        if (appModeManager.isLocal) {
+            val all =
+                db.bissbilanzDatabaseQueries
+                    .selectAllFoods()
+                    .executeAsList()
+                    .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
+            return FoodsListResponse(foods = all.drop(offset).take(limit), total = all.size)
+        }
         val response = api.getFoodsPaginated(limit, offset)
         cacheFoods(response.foods)
         return response
@@ -66,16 +79,27 @@ class FoodRepository(
         limit: Int = 100,
         offset: Int = 0,
     ) {
+        if (appModeManager.isLocal) return
         val foods = api.getFoods(limit, offset)
         cacheFoods(foods)
     }
 
     suspend fun refreshFavorites() {
+        if (appModeManager.isLocal) return
         val favs = api.getFavorites()
         favs.forEach { cacheFood(it) }
     }
 
     suspend fun refreshRecentFoods(limit: Int = 20) {
+        if (appModeManager.isLocal) {
+            // Derive recents from the local entry log so the add-food flow still works.
+            _recentFoods.value =
+                db.bissbilanzDatabaseQueries
+                    .selectRecentFoods(limit.toLong())
+                    .executeAsList()
+                    .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
+            return
+        }
         _recentFoods.value =
             api.getRecentFoods(limit).map { recent ->
                 Food(
@@ -101,8 +125,11 @@ class FoodRepository(
             }
     }
 
-    suspend fun getFood(id: String): Food =
-        try {
+    suspend fun getFood(id: String): Food {
+        if (appModeManager.isLocal) {
+            return getFoodCached(id) ?: throw IllegalStateException("Food $id not found in local database")
+        }
+        return try {
             val food = api.getFood(id)
             cacheFood(food)
             food
@@ -112,6 +139,7 @@ class FoodRepository(
             val cached = db.bissbilanzDatabaseQueries.selectFoodById(id).executeAsOneOrNull()
             cached?.let { json.decodeOrNull<Food>(it.jsonData) } ?: throw e
         }
+    }
 
     fun getFoodCached(id: String): Food? {
         val cached = db.bissbilanzDatabaseQueries.selectFoodById(id).executeAsOneOrNull()
@@ -167,17 +195,40 @@ class FoodRepository(
         }
     }
 
-    suspend fun searchFoods(query: String): List<Food> =
-        try {
+    suspend fun searchFoods(query: String): List<Food> {
+        if (appModeManager.isLocal) return searchFoodsCached(query)
+        return try {
             api.searchFoods(query)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
-            val pattern = "%$query%"
-            db.bissbilanzDatabaseQueries
-                .searchFoods(pattern, pattern, 50)
-                .executeAsList()
-                .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
+            searchFoodsCached(query)
+        }
+    }
+
+    private fun searchFoodsCached(query: String): List<Food> {
+        val pattern = "%$query%"
+        return db.bissbilanzDatabaseQueries
+            .searchFoods(pattern, pattern, 50)
+            .executeAsList()
+            .mapNotNull { json.decodeOrNull<Food>(it.jsonData) }
+    }
+
+    /**
+     * Looks up a barcode in Open Food Facts: via the backend proxy when synced, via
+     * the public OFF API directly when in Local mode (no backend available).
+     */
+    suspend fun lookupOpenFoodFacts(barcode: String): OpenFoodFactsProduct? =
+        if (appModeManager.isLocal) {
+            try {
+                openFoodFactsClient.fetchProduct(barcode)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                errorReporter.captureException(e)
+                null
+            }
+        } else {
+            api.lookupOpenFoodFacts(barcode)
         }
 
     suspend fun enrichFood(
@@ -185,8 +236,14 @@ class FoodRepository(
         barcode: String,
     ): Food {
         val product =
-            api.lookupOpenFoodFacts(barcode)
+            lookupOpenFoodFacts(barcode)
                 ?: throw IllegalStateException("Product not found in Open Food Facts")
+        if (appModeManager.isLocal) {
+            val current = getFoodCached(id) ?: throw IllegalStateException("Food $id not found in local database")
+            val enriched = mergeOpenFoodFactsOntoFood(baseline = current, product = product)
+            // updateFood is cache-write + (mode-gated) enqueue and fires onFoodChanged.
+            return updateFood(id, enriched)
+        }
         val current = api.getFood(id)
         val enriched = mergeOpenFoodFactsOntoFood(baseline = current, product = product)
         val updated = api.updateFood(id, enriched)
@@ -195,8 +252,14 @@ class FoodRepository(
         return updated
     }
 
-    suspend fun findByBarcode(barcode: String): Food? =
-        coroutineScope {
+    suspend fun findByBarcode(barcode: String): Food? {
+        if (appModeManager.isLocal) {
+            return db.bissbilanzDatabaseQueries
+                .selectFoodByBarcode(barcode)
+                .executeAsOneOrNull()
+                ?.let { json.decodeOrNull<Food>(it.jsonData) }
+        }
+        return coroutineScope {
             val apiResult =
                 async {
                     try {
@@ -225,6 +288,7 @@ class FoodRepository(
                 cachedFood
             }
         }
+    }
 
     private fun cacheFood(food: Food) {
         db.bissbilanzDatabaseQueries.insertFood(
@@ -271,10 +335,53 @@ class FoodRepository(
             fiber = food.fiber,
             barcode = food.barcode,
             isFavorite = food.isFavorite ?: false,
-            nutriScore = null,
-            novaGroup = null,
-            additives = null,
-            ingredientsText = null,
+            nutriScore = food.nutriScore?.value,
+            novaGroup = food.novaGroup,
+            additives = food.additives,
+            ingredientsText = food.ingredientsText,
             imageUrl = food.imageUrl,
+            saturatedFat = food.saturatedFat,
+            monounsaturatedFat = food.monounsaturatedFat,
+            polyunsaturatedFat = food.polyunsaturatedFat,
+            transFat = food.transFat,
+            cholesterol = food.cholesterol,
+            omega3 = food.omega3,
+            omega6 = food.omega6,
+            sugar = food.sugar,
+            addedSugars = food.addedSugars,
+            sugarAlcohols = food.sugarAlcohols,
+            starch = food.starch,
+            sodium = food.sodium,
+            potassium = food.potassium,
+            calcium = food.calcium,
+            iron = food.iron,
+            magnesium = food.magnesium,
+            phosphorus = food.phosphorus,
+            zinc = food.zinc,
+            copper = food.copper,
+            manganese = food.manganese,
+            selenium = food.selenium,
+            iodine = food.iodine,
+            fluoride = food.fluoride,
+            chromium = food.chromium,
+            molybdenum = food.molybdenum,
+            chloride = food.chloride,
+            vitaminA = food.vitaminA,
+            vitaminC = food.vitaminC,
+            vitaminD = food.vitaminD,
+            vitaminE = food.vitaminE,
+            vitaminK = food.vitaminK,
+            vitaminB1 = food.vitaminB1,
+            vitaminB2 = food.vitaminB2,
+            vitaminB3 = food.vitaminB3,
+            vitaminB5 = food.vitaminB5,
+            vitaminB6 = food.vitaminB6,
+            vitaminB7 = food.vitaminB7,
+            vitaminB9 = food.vitaminB9,
+            vitaminB12 = food.vitaminB12,
+            caffeine = food.caffeine,
+            alcohol = food.alcohol,
+            water = food.water,
+            salt = food.salt,
         )
 }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/FoodRepository.kt
@@ -121,7 +121,7 @@ class FoodRepository(
     suspend fun createFood(food: FoodCreate): Food {
         val tempFood = foodCreateToFood(food)
         cacheFood(tempFood)
-        syncQueue.enqueue(SyncOperation.CreateFood(json.encodeToString(food)))
+        syncQueue.enqueue(SyncOperation.CreateFood(json.encodeToString(food), localId = tempFood.id))
         onFoodChanged?.invoke()
         return tempFood
     }
@@ -132,15 +132,39 @@ class FoodRepository(
     ): Food {
         val tempFood = foodCreateToFood(food, id)
         cacheFood(tempFood)
-        syncQueue.enqueue(SyncOperation.UpdateFood(id, json.encodeToString(food)))
+        if (id.startsWith("temp_")) {
+            coalesceQueuedCreate(id, food)
+        } else {
+            syncQueue.enqueue(SyncOperation.UpdateFood(id, json.encodeToString(food)))
+        }
         onFoodChanged?.invoke()
         return tempFood
     }
 
     suspend fun deleteFood(id: String) {
         db.bissbilanzDatabaseQueries.deleteFood(id)
-        syncQueue.enqueue(SyncOperation.DeleteFood(id))
+        if (id.startsWith("temp_")) {
+            syncQueue.removeByAffected("foods", id)
+        } else {
+            syncQueue.enqueue(SyncOperation.DeleteFood(id))
+        }
         onFoodChanged?.invoke()
+    }
+
+    /**
+     * Rewrites the still-queued Create operation for a temp-id food so the eventual
+     * upload carries the edited values. Updates use the full [FoodCreate] body, so the
+     * new body simply replaces the queued one. If the create has already been drained
+     * (no queued op found), the update is skipped — the temp id is unknown server-side.
+     */
+    private suspend fun coalesceQueuedCreate(
+        tempId: String,
+        food: FoodCreate,
+    ) {
+        for (req in syncQueue.findByAffected("foods", tempId)) {
+            val create = req.operation as? SyncOperation.CreateFood ?: continue
+            syncQueue.replaceOperation(req.id, create.copy(body = json.encodeToString(food)))
+        }
     }
 
     suspend fun searchFoods(query: String): List<Food> =

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/GoalsRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/GoalsRepository.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.Goals
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import kotlinx.coroutines.Dispatchers
@@ -20,6 +21,7 @@ class GoalsRepository(
     private val db: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
+    private val appModeManager: AppModeManager,
 ) {
     fun goals(): Flow<Goals?> =
         db.bissbilanzDatabaseQueries
@@ -53,6 +55,7 @@ class GoalsRepository(
             }
 
     suspend fun refresh() {
+        if (appModeManager.isLocal) return
         val goals = api.getGoals()
         if (goals != null) {
             cacheGoals(goals)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/GoalsRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/GoalsRepository.kt
@@ -8,6 +8,7 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
@@ -18,13 +19,14 @@ import kotlinx.serialization.json.Json
 
 class GoalsRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val appModeManager: AppModeManager,
 ) {
     fun goals(): Flow<Goals?> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectGoals()
             .asFlow()
             .mapToOneOrNull(Dispatchers.IO)
@@ -41,7 +43,7 @@ class GoalsRepository(
             }
 
     suspend fun goalsOnce(): Goals? =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectGoals()
             .executeAsOneOrNull()
             ?.let {
@@ -69,18 +71,17 @@ class GoalsRepository(
     }
 
     private fun cacheGoals(goals: Goals) {
-        db.bissbilanzDatabaseQueries.transaction {
-            db.bissbilanzDatabaseQueries.insertGoals(
-                calorieGoal = goals.calorieGoal,
-                proteinGoal = goals.proteinGoal,
-                carbGoal = goals.carbGoal,
-                fatGoal = goals.fatGoal,
-                fiberGoal = goals.fiberGoal,
-            )
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "goals",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
-        }
+        db.userDataDatabaseQueries.insertGoals(
+            calorieGoal = goals.calorieGoal,
+            proteinGoal = goals.proteinGoal,
+            carbGoal = goals.carbGoal,
+            fatGoal = goals.fatGoal,
+            fiberGoal = goals.fiberGoal,
+        )
+        // SyncMeta lives in the cache database; written after the user-data write.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "goals",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
@@ -9,6 +9,7 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -20,20 +21,21 @@ import kotlinx.serialization.json.Json
 
 class PreferencesRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val appModeManager: AppModeManager,
 ) {
     fun preferences(): Flow<Preferences?> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectPreferences()
             .asFlow()
             .mapToOneOrNull(Dispatchers.IO)
             .map { cached ->
                 cached?.let {
                     json.decodeOrNull<Preferences>(it.jsonData) ?: run {
-                        db.bissbilanzDatabaseQueries.deletePreferences()
+                        db.userDataDatabaseQueries.deletePreferences()
                         null
                     }
                 }
@@ -46,11 +48,11 @@ class PreferencesRepository(
     }
 
     suspend fun updatePreferences(update: PreferencesUpdate): Preferences {
-        val cached = db.bissbilanzDatabaseQueries.selectPreferences().executeAsOneOrNull()
+        val cached = db.userDataDatabaseQueries.selectPreferences().executeAsOneOrNull()
         val current =
             cached?.let {
                 json.decodeOrNull<Preferences>(it.jsonData) ?: run {
-                    db.bissbilanzDatabaseQueries.deletePreferences()
+                    db.userDataDatabaseQueries.deletePreferences()
                     null
                 }
             } ?: Preferences(
@@ -77,15 +79,14 @@ class PreferencesRepository(
     }
 
     private fun cachePreferences(prefs: Preferences) {
-        db.bissbilanzDatabaseQueries.transaction {
-            db.bissbilanzDatabaseQueries.insertPreferences(
-                jsonData = json.encodeToString(prefs),
-            )
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "preferences",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
-        }
+        db.userDataDatabaseQueries.insertPreferences(
+            jsonData = json.encodeToString(prefs),
+        )
+        // SyncMeta lives in the cache database; written after the user-data write.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "preferences",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 
     private fun applyUpdate(

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/PreferencesRepository.kt
@@ -6,6 +6,7 @@ import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.generated.model.Preferences
 import com.bissbilanz.api.generated.model.PreferencesUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.util.decodeOrNull
@@ -22,6 +23,7 @@ class PreferencesRepository(
     private val db: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
+    private val appModeManager: AppModeManager,
 ) {
     fun preferences(): Flow<Preferences?> =
         db.bissbilanzDatabaseQueries
@@ -38,6 +40,7 @@ class PreferencesRepository(
             }
 
     suspend fun refresh() {
+        if (appModeManager.isLocal) return
         val prefs = api.getPreferences()
         cachePreferences(prefs)
     }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
@@ -90,7 +90,7 @@ class RecipeRepository(
     suspend fun createRecipe(recipe: RecipeCreate): RecipeDetail {
         val temp = recipeCreateToRecipe(recipe)
         cacheRecipe(temp)
-        syncQueue.enqueue(SyncOperation.CreateRecipe(json.encodeToString(recipe)))
+        syncQueue.enqueue(SyncOperation.CreateRecipe(json.encodeToString(recipe), localId = temp.id))
         return temp
     }
 
@@ -127,13 +127,45 @@ class RecipeRepository(
                     ingredients = emptyList(),
                 )
             }
-        syncQueue.enqueue(SyncOperation.UpdateRecipe(id, json.encodeToString(recipe)))
+        if (id.startsWith("temp_")) {
+            coalesceQueuedCreate(id, recipe)
+        } else {
+            syncQueue.enqueue(SyncOperation.UpdateRecipe(id, json.encodeToString(recipe)))
+        }
         return result
     }
 
     suspend fun deleteRecipe(id: String) {
         db.bissbilanzDatabaseQueries.deleteRecipe(id)
-        syncQueue.enqueue(SyncOperation.DeleteRecipe(id))
+        if (id.startsWith("temp_")) {
+            syncQueue.removeByAffected("recipes", id)
+        } else {
+            syncQueue.enqueue(SyncOperation.DeleteRecipe(id))
+        }
+    }
+
+    /**
+     * Rewrites the still-queued Create operation for a temp-id recipe so the eventual
+     * upload carries the edited values. If the create has already been drained (no
+     * queued op found), the update is skipped — the temp id is unknown server-side.
+     */
+    private suspend fun coalesceQueuedCreate(
+        tempId: String,
+        update: RecipeUpdate,
+    ) {
+        for (req in syncQueue.findByAffected("recipes", tempId)) {
+            val create = req.operation as? SyncOperation.CreateRecipe ?: continue
+            val body = json.decodeOrNull<RecipeCreate>(create.body) ?: continue
+            val merged =
+                body.copy(
+                    name = update.name ?: body.name,
+                    totalServings = update.totalServings ?: body.totalServings,
+                    ingredients = update.ingredients ?: body.ingredients,
+                    isFavorite = update.isFavorite ?: body.isFavorite,
+                    imageUrl = update.imageUrl ?: body.imageUrl,
+                )
+            syncQueue.replaceOperation(req.id, create.copy(body = json.encodeToString(merged)))
+        }
     }
 
     private fun cacheRecipe(recipe: RecipeDetail) {

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
@@ -8,6 +8,7 @@ import com.bissbilanz.api.generated.model.RecipeCreate
 import com.bissbilanz.api.generated.model.RecipeDetail
 import com.bissbilanz.api.generated.model.RecipeUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.util.decodeOrNull
@@ -27,6 +28,7 @@ class RecipeRepository(
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) {
     fun allRecipes(): Flow<List<RecipeDetail>> =
         db.bissbilanzDatabaseQueries
@@ -36,6 +38,7 @@ class RecipeRepository(
             .map { rows -> rows.mapNotNull { json.decodeOrNull<RecipeDetail>(it.jsonData) } }
 
     suspend fun refresh() {
+        if (appModeManager.isLocal) return
         val summaries = api.getRecipes()
         db.bissbilanzDatabaseQueries.transaction {
             db.bissbilanzDatabaseQueries.deleteAllRecipes()
@@ -75,8 +78,13 @@ class RecipeRepository(
         }
     }
 
-    suspend fun getRecipe(id: String): RecipeDetail =
-        try {
+    suspend fun getRecipe(id: String): RecipeDetail {
+        if (appModeManager.isLocal) {
+            val cached = db.bissbilanzDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
+            return cached?.let { json.decodeOrNull<RecipeDetail>(it.jsonData) }
+                ?: throw IllegalStateException("Recipe $id not found in local database")
+        }
+        return try {
             val recipe = api.getRecipe(id)
             cacheRecipe(recipe)
             recipe
@@ -86,6 +94,7 @@ class RecipeRepository(
             val cached = db.bissbilanzDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
             cached?.let { json.decodeOrNull<RecipeDetail>(it.jsonData) } ?: throw e
         }
+    }
 
     suspend fun createRecipe(recipe: RecipeCreate): RecipeDetail {
         val temp = recipeCreateToRecipe(recipe)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
@@ -11,6 +11,7 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -24,14 +25,15 @@ import kotlin.uuid.Uuid
 
 class RecipeRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
     private val appModeManager: AppModeManager,
 ) {
     fun allRecipes(): Flow<List<RecipeDetail>> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectAllRecipes()
             .asFlow()
             .mapToList(Dispatchers.IO)
@@ -40,8 +42,8 @@ class RecipeRepository(
     suspend fun refresh() {
         if (appModeManager.isLocal) return
         val summaries = api.getRecipes()
-        db.bissbilanzDatabaseQueries.transaction {
-            db.bissbilanzDatabaseQueries.deleteAllRecipes()
+        db.userDataDatabaseQueries.transaction {
+            db.userDataDatabaseQueries.deleteAllRecipes()
             summaries.forEach { s ->
                 val recipe =
                     RecipeDetail(
@@ -58,7 +60,7 @@ class RecipeRepository(
                         fiber = s.fiber,
                         ingredients = emptyList(),
                     )
-                db.bissbilanzDatabaseQueries.insertRecipe(
+                db.userDataDatabaseQueries.insertRecipe(
                     id = recipe.id,
                     name = recipe.name,
                     totalServings = recipe.totalServings,
@@ -71,16 +73,17 @@ class RecipeRepository(
                     jsonData = json.encodeToString(recipe),
                 )
             }
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "recipes",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
         }
+        // SyncMeta lives in the cache database; written after the user-data commit.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "recipes",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 
     suspend fun getRecipe(id: String): RecipeDetail {
         if (appModeManager.isLocal) {
-            val cached = db.bissbilanzDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
+            val cached = db.userDataDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
             return cached?.let { json.decodeOrNull<RecipeDetail>(it.jsonData) }
                 ?: throw IllegalStateException("Recipe $id not found in local database")
         }
@@ -91,7 +94,7 @@ class RecipeRepository(
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
-            val cached = db.bissbilanzDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
+            val cached = db.userDataDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
             cached?.let { json.decodeOrNull<RecipeDetail>(it.jsonData) } ?: throw e
         }
     }
@@ -107,7 +110,7 @@ class RecipeRepository(
         id: String,
         recipe: RecipeUpdate,
     ): RecipeDetail {
-        val cached = db.bissbilanzDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
+        val cached = db.userDataDatabaseQueries.selectRecipeById(id).executeAsOneOrNull()
         val existing = cached?.let { json.decodeOrNull<RecipeDetail>(it.jsonData) }
         val result =
             if (existing != null) {
@@ -145,7 +148,7 @@ class RecipeRepository(
     }
 
     suspend fun deleteRecipe(id: String) {
-        db.bissbilanzDatabaseQueries.deleteRecipe(id)
+        db.userDataDatabaseQueries.deleteRecipe(id)
         if (id.startsWith("temp_")) {
             syncQueue.removeByAffected("recipes", id)
         } else {
@@ -178,7 +181,7 @@ class RecipeRepository(
     }
 
     private fun cacheRecipe(recipe: RecipeDetail) {
-        db.bissbilanzDatabaseQueries.insertRecipe(
+        db.userDataDatabaseQueries.insertRecipe(
             id = recipe.id,
             name = recipe.name,
             totalServings = recipe.totalServings,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/RecipeRepository.kt
@@ -4,14 +4,18 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.Food
 import com.bissbilanz.api.generated.model.RecipeCreate
 import com.bissbilanz.api.generated.model.RecipeDetail
+import com.bissbilanz.api.generated.model.RecipeIngredient
+import com.bissbilanz.api.generated.model.RecipeIngredientInput
 import com.bissbilanz.api.generated.model.RecipeUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.userdata.UserDataDatabase
+import com.bissbilanz.util.computeRecipePerServingMacros
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -115,12 +119,14 @@ class RecipeRepository(
         val result =
             if (existing != null) {
                 val updated =
-                    existing.copy(
-                        name = recipe.name ?: existing.name,
-                        totalServings = recipe.totalServings ?: existing.totalServings,
-                        isFavorite = recipe.isFavorite ?: existing.isFavorite,
-                        imageUrl = recipe.imageUrl ?: existing.imageUrl,
-                    )
+                    existing
+                        .copy(
+                            name = recipe.name ?: existing.name,
+                            totalServings = recipe.totalServings ?: existing.totalServings,
+                            isFavorite = recipe.isFavorite ?: existing.isFavorite,
+                            imageUrl = recipe.imageUrl ?: existing.imageUrl,
+                            ingredients = recipe.ingredients?.toRecipeIngredients() ?: existing.ingredients,
+                        ).withRecomputedMacros()
                 cacheRecipe(updated)
                 updated
             } else {
@@ -136,8 +142,8 @@ class RecipeRepository(
                     carbs = 0.0,
                     fat = 0.0,
                     fiber = 0.0,
-                    ingredients = emptyList(),
-                )
+                    ingredients = recipe.ingredients?.toRecipeIngredients() ?: emptyList(),
+                ).withRecomputedMacros()
             }
         if (id.startsWith("temp_")) {
             coalesceQueuedCreate(id, recipe)
@@ -209,6 +215,39 @@ class RecipeRepository(
             carbs = 0.0,
             fat = 0.0,
             fiber = 0.0,
-            ingredients = emptyList(),
+            ingredients = recipe.ingredients.toRecipeIngredients(),
+        ).withRecomputedMacros()
+
+    private fun List<RecipeIngredientInput>.toRecipeIngredients(): List<RecipeIngredient> =
+        mapIndexed { index, input ->
+            RecipeIngredient(
+                foodId = input.foodId,
+                quantity = input.quantity,
+                servingUnit = RecipeIngredient.ServingUnit.valueOf(input.servingUnit.name),
+                sortOrder = index,
+            )
+        }
+
+    /**
+     * Recomputes the per-serving macros from the locally cached ingredient foods,
+     * matching the server's computation. When that is not possible (no ingredients, or
+     * a referenced food is not cached locally — possible in Synced mode), the current
+     * values are kept and the next server refresh corrects them.
+     */
+    private fun RecipeDetail.withRecomputedMacros(): RecipeDetail {
+        val macros =
+            computeRecipePerServingMacros(ingredients, totalServings) { foodId ->
+                db.userDataDatabaseQueries
+                    .selectFoodById(foodId)
+                    .executeAsOneOrNull()
+                    ?.let { json.decodeOrNull<Food>(it.jsonData) }
+            } ?: return this
+        return copy(
+            calories = macros.calories,
+            protein = macros.protein,
+            carbs = macros.carbs,
+            fat = macros.fat,
+            fiber = macros.fiber,
         )
+    }
 }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
@@ -9,6 +9,7 @@ import com.bissbilanz.api.generated.model.SleepEntry
 import com.bissbilanz.api.generated.model.SleepFoodCorrelationEntry
 import com.bissbilanz.api.generated.model.SleepUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.util.decodeOrNull
@@ -28,6 +29,7 @@ class SleepRepository(
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) {
     fun entries(): Flow<List<SleepEntry>> =
         db.bissbilanzDatabaseQueries
@@ -40,6 +42,7 @@ class SleepRepository(
         from: String? = null,
         to: String? = null,
     ) {
+        if (appModeManager.isLocal) return
         try {
             val entries = api.getSleepEntries(from, to)
             cacheSleepEntries(entries)
@@ -159,14 +162,17 @@ class SleepRepository(
     suspend fun getSleepFoodCorrelation(
         startDate: String,
         endDate: String,
-    ): List<SleepFoodCorrelationEntry> =
-        try {
+    ): List<SleepFoodCorrelationEntry> {
+        // Server-side analytics; the UI hides this in Local mode.
+        if (appModeManager.isLocal) return emptyList()
+        return try {
             api.getSleepFoodCorrelation(startDate, endDate)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
             emptyList()
         }
+    }
 
     private fun cacheSleepEntry(entry: SleepEntry) {
         db.bissbilanzDatabaseQueries.insertSleepEntry(

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
@@ -52,7 +52,7 @@ class SleepRepository(
     suspend fun createEntry(entry: SleepCreate): SleepEntry {
         val temp = sleepCreateToEntry(entry)
         cacheSleepEntry(temp)
-        syncQueue.enqueue(SyncOperation.CreateSleep(json.encodeToString(entry)))
+        syncQueue.enqueue(SyncOperation.CreateSleep(json.encodeToString(entry), localId = temp.id))
         return temp
     }
 
@@ -94,13 +94,47 @@ class SleepRepository(
                     notes = entry.notes,
                 )
             }
-        syncQueue.enqueue(SyncOperation.UpdateSleep(id, json.encodeToString(entry)))
+        if (id.startsWith("temp_")) {
+            coalesceQueuedCreate(id, entry)
+        } else {
+            syncQueue.enqueue(SyncOperation.UpdateSleep(id, json.encodeToString(entry)))
+        }
         return result
     }
 
     suspend fun deleteEntry(id: String) {
         db.bissbilanzDatabaseQueries.deleteSleepEntry(id)
-        syncQueue.enqueue(SyncOperation.DeleteSleep(id))
+        if (id.startsWith("temp_")) {
+            syncQueue.removeByAffected("sleep", id)
+        } else {
+            syncQueue.enqueue(SyncOperation.DeleteSleep(id))
+        }
+    }
+
+    /**
+     * Rewrites the still-queued Create operation for a temp-id sleep entry so the
+     * eventual upload carries the edited values. If the create has already been drained
+     * (no queued op found), the update is skipped — the temp id is unknown server-side.
+     */
+    private suspend fun coalesceQueuedCreate(
+        tempId: String,
+        update: SleepUpdate,
+    ) {
+        for (req in syncQueue.findByAffected("sleep", tempId)) {
+            val create = req.operation as? SyncOperation.CreateSleep ?: continue
+            val body = json.decodeOrNull<SleepCreate>(create.body) ?: continue
+            val merged =
+                body.copy(
+                    durationMinutes = update.durationMinutes ?: body.durationMinutes,
+                    quality = update.quality ?: body.quality,
+                    entryDate = update.entryDate ?: body.entryDate,
+                    bedtime = update.bedtime ?: body.bedtime,
+                    wakeTime = update.wakeTime ?: body.wakeTime,
+                    wakeUps = update.wakeUps ?: body.wakeUps,
+                    notes = update.notes ?: body.notes,
+                )
+            syncQueue.replaceOperation(req.id, create.copy(body = json.encodeToString(merged)))
+        }
     }
 
     /**

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
@@ -12,6 +12,7 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -25,14 +26,15 @@ import kotlin.uuid.Uuid
 
 class SleepRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
     private val appModeManager: AppModeManager,
 ) {
     fun entries(): Flow<List<SleepEntry>> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectAllSleepEntries()
             .asFlow()
             .mapToList(Dispatchers.IO)
@@ -63,7 +65,7 @@ class SleepRepository(
         id: String,
         entry: SleepUpdate,
     ): SleepEntry {
-        val cached = db.bissbilanzDatabaseQueries.selectAllSleepEntries().executeAsList()
+        val cached = db.userDataDatabaseQueries.selectAllSleepEntries().executeAsList()
         val existing = cached.mapNotNull { json.decodeOrNull<SleepEntry>(it.jsonData) }.find { it.id == id }
         val result =
             if (existing != null) {
@@ -106,7 +108,7 @@ class SleepRepository(
     }
 
     suspend fun deleteEntry(id: String) {
-        db.bissbilanzDatabaseQueries.deleteSleepEntry(id)
+        db.userDataDatabaseQueries.deleteSleepEntry(id)
         if (id.startsWith("temp_")) {
             syncQueue.removeByAffected("sleep", id)
         } else {
@@ -152,7 +154,7 @@ class SleepRepository(
     }
 
     private fun findInCache(id: String): SleepEntry? =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectAllSleepEntries()
             .executeAsList()
             .asSequence()
@@ -175,7 +177,7 @@ class SleepRepository(
     }
 
     private fun cacheSleepEntry(entry: SleepEntry) {
-        db.bissbilanzDatabaseQueries.insertSleepEntry(
+        db.userDataDatabaseQueries.insertSleepEntry(
             id = entry.id,
             entryDate = entry.entryDate,
             durationMinutes = entry.durationMinutes.toLong(),
@@ -186,14 +188,15 @@ class SleepRepository(
     }
 
     private fun cacheSleepEntries(entries: List<SleepEntry>) {
-        db.bissbilanzDatabaseQueries.transaction {
-            db.bissbilanzDatabaseQueries.deleteAllSleepEntries()
+        db.userDataDatabaseQueries.transaction {
+            db.userDataDatabaseQueries.deleteAllSleepEntries()
             entries.forEach { entry -> cacheSleepEntry(entry) }
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "sleep",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
         }
+        // SyncMeta lives in the cache database; written after the user-data commit.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "sleep",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/StatsRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/StatsRepository.kt
@@ -3,6 +3,7 @@ package com.bissbilanz.repository
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.*
 import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.totalMacros
@@ -16,18 +17,21 @@ class StatsRepository(
     private val db: BissbilanzDatabase,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) {
     suspend fun getDailyStats(
         startDate: String,
         endDate: String,
-    ): DailyStatsResponse =
-        try {
+    ): DailyStatsResponse {
+        if (appModeManager.isLocal) return computeDailyStatsFromCache(startDate, endDate)
+        return try {
             api.getDailyStats(startDate, endDate)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
             computeDailyStatsFromCache(startDate, endDate)
         }
+    }
 
     suspend fun getWeeklyStats(): WeeklyStatsResponse = api.getWeeklyStats()
 
@@ -48,6 +52,8 @@ class StatsRepository(
     ): TopFoodsResponse = api.getTopFoods(days, limit)
 
     suspend fun getCalendarStats(month: String): List<CalendarDay> {
+        // In Local mode the local DB is complete, so the calendar is computed from cache.
+        if (appModeManager.isLocal) return computeCalendarStatsFromCache(month)
         val response = api.getCalendarStats(month)
         val days =
             response.days.map { (date, raw) ->
@@ -59,6 +65,21 @@ class StatsRepository(
             }
         return days.sortedBy { it.date }
     }
+
+    /** [month] is "YYYY-MM"; dates are zero-padded so string range comparison works. */
+    private fun computeCalendarStatsFromCache(month: String): List<CalendarDay> =
+        db.bissbilanzDatabaseQueries
+            .selectEntriesByDateRange("$month-01", "$month-31")
+            .executeAsList()
+            .groupBy { it.date }
+            .map { (date, rows) ->
+                val entries = rows.mapNotNull { json.decodeOrNull<Entry>(it.jsonData) }
+                CalendarDay(
+                    date = date,
+                    calories = entries.totalMacros().calories,
+                    hasEntries = entries.isNotEmpty(),
+                )
+            }.sortedBy { it.date }
 
     private fun computeDailyStatsFromCache(
         startDate: String,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/StatsRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/StatsRepository.kt
@@ -2,9 +2,9 @@ package com.bissbilanz.repository
 
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.api.BissbilanzApi
-import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.*
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import com.bissbilanz.util.totalMacros
 import kotlinx.datetime.DateTimeUnit
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.Json
 
 class StatsRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
     private val json: Json,
     private val errorReporter: ErrorReporter,
     private val appModeManager: AppModeManager,
@@ -68,7 +68,7 @@ class StatsRepository(
 
     /** [month] is "YYYY-MM"; dates are zero-padded so string range comparison works. */
     private fun computeCalendarStatsFromCache(month: String): List<CalendarDay> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectEntriesByDateRange("$month-01", "$month-31")
             .executeAsList()
             .groupBy { it.date }
@@ -88,7 +88,7 @@ class StatsRepository(
         val data = mutableListOf<DailyStatsEntry>()
         var current = startDate
         while (current <= endDate) {
-            val rows = db.bissbilanzDatabaseQueries.selectEntriesByDate(current).executeAsList()
+            val rows = db.userDataDatabaseQueries.selectEntriesByDate(current).executeAsList()
             if (rows.isNotEmpty()) {
                 val entries = rows.mapNotNull { json.decodeOrNull<Entry>(it.jsonData) }
                 val totals = entries.totalMacros()
@@ -107,7 +107,7 @@ class StatsRepository(
         }
 
         val goals =
-            db.bissbilanzDatabaseQueries.selectGoals().executeAsOneOrNull()?.let {
+            db.userDataDatabaseQueries.selectGoals().executeAsOneOrNull()?.let {
                 GoalsSummary(
                     calorieGoal = it.calorieGoal,
                     proteinGoal = it.proteinGoal,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
@@ -8,6 +8,7 @@ import com.bissbilanz.api.generated.model.Supplement
 import com.bissbilanz.api.generated.model.SupplementCreate
 import com.bissbilanz.api.generated.model.SupplementLog
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.SupplementHistoryEntry
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
@@ -36,6 +37,7 @@ class SupplementRepository(
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) {
     fun supplements(): Flow<List<Supplement>> =
         db.bissbilanzDatabaseQueries
@@ -45,6 +47,7 @@ class SupplementRepository(
             .map { rows -> rows.mapNotNull { json.decodeOrNull<Supplement>(it.jsonData) } }
 
     suspend fun refresh() {
+        if (appModeManager.isLocal) return
         val supplements = api.getSupplements()
         cacheSupplements(supplements)
     }
@@ -96,8 +99,9 @@ class SupplementRepository(
         }
     }
 
-    suspend fun getChecklist(date: String): List<SupplementLog> =
-        try {
+    suspend fun getChecklist(date: String): List<SupplementLog> {
+        if (appModeManager.isLocal) return checklistFromCache(date)
+        return try {
             val checklist = api.getSupplementChecklist(date)
             val logs =
                 checklist.filter { it.taken }.map { item ->
@@ -120,9 +124,15 @@ class SupplementRepository(
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
-            val cachedLogs =
-                db.bissbilanzDatabaseQueries.selectSupplementLogsByDate(date).executeAsList()
-            cachedLogs.map { log ->
+            checklistFromCache(date)
+        }
+    }
+
+    private fun checklistFromCache(date: String): List<SupplementLog> =
+        db.bissbilanzDatabaseQueries
+            .selectSupplementLogsByDate(date)
+            .executeAsList()
+            .map { log ->
                 SupplementLog(
                     supplementId = log.supplementId,
                     date = log.date,
@@ -130,7 +140,6 @@ class SupplementRepository(
                     entryIds = emptyList(),
                 )
             }
-        }
 
     @OptIn(ExperimentalUuidApi::class)
     suspend fun logSupplement(
@@ -167,35 +176,51 @@ class SupplementRepository(
     suspend fun getHistory(
         from: String,
         to: String,
-    ): List<SupplementHistoryEntry> =
-        try {
+    ): List<SupplementHistoryEntry> {
+        if (appModeManager.isLocal) return historyFromCache(from, to)
+        return try {
             api.getSupplementHistory(from, to).history
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
-            val logs =
-                db.bissbilanzDatabaseQueries
-                    .selectSupplementLogsByDateRange(from, to)
-                    .executeAsList()
-            val supplements =
-                db.bissbilanzDatabaseQueries
-                    .selectAllSupplements()
-                    .executeAsList()
-                    .mapNotNull { row -> json.decodeOrNull<Supplement>(row.jsonData)?.let { row.id to it } }
-                    .toMap()
-            logs.map { log ->
-                val supplement = supplements[log.supplementId]
-                SupplementHistoryEntry(
-                    supplementId = log.supplementId,
-                    supplementName = supplement?.name ?: "",
-                    date = log.date,
-                    takenAt = log.takenAt,
-                )
-            }
+            historyFromCache(from, to)
         }
+    }
 
-    suspend fun getAllSupplements(): List<Supplement> =
-        try {
+    private fun historyFromCache(
+        from: String,
+        to: String,
+    ): List<SupplementHistoryEntry> {
+        val logs =
+            db.bissbilanzDatabaseQueries
+                .selectSupplementLogsByDateRange(from, to)
+                .executeAsList()
+        val supplements =
+            db.bissbilanzDatabaseQueries
+                .selectAllSupplements()
+                .executeAsList()
+                .mapNotNull { row -> json.decodeOrNull<Supplement>(row.jsonData)?.let { row.id to it } }
+                .toMap()
+        return logs.map { log ->
+            val supplement = supplements[log.supplementId]
+            SupplementHistoryEntry(
+                supplementId = log.supplementId,
+                supplementName = supplement?.name ?: "",
+                date = log.date,
+                takenAt = log.takenAt,
+            )
+        }
+    }
+
+    suspend fun getAllSupplements(): List<Supplement> {
+        if (appModeManager.isLocal) {
+            // The local DB is the primary store in Local mode; an empty list is the truth.
+            return db.bissbilanzDatabaseQueries
+                .selectAllSupplements()
+                .executeAsList()
+                .mapNotNull { json.decodeOrNull<Supplement>(it.jsonData) }
+        }
+        return try {
             val all = api.getAllSupplements().supplements
             cacheSupplements(all, includeInactive = true)
             all
@@ -209,6 +234,7 @@ class SupplementRepository(
                 throw e
             }
         }
+    }
 
     private fun cacheSupplement(supplement: Supplement) {
         db.bissbilanzDatabaseQueries.insertSupplement(

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
@@ -12,6 +12,7 @@ import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.model.SupplementHistoryEntry
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -33,14 +34,15 @@ private fun cacheKeyFor(
 
 class SupplementRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
     private val appModeManager: AppModeManager,
 ) {
     fun supplements(): Flow<List<Supplement>> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectActiveSupplements()
             .asFlow()
             .mapToList(Dispatchers.IO)
@@ -74,7 +76,7 @@ class SupplementRepository(
     }
 
     suspend fun deleteSupplement(id: String) {
-        db.bissbilanzDatabaseQueries.deleteSupplement(id)
+        db.userDataDatabaseQueries.deleteSupplement(id)
         if (id.startsWith("temp_")) {
             syncQueue.removeByAffected("supplements", id)
         } else {
@@ -113,7 +115,7 @@ class SupplementRepository(
                     )
                 }
             logs.forEach { log ->
-                db.bissbilanzDatabaseQueries.insertSupplementLog(
+                db.userDataDatabaseQueries.insertSupplementLog(
                     id = cacheKeyFor(log.supplementId, log.date),
                     supplementId = log.supplementId,
                     date = log.date,
@@ -129,7 +131,7 @@ class SupplementRepository(
     }
 
     private fun checklistFromCache(date: String): List<SupplementLog> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectSupplementLogsByDate(date)
             .executeAsList()
             .map { log ->
@@ -155,7 +157,7 @@ class SupplementRepository(
                 takenAt = now,
                 entryIds = emptyList(),
             )
-        db.bissbilanzDatabaseQueries.insertSupplementLog(
+        db.userDataDatabaseQueries.insertSupplementLog(
             id = cacheKeyFor(temp.supplementId, temp.date),
             supplementId = temp.supplementId,
             date = temp.date,
@@ -169,7 +171,7 @@ class SupplementRepository(
         supplementId: String,
         date: String,
     ) {
-        db.bissbilanzDatabaseQueries.deleteSupplementLog(supplementId, date)
+        db.userDataDatabaseQueries.deleteSupplementLog(supplementId, date)
         syncQueue.enqueue(SyncOperation.UnlogSupplement(supplementId, date))
     }
 
@@ -192,11 +194,11 @@ class SupplementRepository(
         to: String,
     ): List<SupplementHistoryEntry> {
         val logs =
-            db.bissbilanzDatabaseQueries
+            db.userDataDatabaseQueries
                 .selectSupplementLogsByDateRange(from, to)
                 .executeAsList()
         val supplements =
-            db.bissbilanzDatabaseQueries
+            db.userDataDatabaseQueries
                 .selectAllSupplements()
                 .executeAsList()
                 .mapNotNull { row -> json.decodeOrNull<Supplement>(row.jsonData)?.let { row.id to it } }
@@ -215,7 +217,7 @@ class SupplementRepository(
     suspend fun getAllSupplements(): List<Supplement> {
         if (appModeManager.isLocal) {
             // The local DB is the primary store in Local mode; an empty list is the truth.
-            return db.bissbilanzDatabaseQueries
+            return db.userDataDatabaseQueries
                 .selectAllSupplements()
                 .executeAsList()
                 .mapNotNull { json.decodeOrNull<Supplement>(it.jsonData) }
@@ -227,7 +229,7 @@ class SupplementRepository(
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
-            val cached = db.bissbilanzDatabaseQueries.selectAllSupplements().executeAsList()
+            val cached = db.userDataDatabaseQueries.selectAllSupplements().executeAsList()
             if (cached.isNotEmpty()) {
                 cached.mapNotNull { json.decodeOrNull<Supplement>(it.jsonData) }
             } else {
@@ -237,7 +239,7 @@ class SupplementRepository(
     }
 
     private fun cacheSupplement(supplement: Supplement) {
-        db.bissbilanzDatabaseQueries.insertSupplement(
+        db.userDataDatabaseQueries.insertSupplement(
             id = supplement.id,
             name = supplement.name,
             isActive = if (supplement.isActive) 1L else 0L,
@@ -250,16 +252,17 @@ class SupplementRepository(
         supplements: List<Supplement>,
         includeInactive: Boolean = false,
     ) {
-        db.bissbilanzDatabaseQueries.transaction {
+        db.userDataDatabaseQueries.transaction {
             if (includeInactive) {
-                db.bissbilanzDatabaseQueries.deleteAllSupplements()
+                db.userDataDatabaseQueries.deleteAllSupplements()
             }
             supplements.forEach { supplement -> cacheSupplement(supplement) }
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "supplements",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
         }
+        // SyncMeta lives in the cache database; written after the user-data commit.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "supplements",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
@@ -52,7 +52,7 @@ class SupplementRepository(
     suspend fun createSupplement(supplement: SupplementCreate): Supplement {
         val temp = supplementCreateToSupplement(supplement)
         cacheSupplement(temp)
-        syncQueue.enqueue(SyncOperation.CreateSupplement(json.encodeToString(supplement)))
+        syncQueue.enqueue(SyncOperation.CreateSupplement(json.encodeToString(supplement), localId = temp.id))
         return temp
     }
 
@@ -62,13 +62,38 @@ class SupplementRepository(
     ): Supplement {
         val temp = supplementCreateToSupplement(supplement, id)
         cacheSupplement(temp)
-        syncQueue.enqueue(SyncOperation.UpdateSupplement(id, json.encodeToString(supplement)))
+        if (id.startsWith("temp_")) {
+            coalesceQueuedCreate(id, supplement)
+        } else {
+            syncQueue.enqueue(SyncOperation.UpdateSupplement(id, json.encodeToString(supplement)))
+        }
         return temp
     }
 
     suspend fun deleteSupplement(id: String) {
         db.bissbilanzDatabaseQueries.deleteSupplement(id)
-        syncQueue.enqueue(SyncOperation.DeleteSupplement(id))
+        if (id.startsWith("temp_")) {
+            syncQueue.removeByAffected("supplements", id)
+        } else {
+            syncQueue.enqueue(SyncOperation.DeleteSupplement(id))
+        }
+    }
+
+    /**
+     * Rewrites the still-queued Create operation for a temp-id supplement so the
+     * eventual upload carries the edited values. Updates use the full
+     * [SupplementCreate] body, so the new body simply replaces the queued one. If the
+     * create has already been drained (no queued op found), the update is skipped —
+     * the temp id is unknown server-side.
+     */
+    private suspend fun coalesceQueuedCreate(
+        tempId: String,
+        supplement: SupplementCreate,
+    ) {
+        for (req in syncQueue.findByAffected("supplements", tempId)) {
+            val create = req.operation as? SyncOperation.CreateSupplement ?: continue
+            syncQueue.replaceOperation(req.id, create.copy(body = json.encodeToString(supplement)))
+        }
     }
 
     suspend fun getChecklist(date: String): List<SupplementLog> =

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SupplementRepository.kt
@@ -4,8 +4,13 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.bissbilanz.ErrorReporter
 import com.bissbilanz.api.BissbilanzApi
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.api.generated.model.FoodCreate
 import com.bissbilanz.api.generated.model.Supplement
+import com.bissbilanz.api.generated.model.SupplementBackingFood
 import com.bissbilanz.api.generated.model.SupplementCreate
+import com.bissbilanz.api.generated.model.SupplementIngredient
+import com.bissbilanz.api.generated.model.SupplementIngredientInput
 import com.bissbilanz.api.generated.model.SupplementLog
 import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
@@ -280,6 +285,87 @@ class SupplementRepository(
             isActive = supplement.isActive ?: true,
             sortOrder = supplement.sortOrder ?: 0,
             timeOfDay = supplement.timeOfDay?.let { Supplement.TimeOfDay.valueOf(it.name) },
-            ingredients = emptyList(),
+            ingredients =
+                supplement.ingredients.mapIndexed { index, input ->
+                    input.toSupplementIngredient(supplementId = id, index = index)
+                },
+        )
+
+    /**
+     * Builds the cached ingredient from the create input. An inline `food` (no server
+     * food exists yet — the server would create one) keeps its data embedded under a
+     * synthesized temp food id; a `foodId` reference resolves the backing food from the
+     * local food rows. The embedded copy is what the migrator uses to recreate inline
+     * backing foods when uploading a locally created supplement.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    private fun SupplementIngredientInput.toSupplementIngredient(
+        supplementId: String,
+        index: Int,
+    ): SupplementIngredient {
+        val resolvedFoodId = foodId ?: "temp_${Uuid.random()}"
+        val backingFood =
+            food?.toBackingFood(resolvedFoodId)
+                ?: localBackingFood(resolvedFoodId)
+                ?: placeholderBackingFood(resolvedFoodId)
+        return SupplementIngredient(
+            id = "temp_${Uuid.random()}",
+            supplementId = supplementId,
+            foodId = resolvedFoodId,
+            servings = servings ?: 1.0,
+            sortOrder = sortOrder ?: index,
+            food = backingFood,
+        )
+    }
+
+    private fun FoodCreate.toBackingFood(id: String): SupplementBackingFood =
+        SupplementBackingFood(
+            id = id,
+            name = name,
+            brand = brand,
+            kind = SupplementBackingFood.Kind.supplement,
+            servingSize = servingSize,
+            servingUnit = servingUnit.value,
+            calories = calories,
+            protein = protein,
+            carbs = carbs,
+            fat = fat,
+            fiber = fiber,
+            ingredientsText = ingredientsText,
+        )
+
+    private fun localBackingFood(foodId: String): SupplementBackingFood? {
+        val row = db.userDataDatabaseQueries.selectFoodById(foodId).executeAsOneOrNull() ?: return null
+        val food = json.decodeOrNull<Food>(row.jsonData) ?: return null
+        return SupplementBackingFood(
+            id = food.id,
+            name = food.name,
+            brand = food.brand,
+            kind = SupplementBackingFood.Kind.food,
+            servingSize = food.servingSize,
+            servingUnit = food.servingUnit.value,
+            calories = food.calories,
+            protein = food.protein,
+            carbs = food.carbs,
+            fat = food.fat,
+            fiber = food.fiber,
+            ingredientsText = food.ingredientsText,
+        )
+    }
+
+    private fun placeholderBackingFood(foodId: String): SupplementBackingFood =
+        SupplementBackingFood(
+            id = foodId,
+            name = "",
+            brand = null,
+            kind = SupplementBackingFood.Kind.food,
+            servingSize = 1.0,
+            servingUnit = "g",
+            calories = 0.0,
+            protein = 0.0,
+            carbs = 0.0,
+            fat = 0.0,
+            fiber = 0.0,
+            ingredientsText = null,
         )
 }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
@@ -13,6 +13,7 @@ import com.bissbilanz.cache.BissbilanzDatabase
 import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
+import com.bissbilanz.userdata.UserDataDatabase
 import com.bissbilanz.util.decodeOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -26,7 +27,8 @@ import kotlin.uuid.Uuid
 
 class WeightRepository(
     private val api: BissbilanzApi,
-    private val db: BissbilanzDatabase,
+    private val db: UserDataDatabase,
+    private val cacheDb: BissbilanzDatabase,
     private val healthSync: HealthSyncService,
     private val syncQueue: SyncQueue,
     private val json: Json,
@@ -36,7 +38,7 @@ class WeightRepository(
     var onWeightChanged: (suspend () -> Unit)? = null
 
     fun entries(): Flow<List<WeightEntry>> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectAllWeightEntries()
             .asFlow()
             .mapToList(Dispatchers.IO)
@@ -66,7 +68,7 @@ class WeightRepository(
         id: String,
         entry: WeightUpdate,
     ): WeightEntry {
-        val cached = db.bissbilanzDatabaseQueries.selectAllWeightEntries().executeAsList()
+        val cached = db.userDataDatabaseQueries.selectAllWeightEntries().executeAsList()
         val existing = cached.mapNotNull { json.decodeOrNull<WeightEntry>(it.jsonData) }.find { it.id == id }
         val result =
             if (existing != null) {
@@ -142,7 +144,7 @@ class WeightRepository(
         from: String,
         to: String,
     ): List<WeightTrendEntry> =
-        db.bissbilanzDatabaseQueries
+        db.userDataDatabaseQueries
             .selectAllWeightEntries()
             .executeAsList()
             .mapNotNull { json.decodeOrNull<WeightEntry>(it.jsonData) }
@@ -151,7 +153,7 @@ class WeightRepository(
             .map { WeightTrendEntry(entryDate = it.entryDate, weightKg = it.weightKg, movingAvg = 0.0) }
 
     suspend fun deleteEntry(id: String) {
-        db.bissbilanzDatabaseQueries.deleteWeightEntry(id)
+        db.userDataDatabaseQueries.deleteWeightEntry(id)
         if (id.startsWith("temp_")) {
             syncQueue.removeByAffected("weight", id)
         } else {
@@ -161,7 +163,7 @@ class WeightRepository(
     }
 
     private fun cacheWeightEntry(entry: WeightEntry) {
-        db.bissbilanzDatabaseQueries.insertWeightEntry(
+        db.userDataDatabaseQueries.insertWeightEntry(
             id = entry.id,
             entryDate = entry.entryDate,
             weightKg = entry.weightKg,
@@ -171,14 +173,15 @@ class WeightRepository(
     }
 
     private fun cacheWeightEntries(entries: List<WeightEntry>) {
-        db.bissbilanzDatabaseQueries.transaction {
-            db.bissbilanzDatabaseQueries.deleteAllWeightEntries()
+        db.userDataDatabaseQueries.transaction {
+            db.userDataDatabaseQueries.deleteAllWeightEntries()
             entries.forEach { entry -> cacheWeightEntry(entry) }
-            db.bissbilanzDatabaseQueries.upsertSyncMeta(
-                entityType = "weight",
-                lastSyncedAt = Clock.System.now().toString(),
-            )
         }
+        // SyncMeta lives in the cache database; written after the user-data commit.
+        cacheDb.bissbilanzDatabaseQueries.upsertSyncMeta(
+            entityType = "weight",
+            lastSyncedAt = Clock.System.now().toString(),
+        )
     }
 
     @OptIn(ExperimentalUuidApi::class)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
@@ -54,7 +54,7 @@ class WeightRepository(
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
         }
-        syncQueue.enqueue(SyncOperation.CreateWeight(json.encodeToString(entry)))
+        syncQueue.enqueue(SyncOperation.CreateWeight(json.encodeToString(entry), localId = temp.id))
         onWeightChanged?.invoke()
         return temp
     }
@@ -90,9 +90,35 @@ class WeightRepository(
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
         }
-        syncQueue.enqueue(SyncOperation.UpdateWeight(id, json.encodeToString(entry)))
+        if (id.startsWith("temp_")) {
+            coalesceQueuedCreate(id, entry)
+        } else {
+            syncQueue.enqueue(SyncOperation.UpdateWeight(id, json.encodeToString(entry)))
+        }
         onWeightChanged?.invoke()
         return result
+    }
+
+    /**
+     * Rewrites the still-queued Create operation for a temp-id weight entry so the
+     * eventual upload carries the edited values. If the create has already been drained
+     * (no queued op found), the update is skipped — the temp id is unknown server-side.
+     */
+    private suspend fun coalesceQueuedCreate(
+        tempId: String,
+        update: WeightUpdate,
+    ) {
+        for (req in syncQueue.findByAffected("weight", tempId)) {
+            val create = req.operation as? SyncOperation.CreateWeight ?: continue
+            val body = json.decodeOrNull<WeightCreate>(create.body) ?: continue
+            val merged =
+                body.copy(
+                    weightKg = update.weightKg ?: body.weightKg,
+                    entryDate = update.entryDate ?: body.entryDate,
+                    notes = update.notes ?: body.notes,
+                )
+            syncQueue.replaceOperation(req.id, create.copy(body = json.encodeToString(merged)))
+        }
     }
 
     suspend fun getTrend(
@@ -115,7 +141,11 @@ class WeightRepository(
 
     suspend fun deleteEntry(id: String) {
         db.bissbilanzDatabaseQueries.deleteWeightEntry(id)
-        syncQueue.enqueue(SyncOperation.DeleteWeight(id))
+        if (id.startsWith("temp_")) {
+            syncQueue.removeByAffected("weight", id)
+        } else {
+            syncQueue.enqueue(SyncOperation.DeleteWeight(id))
+        }
         onWeightChanged?.invoke()
     }
 

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/WeightRepository.kt
@@ -10,6 +10,7 @@ import com.bissbilanz.api.generated.model.WeightEntry
 import com.bissbilanz.api.generated.model.WeightTrendEntry
 import com.bissbilanz.api.generated.model.WeightUpdate
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import com.bissbilanz.sync.SyncOperation
 import com.bissbilanz.sync.SyncQueue
 import com.bissbilanz.util.decodeOrNull
@@ -30,6 +31,7 @@ class WeightRepository(
     private val syncQueue: SyncQueue,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) {
     var onWeightChanged: (suspend () -> Unit)? = null
 
@@ -41,6 +43,7 @@ class WeightRepository(
             .map { rows -> rows.mapNotNull { json.decodeOrNull<WeightEntry>(it.jsonData) } }
 
     suspend fun refresh(limit: Int = 30) {
+        if (appModeManager.isLocal) return
         val entries = api.getWeightEntries(limit)
         cacheWeightEntries(entries)
     }
@@ -124,20 +127,28 @@ class WeightRepository(
     suspend fun getTrend(
         from: String,
         to: String,
-    ): List<WeightTrendEntry> =
-        try {
+    ): List<WeightTrendEntry> {
+        if (appModeManager.isLocal) return trendFromCache(from, to)
+        return try {
             api.getWeightTrend(from, to)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             errorReporter.captureException(e)
-            db.bissbilanzDatabaseQueries
-                .selectAllWeightEntries()
-                .executeAsList()
-                .mapNotNull { json.decodeOrNull<WeightEntry>(it.jsonData) }
-                .filter { it.entryDate in from..to }
-                .sortedBy { it.entryDate }
-                .map { WeightTrendEntry(entryDate = it.entryDate, weightKg = it.weightKg, movingAvg = 0.0) }
+            trendFromCache(from, to)
         }
+    }
+
+    private fun trendFromCache(
+        from: String,
+        to: String,
+    ): List<WeightTrendEntry> =
+        db.bissbilanzDatabaseQueries
+            .selectAllWeightEntries()
+            .executeAsList()
+            .mapNotNull { json.decodeOrNull<WeightEntry>(it.jsonData) }
+            .filter { it.entryDate in from..to }
+            .sortedBy { it.entryDate }
+            .map { WeightTrendEntry(entryDate = it.entryDate, weightKg = it.weightKg, movingAvg = 0.0) }
 
     suspend fun deleteEntry(id: String) {
         db.bissbilanzDatabaseQueries.deleteWeightEntry(id)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/storage/KeyValueStore.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/storage/KeyValueStore.kt
@@ -1,0 +1,16 @@
+package com.bissbilanz.storage
+
+/**
+ * Minimal string key-value store abstraction. [PlainStorage] is the platform-backed
+ * implementation; tests can supply an in-memory fake.
+ */
+interface KeyValueStore {
+    fun save(
+        key: String,
+        value: String,
+    )
+
+    fun load(key: String): String?
+
+    fun delete(key: String)
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/storage/PlainStorage.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/storage/PlainStorage.kt
@@ -1,0 +1,17 @@
+package com.bissbilanz.storage
+
+/**
+ * Unencrypted persistent key-value storage for non-secret app state (e.g. the app
+ * mode). Deliberately NOT encrypted so values survive Android Auto Backup / device
+ * restores. Never store secrets here — use [com.bissbilanz.auth.SecureStorage].
+ */
+expect class PlainStorage : KeyValueStore {
+    override fun save(
+        key: String,
+        value: String,
+    )
+
+    override fun load(key: String): String?
+
+    override fun delete(key: String)
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncManager.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncManager.kt
@@ -6,6 +6,7 @@ import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.UnauthorizedException
 import com.bissbilanz.api.generated.model.*
 import com.bissbilanz.mode.AppModeManager
+import com.bissbilanz.userdata.UserDataDatabase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -15,6 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 data class SyncState(
@@ -28,10 +30,17 @@ class SyncManager(
     private val syncQueue: SyncQueue,
     private val connectivityProvider: ConnectivityProvider,
     private val api: BissbilanzApi,
+    private val db: UserDataDatabase,
     private val json: Json,
     private val errorReporter: ErrorReporter,
     private val appModeManager: AppModeManager,
 ) {
+    /** A drained create succeeded: [tempId] now lives on the server as [serverId]. */
+    private data class TempIdRemap(
+        val tempId: String,
+        val serverId: String,
+    )
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val _state = MutableStateFlow(SyncState())
@@ -75,9 +84,19 @@ class SyncManager(
             val queued = syncQueue.drain()
             _state.value = _state.value.copy(pendingCount = syncQueue.pendingCount())
 
+            // Temp ids whose creates drained in THIS batch. The drained snapshot still
+            // carries the original payloads, so later operations in the batch are
+            // remapped in memory; operations still sitting in the queue (including ones
+            // beyond the drain limit) are rewritten in place after each create succeeds.
+            val remaps = mutableMapOf<String, String>()
+
             for (req in queued) {
                 try {
-                    execute(req.operation)
+                    val remap = execute(remapTempIds(req.operation, remaps, json))
+                    if (remap != null) {
+                        remaps[remap.tempId] = remap.serverId
+                        rewriteQueuedReferences(remap.tempId, remap.serverId)
+                    }
                     syncQueue.remove(req.id)
                     synced++
                 } catch (e: UnauthorizedException) {
@@ -136,11 +155,22 @@ class SyncManager(
         return synced
     }
 
+    /**
+     * Executes one operation. For creates of records that other records can reference
+     * (foods, recipes, supplements) the server response replaces the local temp row and
+     * the resulting temp→server id mapping is returned so still-queued references can be
+     * rewritten. Other create responses stay ignored — nothing references those records
+     * and their local rows self-heal on the next refresh.
+     */
     @Suppress("CyclomaticComplexMethod")
-    private suspend fun execute(op: SyncOperation) {
+    private suspend fun execute(op: SyncOperation): TempIdRemap? {
         when (op) {
             is SyncOperation.CreateFood -> {
-                api.createFood(json.decodeFromString<FoodCreate>(op.body))
+                val server = api.createFood(json.decodeFromString<FoodCreate>(op.body))
+                return op.localId?.takeIf { it.startsWith(TEMP_PREFIX) }?.let { tempId ->
+                    replaceLocalFood(tempId, server)
+                    TempIdRemap(tempId, server.id)
+                }
             }
 
             is SyncOperation.UpdateFood -> {
@@ -164,7 +194,11 @@ class SyncManager(
             }
 
             is SyncOperation.CreateRecipe -> {
-                api.createRecipe(json.decodeFromString<RecipeCreate>(op.body))
+                val server = api.createRecipe(json.decodeFromString<RecipeCreate>(op.body))
+                return op.localId?.takeIf { it.startsWith(TEMP_PREFIX) }?.let { tempId ->
+                    replaceLocalRecipe(tempId, server)
+                    TempIdRemap(tempId, server.id)
+                }
             }
 
             is SyncOperation.UpdateRecipe -> {
@@ -192,7 +226,11 @@ class SyncManager(
             }
 
             is SyncOperation.CreateSupplement -> {
-                api.createSupplement(json.decodeFromString<SupplementCreate>(op.body))
+                val server = api.createSupplement(json.decodeFromString<SupplementCreate>(op.body))
+                return op.localId?.takeIf { it.startsWith(TEMP_PREFIX) }?.let { tempId ->
+                    replaceLocalSupplement(tempId, server)
+                    TempIdRemap(tempId, server.id)
+                }
             }
 
             is SyncOperation.UpdateSupplement -> {
@@ -235,6 +273,94 @@ class SyncManager(
                 api.deleteSleepEntry(op.id)
             }
         }
+        return null
+    }
+
+    /** Rewrites every still-queued operation that references [tempId] to use [serverId]. */
+    private suspend fun rewriteQueuedReferences(
+        tempId: String,
+        serverId: String,
+    ) {
+        val remap = mapOf(tempId to serverId)
+        for (req in syncQueue.all()) {
+            val rewritten = remapTempIds(req.operation, remap, json)
+            if (rewritten != req.operation) {
+                syncQueue.replaceOperationAndAffected(req.id, rewritten)
+            }
+        }
+    }
+
+    private fun replaceLocalFood(
+        tempId: String,
+        server: Food,
+    ) {
+        val queries = db.userDataDatabaseQueries
+        queries.transaction {
+            queries.deleteFood(tempId)
+            queries.insertFood(
+                id = server.id,
+                name = server.name,
+                brand = server.brand,
+                calories = server.calories,
+                protein = server.protein,
+                carbs = server.carbs,
+                fat = server.fat,
+                fiber = server.fiber,
+                isFavorite = if (server.isFavorite) 1L else 0L,
+                barcode = server.barcode,
+                jsonData = json.encodeToString(server),
+            )
+        }
+    }
+
+    private fun replaceLocalRecipe(
+        tempId: String,
+        server: RecipeDetail,
+    ) {
+        val queries = db.userDataDatabaseQueries
+        queries.transaction {
+            queries.deleteRecipe(tempId)
+            queries.insertRecipe(
+                id = server.id,
+                name = server.name,
+                totalServings = server.totalServings,
+                isFavorite = if (server.isFavorite) 1L else 0L,
+                calories = server.calories,
+                protein = server.protein,
+                carbs = server.carbs,
+                fat = server.fat,
+                fiber = server.fiber,
+                jsonData = json.encodeToString(server),
+            )
+        }
+    }
+
+    private fun replaceLocalSupplement(
+        tempId: String,
+        server: Supplement,
+    ) {
+        val queries = db.userDataDatabaseQueries
+        queries.transaction {
+            queries.deleteSupplement(tempId)
+            queries.insertSupplement(
+                id = server.id,
+                name = server.name,
+                isActive = if (server.isActive) 1L else 0L,
+                sortOrder = server.sortOrder.toLong(),
+                jsonData = json.encodeToString(server),
+            )
+            // The synthesized log cache key embeds the supplement id — re-key any local
+            // logs so unlogging and the offline checklist keep working after the remap.
+            for (log in queries.selectSupplementLogsBySupplementId(tempId).executeAsList()) {
+                queries.deleteSupplementLogById(log.id)
+                queries.insertSupplementLog(
+                    id = "${server.id}-${log.date}",
+                    supplementId = server.id,
+                    date = log.date,
+                    takenAt = log.takenAt,
+                )
+            }
+        }
     }
 
     private fun addError(message: String) {
@@ -243,5 +369,6 @@ class SyncManager(
 
     companion object {
         private const val MAX_RETRIES = 3
+        private const val TEMP_PREFIX = "temp_"
     }
 }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncManager.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncManager.kt
@@ -5,6 +5,7 @@ import com.bissbilanz.api.ApiException
 import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.api.UnauthorizedException
 import com.bissbilanz.api.generated.model.*
+import com.bissbilanz.mode.AppModeManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -29,6 +30,7 @@ class SyncManager(
     private val api: BissbilanzApi,
     private val json: Json,
     private val errorReporter: ErrorReporter,
+    private val appModeManager: AppModeManager,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -61,6 +63,9 @@ class SyncManager(
     }
 
     suspend fun syncPendingQueue(): Int {
+        // In Local mode nothing is enqueued and nothing may be uploaded. The network
+        // listener can keep running; it simply becomes a no-op.
+        if (appModeManager.isLocal) return 0
         if (!syncMutex.tryLock()) return 0
         var synced = 0
         try {
@@ -86,6 +91,7 @@ class SyncManager(
                             synced++
                             addError("Failed to sync ${req.operation.description}: HTTP ${e.statusCode}")
                         }
+
                         else -> {
                             syncQueue.releaseForRetry(req.id)
                             val count = syncQueue.incrementAndGetRetryCount(req.id)
@@ -133,50 +139,101 @@ class SyncManager(
     @Suppress("CyclomaticComplexMethod")
     private suspend fun execute(op: SyncOperation) {
         when (op) {
-            is SyncOperation.CreateFood ->
+            is SyncOperation.CreateFood -> {
                 api.createFood(json.decodeFromString<FoodCreate>(op.body))
-            is SyncOperation.UpdateFood ->
+            }
+
+            is SyncOperation.UpdateFood -> {
                 api.updateFood(op.id, json.decodeFromString<FoodCreate>(op.body))
-            is SyncOperation.DeleteFood ->
+            }
+
+            is SyncOperation.DeleteFood -> {
                 api.deleteFood(op.id)
-            is SyncOperation.CreateEntry ->
+            }
+
+            is SyncOperation.CreateEntry -> {
                 api.createEntry(json.decodeFromString<EntryCreate>(op.body))
-            is SyncOperation.UpdateEntry ->
+            }
+
+            is SyncOperation.UpdateEntry -> {
                 api.updateEntry(op.id, json.decodeFromString<EntryUpdate>(op.body))
-            is SyncOperation.DeleteEntry ->
+            }
+
+            is SyncOperation.DeleteEntry -> {
                 api.deleteEntry(op.id)
-            is SyncOperation.CreateRecipe ->
+            }
+
+            is SyncOperation.CreateRecipe -> {
                 api.createRecipe(json.decodeFromString<RecipeCreate>(op.body))
-            is SyncOperation.UpdateRecipe ->
+            }
+
+            is SyncOperation.UpdateRecipe -> {
                 api.updateRecipe(op.id, json.decodeFromString<RecipeUpdate>(op.body))
-            is SyncOperation.DeleteRecipe ->
+            }
+
+            is SyncOperation.DeleteRecipe -> {
                 api.deleteRecipe(op.id)
-            is SyncOperation.SetGoals ->
+            }
+
+            is SyncOperation.SetGoals -> {
                 api.setGoals(json.decodeFromString<Goals>(op.body))
-            is SyncOperation.CreateWeight ->
+            }
+
+            is SyncOperation.CreateWeight -> {
                 api.createWeightEntry(json.decodeFromString<WeightCreate>(op.body))
-            is SyncOperation.UpdateWeight ->
+            }
+
+            is SyncOperation.UpdateWeight -> {
                 api.updateWeightEntry(op.id, json.decodeFromString<WeightUpdate>(op.body))
-            is SyncOperation.DeleteWeight ->
+            }
+
+            is SyncOperation.DeleteWeight -> {
                 api.deleteWeightEntry(op.id)
-            is SyncOperation.CreateSupplement ->
+            }
+
+            is SyncOperation.CreateSupplement -> {
                 api.createSupplement(json.decodeFromString<SupplementCreate>(op.body))
-            is SyncOperation.UpdateSupplement ->
+            }
+
+            is SyncOperation.UpdateSupplement -> {
                 api.updateSupplement(op.id, json.decodeFromString<SupplementCreate>(op.body))
-            is SyncOperation.DeleteSupplement ->
+            }
+
+            is SyncOperation.DeleteSupplement -> {
                 api.deleteSupplement(op.id)
-            is SyncOperation.LogSupplement ->
+            }
+
+            is SyncOperation.LogSupplement -> {
                 api.logSupplement(op.supplementId, op.date)
-            is SyncOperation.UnlogSupplement ->
+            }
+
+            is SyncOperation.UnlogSupplement -> {
                 api.unlogSupplement(op.supplementId, op.date)
-            is SyncOperation.UpdatePreferences ->
+            }
+
+            is SyncOperation.SetDayProperties -> {
+                api.setDayProperties(op.date, op.isFastingDay)
+            }
+
+            is SyncOperation.DeleteDayProperties -> {
+                api.deleteDayProperties(op.date)
+            }
+
+            is SyncOperation.UpdatePreferences -> {
                 api.updatePreferences(json.decodeFromString<PreferencesUpdate>(op.body))
-            is SyncOperation.CreateSleep ->
+            }
+
+            is SyncOperation.CreateSleep -> {
                 api.createSleepEntry(json.decodeFromString<SleepCreate>(op.body))
-            is SyncOperation.UpdateSleep ->
+            }
+
+            is SyncOperation.UpdateSleep -> {
                 api.updateSleepEntry(op.id, json.decodeFromString<SleepUpdate>(op.body))
-            is SyncOperation.DeleteSleep ->
+            }
+
+            is SyncOperation.DeleteSleep -> {
                 api.deleteSleepEntry(op.id)
+            }
         }
     }
 

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncOperation.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncOperation.kt
@@ -202,6 +202,27 @@ sealed class SyncOperation {
     }
 
     @Serializable
+    @SerialName("set_day_properties")
+    data class SetDayProperties(
+        val date: String,
+        val isFastingDay: Boolean,
+    ) : SyncOperation() {
+        override val affectedTable = "day_properties"
+        override val affectedId get() = date
+        override val description get() = "set day properties $date"
+    }
+
+    @Serializable
+    @SerialName("delete_day_properties")
+    data class DeleteDayProperties(
+        val date: String,
+    ) : SyncOperation() {
+        override val affectedTable = "day_properties"
+        override val affectedId get() = date
+        override val description get() = "delete day properties $date"
+    }
+
+    @Serializable
     @SerialName("update_preferences")
     data class UpdatePreferences(
         val body: String,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncOperation.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncOperation.kt
@@ -13,9 +13,10 @@ sealed class SyncOperation {
     @SerialName("create_food")
     data class CreateFood(
         val body: String,
+        val localId: String? = null,
     ) : SyncOperation() {
         override val affectedTable = "foods"
-        override val affectedId: String? = null
+        override val affectedId get() = localId
         override val description = "create food"
     }
 
@@ -44,9 +45,10 @@ sealed class SyncOperation {
     @SerialName("create_entry")
     data class CreateEntry(
         val body: String,
+        val localId: String? = null,
     ) : SyncOperation() {
         override val affectedTable = "entries"
-        override val affectedId: String? = null
+        override val affectedId get() = localId
         override val description = "create entry"
     }
 
@@ -75,9 +77,10 @@ sealed class SyncOperation {
     @SerialName("create_recipe")
     data class CreateRecipe(
         val body: String,
+        val localId: String? = null,
     ) : SyncOperation() {
         override val affectedTable = "recipes"
-        override val affectedId: String? = null
+        override val affectedId get() = localId
         override val description = "create recipe"
     }
 
@@ -116,9 +119,10 @@ sealed class SyncOperation {
     @SerialName("create_weight")
     data class CreateWeight(
         val body: String,
+        val localId: String? = null,
     ) : SyncOperation() {
         override val affectedTable = "weight"
-        override val affectedId: String? = null
+        override val affectedId get() = localId
         override val description = "create weight entry"
     }
 
@@ -147,9 +151,10 @@ sealed class SyncOperation {
     @SerialName("create_supplement")
     data class CreateSupplement(
         val body: String,
+        val localId: String? = null,
     ) : SyncOperation() {
         override val affectedTable = "supplements"
-        override val affectedId: String? = null
+        override val affectedId get() = localId
         override val description = "create supplement"
     }
 
@@ -210,9 +215,10 @@ sealed class SyncOperation {
     @SerialName("create_sleep")
     data class CreateSleep(
         val body: String,
+        val localId: String? = null,
     ) : SyncOperation() {
         override val affectedTable = "sleep"
-        override val affectedId: String? = null
+        override val affectedId get() = localId
         override val description = "create sleep entry"
     }
 

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncQueue.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncQueue.kt
@@ -1,6 +1,7 @@
 package com.bissbilanz.sync
 
 import com.bissbilanz.cache.BissbilanzDatabase
+import com.bissbilanz.mode.AppModeManager
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -19,6 +20,7 @@ data class QueuedRequest(
 class SyncQueue(
     private val db: BissbilanzDatabase,
     private val json: Json,
+    private val appModeManager: AppModeManager,
 ) {
     private val mutex = Mutex()
     private val inProgress = mutableSetOf<Long>()
@@ -26,7 +28,11 @@ class SyncQueue(
     private val _enqueueSignal = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val enqueueSignal: SharedFlow<Unit> = _enqueueSignal.asSharedFlow()
 
-    suspend fun enqueue(operation: SyncOperation) =
+    suspend fun enqueue(operation: SyncOperation) {
+        // In Local mode the local DB is the primary store, so nothing is queued for
+        // upload. The login migrator uploads the cache state when switching to Synced;
+        // queued ops would double-apply.
+        if (appModeManager.isLocal) return
         mutex.withLock {
             db.bissbilanzDatabaseQueries.insertSyncQueueItem(
                 operation = json.encodeToString(SyncOperation.serializer(), operation),
@@ -36,6 +42,7 @@ class SyncQueue(
             )
             _enqueueSignal.tryEmit(Unit)
         }
+    }
 
     suspend fun drain(): List<QueuedRequest> =
         mutex.withLock {

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncQueue.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncQueue.kt
@@ -67,6 +67,22 @@ class SyncQueue(
             db.bissbilanzDatabaseQueries.deleteSyncQueueItem(id)
         }
 
+    /** Snapshot of every queued operation, including drained/in-flight ones. */
+    suspend fun all(): List<QueuedRequest> =
+        mutex.withLock {
+            db.bissbilanzDatabaseQueries
+                .selectAllSyncQueue()
+                .executeAsList()
+                .map {
+                    QueuedRequest(
+                        id = it.id,
+                        operation = json.decodeFromString(SyncOperation.serializer(), it.operation),
+                        createdAt = it.createdAt,
+                        retryCount = it.retryCount,
+                    )
+                }
+        }
+
     suspend fun findByAffected(
         table: String,
         id: String,
@@ -96,6 +112,25 @@ class SyncQueue(
             // affectedTable/affectedId stay the same: coalescing never changes them.
             db.bissbilanzDatabaseQueries.updateSyncQueueOperation(
                 operation = json.encodeToString(SyncOperation.serializer(), operation),
+                id = queueId,
+            )
+        }
+    }
+
+    /**
+     * Replaces an operation INCLUDING its affected table/id columns. Used when a temp id
+     * is remapped to its server id after a create drains — unlike coalescing, remapping
+     * changes the id the operation is keyed on.
+     */
+    suspend fun replaceOperationAndAffected(
+        queueId: Long,
+        operation: SyncOperation,
+    ) {
+        mutex.withLock {
+            db.bissbilanzDatabaseQueries.updateSyncQueueOperationAndAffected(
+                operation = json.encodeToString(SyncOperation.serializer(), operation),
+                affectedTable = operation.affectedTable,
+                affectedId = operation.affectedId,
                 id = queueId,
             )
         }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncQueue.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/SyncQueue.kt
@@ -60,6 +60,49 @@ class SyncQueue(
             db.bissbilanzDatabaseQueries.deleteSyncQueueItem(id)
         }
 
+    suspend fun findByAffected(
+        table: String,
+        id: String,
+    ): List<QueuedRequest> =
+        mutex.withLock {
+            db.bissbilanzDatabaseQueries
+                .selectSyncQueueByAffected(table, id)
+                .executeAsList()
+                .map {
+                    QueuedRequest(
+                        id = it.id,
+                        operation = json.decodeFromString(SyncOperation.serializer(), it.operation),
+                        createdAt = it.createdAt,
+                        retryCount = it.retryCount,
+                    )
+                }
+        }
+
+    // Note: an item that has already been drained (in progress) can still be rewritten or
+    // removed here while its original payload is in flight. That small race is accepted —
+    // the in-flight upload wins and the local change for that item is lost.
+    suspend fun replaceOperation(
+        queueId: Long,
+        operation: SyncOperation,
+    ) {
+        mutex.withLock {
+            // affectedTable/affectedId stay the same: coalescing never changes them.
+            db.bissbilanzDatabaseQueries.updateSyncQueueOperation(
+                operation = json.encodeToString(SyncOperation.serializer(), operation),
+                id = queueId,
+            )
+        }
+    }
+
+    suspend fun removeByAffected(
+        table: String,
+        id: String,
+    ) {
+        mutex.withLock {
+            db.bissbilanzDatabaseQueries.deleteSyncQueueByAffected(table, id)
+        }
+    }
+
     suspend fun releaseForRetry(id: Long) =
         mutex.withLock {
             inProgress.remove(id)

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/TempIdRemapper.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/sync/TempIdRemapper.kt
@@ -1,0 +1,152 @@
+package com.bissbilanz.sync
+
+import com.bissbilanz.api.generated.model.EntryCreate
+import com.bissbilanz.api.generated.model.EntryUpdate
+import com.bissbilanz.api.generated.model.RecipeCreate
+import com.bissbilanz.api.generated.model.RecipeUpdate
+import com.bissbilanz.api.generated.model.SupplementCreate
+import com.bissbilanz.util.decodeOrNull
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Rewrites every reference to a temp id inside a queued operation to the corresponding
+ * server id once the create that owns the temp id has drained. Covers:
+ *
+ * - `UpdateX`/`DeleteX` operations whose own id is a temp id,
+ * - `foodId`/`recipeId` inside queued `CreateEntry`/`UpdateEntry` bodies,
+ * - ingredient `foodId`s inside queued recipe and supplement create/update bodies,
+ * - `supplementId` in `Log`/`UnlogSupplement` operations.
+ *
+ * Returns an operation equal to [op] when nothing matched. Temp ids are random UUIDs,
+ * so a flat tempId→serverId map cannot collide across entity types.
+ */
+internal fun remapTempIds(
+    op: SyncOperation,
+    remaps: Map<String, String>,
+    json: Json,
+): SyncOperation {
+    if (remaps.isEmpty()) return op
+
+    fun remap(id: String): String = remaps[id] ?: id
+    return when (op) {
+        is SyncOperation.UpdateFood -> {
+            op.copy(id = remap(op.id))
+        }
+
+        is SyncOperation.DeleteFood -> {
+            op.copy(id = remap(op.id))
+        }
+
+        is SyncOperation.UpdateRecipe -> {
+            op.copy(id = remap(op.id), body = remapRecipeUpdateBody(op.body, remaps, json))
+        }
+
+        is SyncOperation.DeleteRecipe -> {
+            op.copy(id = remap(op.id))
+        }
+
+        is SyncOperation.UpdateSupplement -> {
+            op.copy(id = remap(op.id), body = remapSupplementCreateBody(op.body, remaps, json))
+        }
+
+        is SyncOperation.DeleteSupplement -> {
+            op.copy(id = remap(op.id))
+        }
+
+        is SyncOperation.LogSupplement -> {
+            op.copy(supplementId = remap(op.supplementId))
+        }
+
+        is SyncOperation.UnlogSupplement -> {
+            op.copy(supplementId = remap(op.supplementId))
+        }
+
+        is SyncOperation.CreateEntry -> {
+            op.copy(body = remapEntryCreateBody(op.body, remaps, json))
+        }
+
+        is SyncOperation.UpdateEntry -> {
+            op.copy(body = remapEntryUpdateBody(op.body, remaps, json))
+        }
+
+        is SyncOperation.CreateRecipe -> {
+            op.copy(body = remapRecipeCreateBody(op.body, remaps, json))
+        }
+
+        is SyncOperation.CreateSupplement -> {
+            op.copy(body = remapSupplementCreateBody(op.body, remaps, json))
+        }
+
+        else -> {
+            op
+        }
+    }
+}
+
+private fun remapEntryCreateBody(
+    body: String,
+    remaps: Map<String, String>,
+    json: Json,
+): String {
+    val entry = json.decodeOrNull<EntryCreate>(body) ?: return body
+    val updated =
+        entry.copy(
+            foodId = entry.foodId?.let { remaps[it] ?: it },
+            recipeId = entry.recipeId?.let { remaps[it] ?: it },
+        )
+    return if (updated == entry) body else json.encodeToString(updated)
+}
+
+private fun remapEntryUpdateBody(
+    body: String,
+    remaps: Map<String, String>,
+    json: Json,
+): String {
+    val entry = json.decodeOrNull<EntryUpdate>(body) ?: return body
+    val updated =
+        entry.copy(
+            foodId = entry.foodId?.let { remaps[it] ?: it },
+            recipeId = entry.recipeId?.let { remaps[it] ?: it },
+        )
+    return if (updated == entry) body else json.encodeToString(updated)
+}
+
+private fun remapRecipeCreateBody(
+    body: String,
+    remaps: Map<String, String>,
+    json: Json,
+): String {
+    val recipe = json.decodeOrNull<RecipeCreate>(body) ?: return body
+    val updated =
+        recipe.copy(
+            ingredients = recipe.ingredients.map { it.copy(foodId = remaps[it.foodId] ?: it.foodId) },
+        )
+    return if (updated == recipe) body else json.encodeToString(updated)
+}
+
+private fun remapRecipeUpdateBody(
+    body: String,
+    remaps: Map<String, String>,
+    json: Json,
+): String {
+    val recipe = json.decodeOrNull<RecipeUpdate>(body) ?: return body
+    val updated =
+        recipe.copy(
+            ingredients = recipe.ingredients?.map { it.copy(foodId = remaps[it.foodId] ?: it.foodId) },
+        )
+    return if (updated == recipe) body else json.encodeToString(updated)
+}
+
+private fun remapSupplementCreateBody(
+    body: String,
+    remaps: Map<String, String>,
+    json: Json,
+): String {
+    val supplement = json.decodeOrNull<SupplementCreate>(body) ?: return body
+    val updated =
+        supplement.copy(
+            ingredients = supplement.ingredients.map { it.copy(foodId = it.foodId?.let { id -> remaps[id] ?: id }) },
+        )
+    return if (updated == supplement) body else json.encodeToString(updated)
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/util/RecipeMacros.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/util/RecipeMacros.kt
@@ -1,0 +1,49 @@
+package com.bissbilanz.util
+
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.api.generated.model.MacroSummary
+import com.bissbilanz.api.generated.model.RecipeIngredient
+
+/**
+ * Replicates the server's per-serving recipe macro computation
+ * (`buildRecipeMacrosCte` in `src/lib/server/entries.ts`):
+ *
+ *     SUM(food.macro * ingredient.quantity / food.servingSize) / recipe.totalServings
+ *
+ * so values computed locally (Local mode, optimistic temp records) agree with what the
+ * server reports for the same recipe after migration/upload.
+ *
+ * Returns null when the macros cannot be computed faithfully — no ingredients, a
+ * non-positive divisor, or a referenced food that cannot be resolved (e.g. not cached
+ * locally in Synced mode). Callers keep their previous values in that case rather than
+ * under-counting.
+ */
+fun computeRecipePerServingMacros(
+    ingredients: List<RecipeIngredient>,
+    totalServings: Double,
+    resolveFood: (String) -> Food?,
+): MacroSummary? {
+    if (ingredients.isEmpty() || totalServings <= 0.0) return null
+    var calories = 0.0
+    var protein = 0.0
+    var carbs = 0.0
+    var fat = 0.0
+    var fiber = 0.0
+    for (ingredient in ingredients) {
+        val food = resolveFood(ingredient.foodId) ?: return null
+        if (food.servingSize <= 0.0) return null
+        val factor = ingredient.quantity / food.servingSize
+        calories += food.calories * factor
+        protein += food.protein * factor
+        carbs += food.carbs * factor
+        fat += food.fat * factor
+        fiber += food.fiber * factor
+    }
+    return MacroSummary(
+        calories = calories / totalServings,
+        protein = protein / totalServings,
+        carbs = carbs / totalServings,
+        fat = fat / totalServings,
+        fiber = fiber / totalServings,
+    )
+}

--- a/mobile/shared/src/commonMain/sqldelight-userdata/com/bissbilanz/userdata/UserDataDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight-userdata/com/bissbilanz/userdata/UserDataDatabase.sq
@@ -1,0 +1,343 @@
+-- The user's own data (userdata.db). This file IS included in Android Auto Backup,
+-- so it must never contain server-derived/transient state (sync queue, sync meta,
+-- meal-type cache) — those live in BissbilanzDatabase (bissbilanz.db).
+--
+-- Schema convention (CRITICAL): every statement must stay CREATE TABLE IF NOT EXISTS
+-- and changes must be additive-only. DatabaseDriverFactory re-runs Schema.create on
+-- every open to materialize tables added in app updates; that is only safe while
+-- this convention holds.
+
+CREATE TABLE IF NOT EXISTS CachedEntry (
+    id TEXT NOT NULL PRIMARY KEY,
+    date TEXT NOT NULL,
+    mealType TEXT NOT NULL,
+    servings REAL NOT NULL,
+    foodId TEXT,
+    recipeId TEXT,
+    foodName TEXT,
+    calories REAL NOT NULL DEFAULT 0,
+    protein REAL NOT NULL DEFAULT 0,
+    carbs REAL NOT NULL DEFAULT 0,
+    fat REAL NOT NULL DEFAULT 0,
+    fiber REAL NOT NULL DEFAULT 0,
+    jsonData TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedFood (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    brand TEXT,
+    calories REAL NOT NULL DEFAULT 0,
+    protein REAL NOT NULL DEFAULT 0,
+    carbs REAL NOT NULL DEFAULT 0,
+    fat REAL NOT NULL DEFAULT 0,
+    fiber REAL NOT NULL DEFAULT 0,
+    isFavorite INTEGER NOT NULL DEFAULT 0,
+    barcode TEXT,
+    jsonData TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedGoals (
+    id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
+    calorieGoal REAL NOT NULL,
+    proteinGoal REAL NOT NULL,
+    carbGoal REAL NOT NULL,
+    fatGoal REAL NOT NULL,
+    fiberGoal REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedRecipe (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    totalServings REAL NOT NULL DEFAULT 1,
+    isFavorite INTEGER NOT NULL DEFAULT 0,
+    calories REAL NOT NULL DEFAULT 0,
+    protein REAL NOT NULL DEFAULT 0,
+    carbs REAL NOT NULL DEFAULT 0,
+    fat REAL NOT NULL DEFAULT 0,
+    fiber REAL NOT NULL DEFAULT 0,
+    jsonData TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedSupplement (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    isActive INTEGER NOT NULL DEFAULT 1,
+    sortOrder INTEGER NOT NULL DEFAULT 0,
+    jsonData TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedSupplementLog (
+    id TEXT NOT NULL PRIMARY KEY,
+    supplementId TEXT NOT NULL,
+    date TEXT NOT NULL,
+    takenAt TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedWeightEntry (
+    id TEXT NOT NULL PRIMARY KEY,
+    entryDate TEXT NOT NULL,
+    weightKg REAL NOT NULL,
+    loggedAt TEXT,
+    jsonData TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedSleepEntry (
+    id TEXT NOT NULL PRIMARY KEY,
+    entryDate TEXT NOT NULL,
+    durationMinutes INTEGER NOT NULL,
+    quality INTEGER NOT NULL,
+    loggedAt TEXT,
+    jsonData TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedPreferences (
+    id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
+    jsonData TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CachedDayProperties (
+    date TEXT NOT NULL PRIMARY KEY,
+    isFastingDay INTEGER NOT NULL DEFAULT 0
+);
+
+-- Tiny key/value store local to this database file. Currently only holds the
+-- "legacy user data copied out of bissbilanz.db" marker written by
+-- LegacyUserDataMigration; being part of userdata.db it survives backup/restore,
+-- which is exactly right (a restored device must not re-copy from a fresh cache DB).
+CREATE TABLE IF NOT EXISTS LocalMeta (
+    key TEXT NOT NULL PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- Entries
+selectAllEntries:
+SELECT * FROM CachedEntry;
+
+selectEntriesByFoodId:
+SELECT * FROM CachedEntry WHERE foodId = ?;
+
+selectEntriesByRecipeId:
+SELECT * FROM CachedEntry WHERE recipeId = ?;
+
+selectEntriesByDate:
+SELECT * FROM CachedEntry WHERE date = ?;
+
+selectEntriesByDateRange:
+SELECT * FROM CachedEntry WHERE date >= ? AND date <= ? ORDER BY date;
+
+insertEntry:
+INSERT OR REPLACE INTO CachedEntry(id, date, mealType, servings, foodId, recipeId, foodName, calories, protein, carbs, fat, fiber, jsonData)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteEntry:
+DELETE FROM CachedEntry WHERE id = ?;
+
+deleteEntriesByDate:
+DELETE FROM CachedEntry WHERE date = ?;
+
+-- Foods
+selectAllFoods:
+SELECT * FROM CachedFood ORDER BY name;
+
+selectFoodById:
+SELECT * FROM CachedFood WHERE id = ?;
+
+selectFoodByBarcode:
+SELECT * FROM CachedFood WHERE barcode = ? LIMIT 1;
+
+selectFavorites:
+SELECT * FROM CachedFood WHERE isFavorite = 1 ORDER BY name;
+
+searchFoods:
+SELECT * FROM CachedFood WHERE name LIKE ? OR brand LIKE ? ORDER BY name LIMIT ?;
+
+-- Foods recently logged via cached entries (Local mode replacement for /api/foods/recent)
+selectRecentFoods:
+SELECT CachedFood.* FROM CachedFood
+JOIN (
+    SELECT foodId, MAX(date) AS lastDate
+    FROM CachedEntry
+    WHERE foodId IS NOT NULL
+    GROUP BY foodId
+) recent ON recent.foodId = CachedFood.id
+ORDER BY recent.lastDate DESC
+LIMIT ?;
+
+insertFood:
+INSERT OR REPLACE INTO CachedFood(id, name, brand, calories, protein, carbs, fat, fiber, isFavorite, barcode, jsonData)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteFood:
+DELETE FROM CachedFood WHERE id = ?;
+
+deleteAllFoods:
+DELETE FROM CachedFood;
+
+-- Goals
+selectGoals:
+SELECT * FROM CachedGoals WHERE id = 1;
+
+insertGoals:
+INSERT OR REPLACE INTO CachedGoals(id, calorieGoal, proteinGoal, carbGoal, fatGoal, fiberGoal)
+VALUES (1, ?, ?, ?, ?, ?);
+
+-- Recipes
+selectAllRecipes:
+SELECT * FROM CachedRecipe ORDER BY name;
+
+selectRecipeById:
+SELECT * FROM CachedRecipe WHERE id = ?;
+
+selectFavoriteRecipes:
+SELECT * FROM CachedRecipe WHERE isFavorite = 1 ORDER BY name;
+
+insertRecipe:
+INSERT OR REPLACE INTO CachedRecipe(id, name, totalServings, isFavorite, calories, protein, carbs, fat, fiber, jsonData)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteRecipe:
+DELETE FROM CachedRecipe WHERE id = ?;
+
+deleteAllRecipes:
+DELETE FROM CachedRecipe;
+
+-- Supplements
+selectAllSupplements:
+SELECT * FROM CachedSupplement ORDER BY sortOrder;
+
+selectActiveSupplements:
+SELECT * FROM CachedSupplement WHERE isActive = 1 ORDER BY sortOrder;
+
+selectSupplementById:
+SELECT * FROM CachedSupplement WHERE id = ?;
+
+insertSupplement:
+INSERT OR REPLACE INTO CachedSupplement(id, name, isActive, sortOrder, jsonData)
+VALUES (?, ?, ?, ?, ?);
+
+deleteSupplement:
+DELETE FROM CachedSupplement WHERE id = ?;
+
+deleteAllSupplements:
+DELETE FROM CachedSupplement;
+
+-- Supplement Logs
+selectAllSupplementLogs:
+SELECT * FROM CachedSupplementLog;
+
+selectSupplementLogsBySupplementId:
+SELECT * FROM CachedSupplementLog WHERE supplementId = ?;
+
+selectSupplementLogsByDate:
+SELECT * FROM CachedSupplementLog WHERE date = ?;
+
+selectSupplementLogsByDateRange:
+SELECT * FROM CachedSupplementLog WHERE date >= ? AND date <= ?;
+
+selectSupplementLogBySupplementAndDate:
+SELECT * FROM CachedSupplementLog WHERE supplementId = ? AND date = ? LIMIT 1;
+
+insertSupplementLog:
+INSERT OR REPLACE INTO CachedSupplementLog(id, supplementId, date, takenAt)
+VALUES (?, ?, ?, ?);
+
+deleteSupplementLog:
+DELETE FROM CachedSupplementLog WHERE supplementId = ? AND date = ?;
+
+deleteSupplementLogById:
+DELETE FROM CachedSupplementLog WHERE id = ?;
+
+-- Weight
+selectAllWeightEntries:
+SELECT * FROM CachedWeightEntry ORDER BY entryDate DESC;
+
+selectWeightEntriesLimited:
+SELECT * FROM CachedWeightEntry ORDER BY loggedAt DESC LIMIT ?;
+
+selectLatestWeightEntry:
+SELECT * FROM CachedWeightEntry ORDER BY entryDate DESC LIMIT 1;
+
+selectWeightEntriesByDateRange:
+SELECT * FROM CachedWeightEntry WHERE entryDate >= ? AND entryDate <= ? ORDER BY entryDate;
+
+insertWeightEntry:
+INSERT OR REPLACE INTO CachedWeightEntry(id, entryDate, weightKg, loggedAt, jsonData)
+VALUES (?, ?, ?, ?, ?);
+
+deleteWeightEntry:
+DELETE FROM CachedWeightEntry WHERE id = ?;
+
+deleteAllWeightEntries:
+DELETE FROM CachedWeightEntry;
+
+-- Sleep
+selectAllSleepEntries:
+SELECT * FROM CachedSleepEntry ORDER BY entryDate DESC;
+
+selectSleepEntriesByDateRange:
+SELECT * FROM CachedSleepEntry WHERE entryDate >= ? AND entryDate <= ? ORDER BY entryDate;
+
+insertSleepEntry:
+INSERT OR REPLACE INTO CachedSleepEntry(id, entryDate, durationMinutes, quality, loggedAt, jsonData)
+VALUES (?, ?, ?, ?, ?, ?);
+
+deleteSleepEntry:
+DELETE FROM CachedSleepEntry WHERE id = ?;
+
+deleteAllSleepEntries:
+DELETE FROM CachedSleepEntry;
+
+-- Preferences
+selectPreferences:
+SELECT * FROM CachedPreferences WHERE id = 1;
+
+insertPreferences:
+INSERT OR REPLACE INTO CachedPreferences(id, jsonData) VALUES (1, ?);
+
+deletePreferences:
+DELETE FROM CachedPreferences WHERE id = 1;
+
+-- Day Properties
+selectAllDayProperties:
+SELECT * FROM CachedDayProperties;
+
+selectDayProperties:
+SELECT * FROM CachedDayProperties WHERE date = ?;
+
+upsertDayProperties:
+INSERT OR REPLACE INTO CachedDayProperties(date, isFastingDay) VALUES (?, ?);
+
+deleteDayProperties:
+DELETE FROM CachedDayProperties WHERE date = ?;
+
+-- Clear all data (for logout)
+clearAllData:
+DELETE FROM CachedEntry;
+
+clearAllFoods:
+DELETE FROM CachedFood;
+
+clearAllGoals:
+DELETE FROM CachedGoals;
+
+clearAllRecipes:
+DELETE FROM CachedRecipe;
+
+clearAllSupplements:
+DELETE FROM CachedSupplement;
+
+clearAllSupplementLogs:
+DELETE FROM CachedSupplementLog;
+
+clearAllWeightEntries:
+DELETE FROM CachedWeightEntry;
+
+clearAllSleepEntries:
+DELETE FROM CachedSleepEntry;
+
+clearAllPreferences:
+DELETE FROM CachedPreferences;
+
+clearAllDayProperties:
+DELETE FROM CachedDayProperties;

--- a/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
@@ -292,6 +292,15 @@ SELECT retryCount FROM SyncQueue WHERE id = ?;
 deleteSyncQueueItem:
 DELETE FROM SyncQueue WHERE id = ?;
 
+selectSyncQueueByAffected:
+SELECT * FROM SyncQueue WHERE affectedTable = ? AND affectedId = ?;
+
+updateSyncQueueOperation:
+UPDATE SyncQueue SET operation = ? WHERE id = ?;
+
+deleteSyncQueueByAffected:
+DELETE FROM SyncQueue WHERE affectedTable = ? AND affectedId = ?;
+
 countSyncQueue:
 SELECT COUNT(*) FROM SyncQueue;
 

--- a/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
@@ -93,6 +93,11 @@ CREATE TABLE IF NOT EXISTS CachedMealType (
     sortOrder INTEGER NOT NULL DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS CachedDayProperties (
+    date TEXT NOT NULL PRIMARY KEY,
+    isFastingDay INTEGER NOT NULL DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS SyncQueue (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     operation TEXT NOT NULL,
@@ -110,6 +115,9 @@ CREATE TABLE IF NOT EXISTS SyncMeta (
 -- Entries
 selectEntriesByDate:
 SELECT * FROM CachedEntry WHERE date = ?;
+
+selectEntriesByDateRange:
+SELECT * FROM CachedEntry WHERE date >= ? AND date <= ? ORDER BY date;
 
 insertEntry:
 INSERT OR REPLACE INTO CachedEntry(id, date, mealType, servings, foodId, recipeId, foodName, calories, protein, carbs, fat, fiber, jsonData)
@@ -136,6 +144,18 @@ SELECT * FROM CachedFood WHERE isFavorite = 1 ORDER BY name;
 
 searchFoods:
 SELECT * FROM CachedFood WHERE name LIKE ? OR brand LIKE ? ORDER BY name LIMIT ?;
+
+-- Foods recently logged via cached entries (Local mode replacement for /api/foods/recent)
+selectRecentFoods:
+SELECT CachedFood.* FROM CachedFood
+JOIN (
+    SELECT foodId, MAX(date) AS lastDate
+    FROM CachedEntry
+    WHERE foodId IS NOT NULL
+    GROUP BY foodId
+) recent ON recent.foodId = CachedFood.id
+ORDER BY recent.lastDate DESC
+LIMIT ?;
 
 insertFood:
 INSERT OR REPLACE INTO CachedFood(id, name, brand, calories, protein, carbs, fat, fiber, isFavorite, barcode, jsonData)
@@ -275,6 +295,16 @@ INSERT OR REPLACE INTO CachedMealType(id, name, sortOrder) VALUES (?, ?, ?);
 deleteAllMealTypes:
 DELETE FROM CachedMealType;
 
+-- Day Properties
+selectDayProperties:
+SELECT * FROM CachedDayProperties WHERE date = ?;
+
+upsertDayProperties:
+INSERT OR REPLACE INTO CachedDayProperties(date, isFastingDay) VALUES (?, ?);
+
+deleteDayProperties:
+DELETE FROM CachedDayProperties WHERE date = ?;
+
 -- Sync Queue
 selectSyncQueue:
 SELECT * FROM SyncQueue ORDER BY createdAt LIMIT 50;
@@ -344,6 +374,9 @@ DELETE FROM CachedPreferences;
 
 clearAllMealTypes:
 DELETE FROM CachedMealType;
+
+clearAllDayProperties:
+DELETE FROM CachedDayProperties;
 
 clearAllSyncQueue:
 DELETE FROM SyncQueue;

--- a/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
@@ -43,6 +43,9 @@ DELETE FROM CachedMealType;
 selectSyncQueue:
 SELECT * FROM SyncQueue ORDER BY createdAt LIMIT 50;
 
+selectAllSyncQueue:
+SELECT * FROM SyncQueue ORDER BY createdAt;
+
 insertSyncQueueItem:
 INSERT INTO SyncQueue(operation, createdAt, affectedTable, affectedId, retryCount)
 VALUES (?, ?, ?, ?, 0);
@@ -61,6 +64,9 @@ SELECT * FROM SyncQueue WHERE affectedTable = ? AND affectedId = ?;
 
 updateSyncQueueOperation:
 UPDATE SyncQueue SET operation = ? WHERE id = ?;
+
+updateSyncQueueOperationAndAffected:
+UPDATE SyncQueue SET operation = ?, affectedTable = ?, affectedId = ? WHERE id = ?;
 
 deleteSyncQueueByAffected:
 DELETE FROM SyncQueue WHERE affectedTable = ? AND affectedId = ?;

--- a/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
@@ -113,6 +113,15 @@ CREATE TABLE IF NOT EXISTS SyncMeta (
 );
 
 -- Entries
+selectAllEntries:
+SELECT * FROM CachedEntry;
+
+selectEntriesByFoodId:
+SELECT * FROM CachedEntry WHERE foodId = ?;
+
+selectEntriesByRecipeId:
+SELECT * FROM CachedEntry WHERE recipeId = ?;
+
 selectEntriesByDate:
 SELECT * FROM CachedEntry WHERE date = ?;
 
@@ -216,6 +225,12 @@ deleteAllSupplements:
 DELETE FROM CachedSupplement;
 
 -- Supplement Logs
+selectAllSupplementLogs:
+SELECT * FROM CachedSupplementLog;
+
+selectSupplementLogsBySupplementId:
+SELECT * FROM CachedSupplementLog WHERE supplementId = ?;
+
 selectSupplementLogsByDate:
 SELECT * FROM CachedSupplementLog WHERE date = ?;
 
@@ -296,6 +311,9 @@ deleteAllMealTypes:
 DELETE FROM CachedMealType;
 
 -- Day Properties
+selectAllDayProperties:
+SELECT * FROM CachedDayProperties;
+
 selectDayProperties:
 SELECT * FROM CachedDayProperties WHERE date = ?;
 
@@ -343,6 +361,9 @@ SELECT lastSyncedAt FROM SyncMeta WHERE entityType = ?;
 
 upsertSyncMeta:
 INSERT OR REPLACE INTO SyncMeta(entityType, lastSyncedAt) VALUES (?, ?);
+
+deleteSyncMeta:
+DELETE FROM SyncMeta WHERE entityType = ?;
 
 -- Clear all data (for logout)
 clearAllData:

--- a/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
+++ b/mobile/shared/src/commonMain/sqldelight/com/bissbilanz/cache/BissbilanzDatabase.sq
@@ -1,101 +1,18 @@
-CREATE TABLE IF NOT EXISTS CachedEntry (
-    id TEXT NOT NULL PRIMARY KEY,
-    date TEXT NOT NULL,
-    mealType TEXT NOT NULL,
-    servings REAL NOT NULL,
-    foodId TEXT,
-    recipeId TEXT,
-    foodName TEXT,
-    calories REAL NOT NULL DEFAULT 0,
-    protein REAL NOT NULL DEFAULT 0,
-    carbs REAL NOT NULL DEFAULT 0,
-    fat REAL NOT NULL DEFAULT 0,
-    fiber REAL NOT NULL DEFAULT 0,
-    jsonData TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedFood (
-    id TEXT NOT NULL PRIMARY KEY,
-    name TEXT NOT NULL,
-    brand TEXT,
-    calories REAL NOT NULL DEFAULT 0,
-    protein REAL NOT NULL DEFAULT 0,
-    carbs REAL NOT NULL DEFAULT 0,
-    fat REAL NOT NULL DEFAULT 0,
-    fiber REAL NOT NULL DEFAULT 0,
-    isFavorite INTEGER NOT NULL DEFAULT 0,
-    barcode TEXT,
-    jsonData TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedGoals (
-    id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
-    calorieGoal REAL NOT NULL,
-    proteinGoal REAL NOT NULL,
-    carbGoal REAL NOT NULL,
-    fatGoal REAL NOT NULL,
-    fiberGoal REAL NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedRecipe (
-    id TEXT NOT NULL PRIMARY KEY,
-    name TEXT NOT NULL,
-    totalServings REAL NOT NULL DEFAULT 1,
-    isFavorite INTEGER NOT NULL DEFAULT 0,
-    calories REAL NOT NULL DEFAULT 0,
-    protein REAL NOT NULL DEFAULT 0,
-    carbs REAL NOT NULL DEFAULT 0,
-    fat REAL NOT NULL DEFAULT 0,
-    fiber REAL NOT NULL DEFAULT 0,
-    jsonData TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedSupplement (
-    id TEXT NOT NULL PRIMARY KEY,
-    name TEXT NOT NULL,
-    isActive INTEGER NOT NULL DEFAULT 1,
-    sortOrder INTEGER NOT NULL DEFAULT 0,
-    jsonData TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedSupplementLog (
-    id TEXT NOT NULL PRIMARY KEY,
-    supplementId TEXT NOT NULL,
-    date TEXT NOT NULL,
-    takenAt TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedWeightEntry (
-    id TEXT NOT NULL PRIMARY KEY,
-    entryDate TEXT NOT NULL,
-    weightKg REAL NOT NULL,
-    loggedAt TEXT,
-    jsonData TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedSleepEntry (
-    id TEXT NOT NULL PRIMARY KEY,
-    entryDate TEXT NOT NULL,
-    durationMinutes INTEGER NOT NULL,
-    quality INTEGER NOT NULL,
-    loggedAt TEXT,
-    jsonData TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS CachedPreferences (
-    id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
-    jsonData TEXT NOT NULL
-);
+-- Server-derived/transient state (bissbilanz.db): the sync queue, sync metadata and
+-- the meal-type cache. This file is excluded from Android Auto Backup — restoring a
+-- stale sync queue onto a new device would replay old operations. The user's own
+-- data lives in UserDataDatabase (userdata.db), which IS backed up.
+--
+-- Schema convention (CRITICAL): every statement must stay CREATE TABLE IF NOT EXISTS
+-- and changes must be additive-only. DatabaseDriverFactory re-runs Schema.create on
+-- every open to materialize tables added in app updates; that is only safe while
+-- this convention holds. The user-data tables that lived here before the split are
+-- dropped from existing installs by LegacyUserDataMigration and must not come back.
 
 CREATE TABLE IF NOT EXISTS CachedMealType (
     id TEXT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
     sortOrder INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS CachedDayProperties (
-    date TEXT NOT NULL PRIMARY KEY,
-    isFastingDay INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS SyncQueue (
@@ -112,194 +29,6 @@ CREATE TABLE IF NOT EXISTS SyncMeta (
     lastSyncedAt TEXT NOT NULL
 );
 
--- Entries
-selectAllEntries:
-SELECT * FROM CachedEntry;
-
-selectEntriesByFoodId:
-SELECT * FROM CachedEntry WHERE foodId = ?;
-
-selectEntriesByRecipeId:
-SELECT * FROM CachedEntry WHERE recipeId = ?;
-
-selectEntriesByDate:
-SELECT * FROM CachedEntry WHERE date = ?;
-
-selectEntriesByDateRange:
-SELECT * FROM CachedEntry WHERE date >= ? AND date <= ? ORDER BY date;
-
-insertEntry:
-INSERT OR REPLACE INTO CachedEntry(id, date, mealType, servings, foodId, recipeId, foodName, calories, protein, carbs, fat, fiber, jsonData)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-
-deleteEntry:
-DELETE FROM CachedEntry WHERE id = ?;
-
-deleteEntriesByDate:
-DELETE FROM CachedEntry WHERE date = ?;
-
--- Foods
-selectAllFoods:
-SELECT * FROM CachedFood ORDER BY name;
-
-selectFoodById:
-SELECT * FROM CachedFood WHERE id = ?;
-
-selectFoodByBarcode:
-SELECT * FROM CachedFood WHERE barcode = ? LIMIT 1;
-
-selectFavorites:
-SELECT * FROM CachedFood WHERE isFavorite = 1 ORDER BY name;
-
-searchFoods:
-SELECT * FROM CachedFood WHERE name LIKE ? OR brand LIKE ? ORDER BY name LIMIT ?;
-
--- Foods recently logged via cached entries (Local mode replacement for /api/foods/recent)
-selectRecentFoods:
-SELECT CachedFood.* FROM CachedFood
-JOIN (
-    SELECT foodId, MAX(date) AS lastDate
-    FROM CachedEntry
-    WHERE foodId IS NOT NULL
-    GROUP BY foodId
-) recent ON recent.foodId = CachedFood.id
-ORDER BY recent.lastDate DESC
-LIMIT ?;
-
-insertFood:
-INSERT OR REPLACE INTO CachedFood(id, name, brand, calories, protein, carbs, fat, fiber, isFavorite, barcode, jsonData)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-
-deleteFood:
-DELETE FROM CachedFood WHERE id = ?;
-
-deleteAllFoods:
-DELETE FROM CachedFood;
-
--- Goals
-selectGoals:
-SELECT * FROM CachedGoals WHERE id = 1;
-
-insertGoals:
-INSERT OR REPLACE INTO CachedGoals(id, calorieGoal, proteinGoal, carbGoal, fatGoal, fiberGoal)
-VALUES (1, ?, ?, ?, ?, ?);
-
--- Recipes
-selectAllRecipes:
-SELECT * FROM CachedRecipe ORDER BY name;
-
-selectRecipeById:
-SELECT * FROM CachedRecipe WHERE id = ?;
-
-selectFavoriteRecipes:
-SELECT * FROM CachedRecipe WHERE isFavorite = 1 ORDER BY name;
-
-insertRecipe:
-INSERT OR REPLACE INTO CachedRecipe(id, name, totalServings, isFavorite, calories, protein, carbs, fat, fiber, jsonData)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-
-deleteRecipe:
-DELETE FROM CachedRecipe WHERE id = ?;
-
-deleteAllRecipes:
-DELETE FROM CachedRecipe;
-
--- Supplements
-selectAllSupplements:
-SELECT * FROM CachedSupplement ORDER BY sortOrder;
-
-selectActiveSupplements:
-SELECT * FROM CachedSupplement WHERE isActive = 1 ORDER BY sortOrder;
-
-selectSupplementById:
-SELECT * FROM CachedSupplement WHERE id = ?;
-
-insertSupplement:
-INSERT OR REPLACE INTO CachedSupplement(id, name, isActive, sortOrder, jsonData)
-VALUES (?, ?, ?, ?, ?);
-
-deleteSupplement:
-DELETE FROM CachedSupplement WHERE id = ?;
-
-deleteAllSupplements:
-DELETE FROM CachedSupplement;
-
--- Supplement Logs
-selectAllSupplementLogs:
-SELECT * FROM CachedSupplementLog;
-
-selectSupplementLogsBySupplementId:
-SELECT * FROM CachedSupplementLog WHERE supplementId = ?;
-
-selectSupplementLogsByDate:
-SELECT * FROM CachedSupplementLog WHERE date = ?;
-
-selectSupplementLogsByDateRange:
-SELECT * FROM CachedSupplementLog WHERE date >= ? AND date <= ?;
-
-selectSupplementLogBySupplementAndDate:
-SELECT * FROM CachedSupplementLog WHERE supplementId = ? AND date = ? LIMIT 1;
-
-insertSupplementLog:
-INSERT OR REPLACE INTO CachedSupplementLog(id, supplementId, date, takenAt)
-VALUES (?, ?, ?, ?);
-
-deleteSupplementLog:
-DELETE FROM CachedSupplementLog WHERE supplementId = ? AND date = ?;
-
-deleteSupplementLogById:
-DELETE FROM CachedSupplementLog WHERE id = ?;
-
--- Weight
-selectAllWeightEntries:
-SELECT * FROM CachedWeightEntry ORDER BY entryDate DESC;
-
-selectWeightEntriesLimited:
-SELECT * FROM CachedWeightEntry ORDER BY loggedAt DESC LIMIT ?;
-
-selectLatestWeightEntry:
-SELECT * FROM CachedWeightEntry ORDER BY entryDate DESC LIMIT 1;
-
-selectWeightEntriesByDateRange:
-SELECT * FROM CachedWeightEntry WHERE entryDate >= ? AND entryDate <= ? ORDER BY entryDate;
-
-insertWeightEntry:
-INSERT OR REPLACE INTO CachedWeightEntry(id, entryDate, weightKg, loggedAt, jsonData)
-VALUES (?, ?, ?, ?, ?);
-
-deleteWeightEntry:
-DELETE FROM CachedWeightEntry WHERE id = ?;
-
-deleteAllWeightEntries:
-DELETE FROM CachedWeightEntry;
-
--- Sleep
-selectAllSleepEntries:
-SELECT * FROM CachedSleepEntry ORDER BY entryDate DESC;
-
-selectSleepEntriesByDateRange:
-SELECT * FROM CachedSleepEntry WHERE entryDate >= ? AND entryDate <= ? ORDER BY entryDate;
-
-insertSleepEntry:
-INSERT OR REPLACE INTO CachedSleepEntry(id, entryDate, durationMinutes, quality, loggedAt, jsonData)
-VALUES (?, ?, ?, ?, ?, ?);
-
-deleteSleepEntry:
-DELETE FROM CachedSleepEntry WHERE id = ?;
-
-deleteAllSleepEntries:
-DELETE FROM CachedSleepEntry;
-
--- Preferences
-selectPreferences:
-SELECT * FROM CachedPreferences WHERE id = 1;
-
-insertPreferences:
-INSERT OR REPLACE INTO CachedPreferences(id, jsonData) VALUES (1, ?);
-
-deletePreferences:
-DELETE FROM CachedPreferences WHERE id = 1;
-
 -- Meal Types
 selectAllMealTypes:
 SELECT * FROM CachedMealType ORDER BY sortOrder;
@@ -309,19 +38,6 @@ INSERT OR REPLACE INTO CachedMealType(id, name, sortOrder) VALUES (?, ?, ?);
 
 deleteAllMealTypes:
 DELETE FROM CachedMealType;
-
--- Day Properties
-selectAllDayProperties:
-SELECT * FROM CachedDayProperties;
-
-selectDayProperties:
-SELECT * FROM CachedDayProperties WHERE date = ?;
-
-upsertDayProperties:
-INSERT OR REPLACE INTO CachedDayProperties(date, isFastingDay) VALUES (?, ?);
-
-deleteDayProperties:
-DELETE FROM CachedDayProperties WHERE date = ?;
 
 -- Sync Queue
 selectSyncQueue:
@@ -366,38 +82,8 @@ deleteSyncMeta:
 DELETE FROM SyncMeta WHERE entityType = ?;
 
 -- Clear all data (for logout)
-clearAllData:
-DELETE FROM CachedEntry;
-
-clearAllFoods:
-DELETE FROM CachedFood;
-
-clearAllGoals:
-DELETE FROM CachedGoals;
-
-clearAllRecipes:
-DELETE FROM CachedRecipe;
-
-clearAllSupplements:
-DELETE FROM CachedSupplement;
-
-clearAllSupplementLogs:
-DELETE FROM CachedSupplementLog;
-
-clearAllWeightEntries:
-DELETE FROM CachedWeightEntry;
-
-clearAllSleepEntries:
-DELETE FROM CachedSleepEntry;
-
-clearAllPreferences:
-DELETE FROM CachedPreferences;
-
 clearAllMealTypes:
 DELETE FROM CachedMealType;
-
-clearAllDayProperties:
-DELETE FROM CachedDayProperties;
 
 clearAllSyncQueue:
 DELETE FROM SyncQueue;

--- a/mobile/shared/src/iosMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
+++ b/mobile/shared/src/iosMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
@@ -4,5 +4,13 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 
 actual class DatabaseDriverFactory {
-    actual fun createDriver(): SqlDriver = NativeSqliteDriver(BissbilanzDatabase.Schema, "bissbilanz.db")
+    actual fun createDriver(): SqlDriver {
+        val driver = NativeSqliteDriver(BissbilanzDatabase.Schema, "bissbilanz.db")
+        // The native driver only runs Schema.create on a brand-new database, so tables
+        // added in app updates would never materialize on existing installs. Re-running
+        // create here is idempotent because the schema is (and must remain)
+        // IF-NOT-EXISTS-only and additive-only.
+        BissbilanzDatabase.Schema.create(driver)
+        return driver
+    }
 }

--- a/mobile/shared/src/iosMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
+++ b/mobile/shared/src/iosMain/kotlin/com/bissbilanz/cache/DatabaseDriverFactory.kt
@@ -2,6 +2,7 @@ package com.bissbilanz.cache
 
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import com.bissbilanz.userdata.UserDataDatabase
 
 actual class DatabaseDriverFactory {
     actual fun createDriver(): SqlDriver {
@@ -11,6 +12,15 @@ actual class DatabaseDriverFactory {
         // create here is idempotent because the schema is (and must remain)
         // IF-NOT-EXISTS-only and additive-only.
         BissbilanzDatabase.Schema.create(driver)
+        return driver
+    }
+
+    actual fun createUserDataDriver(): SqlDriver {
+        val driver = NativeSqliteDriver(UserDataDatabase.Schema, "userdata.db")
+        // Same idempotent-create pattern as createDriver(), see above. The legacy-data
+        // copy is Android-only: the iOS app never shipped with the single-database
+        // layout, so there is nothing to migrate here.
+        UserDataDatabase.Schema.create(driver)
         return driver
     }
 }

--- a/mobile/shared/src/iosMain/kotlin/com/bissbilanz/storage/IosPlainStorage.kt
+++ b/mobile/shared/src/iosMain/kotlin/com/bissbilanz/storage/IosPlainStorage.kt
@@ -1,0 +1,24 @@
+package com.bissbilanz.storage
+
+import platform.Foundation.NSUserDefaults
+
+/**
+ * Plain NSUserDefaults-backed storage for non-secret app state. Never store
+ * secrets here — use the Keychain-backed SecureStorage instead.
+ */
+actual class PlainStorage : KeyValueStore {
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    actual override fun save(
+        key: String,
+        value: String,
+    ) {
+        defaults.setObject(value, forKey = key)
+    }
+
+    actual override fun load(key: String): String? = defaults.stringForKey(key)
+
+    actual override fun delete(key: String) {
+        defaults.removeObjectForKey(key)
+    }
+}


### PR DESCRIPTION
## Summary

Makes both mobile apps local-first with an anonymous Local mode, and polishes the iOS weight/settings UI.

### Local-first storage & sync
- SwiftData local persistence layer on iOS; Android storage split into backed-up `userdata.db` and excluded cache db
- Anonymous **Local mode** on both platforms (use the app without an account); first login migrates local data to the account
- Persistent offline sync queue with FIFO drain, temp-id remapping for chained offline creates, and coalescing of edits into queued creates

### Auth & session handling (iOS)
- Login state is stored in the keychain and auto-refreshed; concurrent 401s share a single in-flight refresh so rotated refresh tokens are not invalidated by races
- Only an explicit server rejection of the refresh token ends the session — offline/5xx failures keep the user signed in
- A previously-signed-in user whose session expires stays in the app (data is local) and gets a sign-in prompt; the login screen only ever shows on first launch or after explicit sign-out

### Weight page redesign (iOS)
- Top row: large Latest card + Trend card (rising/falling/steady icon, 7-day delta; server stat with local fallback)
- History capped at 5 entries with a paginated "Show all" subpage (lazy list, 50 rows/page from SwiftData)

### UI polish (iOS)
- Standalone buttons (quick actions, select all) no longer wrapped in card containers

## Test plan
- 239 iOS unit tests passing (routing table, auth state, sync drain semantics, repositories, migrator, weight trend + pagination)
- Manually verified on device (iPhone 16 Pro): Local mode, login migration, weight page, settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)