### PR TITLE
fix(ci): pad e2e fallback session secret to 32+ chars

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,7 +57,7 @@ jobs:
           # Fallback: dependabot-triggered runs read the (empty) Dependabot
           # secrets store. The value only signs cookies for a throwaway CI
           # server with fake OIDC creds, so a dummy is fine there.
-          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-test-only-session-secret' }}
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-test-only-session-secret-padded-to-32-chars' }}
           PUBLIC_APP_URL: http://localhost:4000
           INFOMANIAK_CLIENT_ID: fake
           INFOMANIAK_CLIENT_SECRET: fake
@@ -69,7 +69,7 @@ jobs:
       - name: Run Playwright tests
         env:
           DATABASE_URL: postgres://test:test@localhost:5432/e2e_test
-          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-test-only-session-secret' }}
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-test-only-session-secret-padded-to-32-chars' }}
           PUBLIC_APP_URL: http://localhost:4000
           INFOMANIAK_CLIENT_ID: fake
           INFOMANIAK_CLIENT_SECRET: fake


### PR DESCRIPTION
Follow-up to #279: the app validates `SESSION_SECRET` length (>= 32 chars) and the dependabot fallback was 28 chars, so the e2e web server still refused to start on dependabot-triggered runs (`SESSION_SECRET must be at least 32 characters`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)