### PR TITLE
chore(ci): switch CodeQL to advanced setup with manual mobile builds

### DIFF
--- a/.github/workflows/codeql-mobile.yml
+++ b/.github/workflows/codeql-mobile.yml
@@ -1,0 +1,160 @@
+name: CodeQL (Mobile)
+
+on:
+  push:
+    branches: [main]
+    paths: [mobile/**, .github/workflows/codeql-mobile.yml]
+  pull_request:
+    branches: [main]
+    paths: [mobile/**, .github/workflows/codeql-mobile.yml]
+  schedule:
+    - cron: '30 5 * * 1' # every Monday at 05:30 UTC
+
+concurrency:
+  group: codeql-mobile-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  kotlin:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4.0.1
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.gradle/build-cache
+          key: gradle-android-${{ runner.os }}-${{ hashFiles('mobile/**/*.gradle*', 'mobile/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-android-${{ runner.os }}-
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      # CodeQL extracts Kotlin by observing the compiler: the build cache must be
+      # off so compilation actually runs, and the compiler must run in-process so
+      # the tracer can see it (the Kotlin daemon escapes tracing).
+      - name: Build Android app
+        run: >
+          ./gradlew --no-daemon --no-build-cache
+          -Pkotlin.compiler.execution.strategy=in-process
+          androidApp:assembleDebug
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:java-kotlin'
+
+  swift:
+    name: Analyze (swift)
+    runs-on: macos-14
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Select Xcode 16.2
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Cache Gradle and Kotlin/Native dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.gradle/build-cache
+            ~/.konan
+          key: gradle-ios-${{ runner.os }}-${{ hashFiles('mobile/**/*.gradle*', 'mobile/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-ios-${{ runner.os }}-
+
+      - name: Cache Homebrew packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /usr/local/Cellar/xcodegen
+          key: brew-xcodegen-${{ runner.os }}
+
+      - name: Install XcodeGen
+        run: brew install --formula xcodegen
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+
+      - name: Build shared iOS framework
+        run: ./gradlew shared:linkDebugFrameworkIosSimulatorArm64
+
+      - name: Stage shared framework for Xcode
+        run: |
+          SDK_NAME=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          DEST="shared/build/xcode-frameworks/Debug/iphonesimulator${SDK_NAME}"
+          mkdir -p "$DEST"
+          cp -R shared/build/bin/iosSimulatorArm64/debugFramework/shared.framework "$DEST/"
+
+      - name: Generate Xcode project
+        working-directory: mobile/iosApp
+        run: xcodegen generate
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: swift
+          build-mode: manual
+
+      - name: Build iOS app
+        working-directory: mobile/iosApp
+        run: |
+          xcodebuild build \
+            -project Bissbilanz.xcodeproj \
+            -scheme Bissbilanz \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:swift'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 5 * * 1' # every Monday at 05:00 UTC
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Problem

CodeQL default setup has been red since March with two broken configurations:

- **swift**: "No Xcode project or workspace found" — the Xcode project is generated by XcodeGen (`project.yml`); no `.xcodeproj` is checked in, so autobuild has nothing to build.
- **java-kotlin**: "Gradle target 'testClasses' not found" — the KMP project doesn't define that task, so autobuild fails.

Both need manual build commands, which default setup doesn't support — GitHub's documented fix is switching to an advanced setup workflow.

## Changes

- **`codeql.yml`**: analyzes `actions` and `javascript-typescript` (buildless) on PRs, pushes to main, and weekly — same coverage default setup provided.
- **`codeql-mobile.yml`**: analyzes `java-kotlin` and `swift` with manual builds mirroring the proven recipes from `mobile-android.yml` / `mobile-ios.yml` (Gradle `assembleDebug`; XcodeGen + staged KMP framework + `xcodebuild`). Path-filtered to `mobile/**` on PRs/pushes, plus a weekly full run — consistent with how the other mobile workflows and security scans are scoped.
- Default setup has been disabled via the API (its presence rejects SARIF uploads from advanced workflows).

Analysis categories (`/language:*`) match the ones default setup used, so alert history carries over. Net result: the two erroring configurations are gone, and Kotlin and Swift are now actually scanned instead of silently skipped.

Supersedes #280, which picked up the wrong branch content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)