### PR TITLE
fix(ci): unblock e2e on dependabot PRs + group testcontainers updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      # testcontainers core and its modules share types — bumping one
+      # without the other breaks svelte-check (duplicate nested copies)
+      testcontainers:
+        patterns:
+          - 'testcontainers'
+          - '@testcontainers/*'
 
   # Gradle (Kotlin Multiplatform / Android)
   - package-ecosystem: 'gradle'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -54,7 +54,10 @@ jobs:
       - name: Build app
         env:
           DATABASE_URL: postgres://test:test@localhost:5432/e2e_test
-          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET }}
+          # Fallback: dependabot-triggered runs read the (empty) Dependabot
+          # secrets store. The value only signs cookies for a throwaway CI
+          # server with fake OIDC creds, so a dummy is fine there.
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-test-only-session-secret' }}
           PUBLIC_APP_URL: http://localhost:4000
           INFOMANIAK_CLIENT_ID: fake
           INFOMANIAK_CLIENT_SECRET: fake
@@ -66,7 +69,7 @@ jobs:
       - name: Run Playwright tests
         env:
           DATABASE_URL: postgres://test:test@localhost:5432/e2e_test
-          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET }}
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-test-only-session-secret' }}
           PUBLIC_APP_URL: http://localhost:4000
           INFOMANIAK_CLIENT_ID: fake
           INFOMANIAK_CLIENT_SECRET: fake


### PR DESCRIPTION
Two small CI fixes so dependabot PRs can actually go green:

1. **e2e on dependabot PRs**: dependabot-triggered runs read the separate Dependabot secrets store, where `E2E_SESSION_SECRET` is unset — the e2e web server failed to start (`SESSION_SECRET is required`) on every dependabot PR. Add a dummy fallback; the value only signs cookies for a throwaway CI server with fake OIDC creds and a scratch database.
2. **Group testcontainers bumps**: `testcontainers` and `@testcontainers/*` must move together — bumping one alone nests a second copy of testcontainers whose `WaitStrategy` types conflict in svelte-check (the current state of #273/#277). A dependabot `groups` stanza makes them one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)