### PR TITLE
feat(ios): adopt iOS 26 design guidelines

### DIFF
--- a/.github/workflows/mobile-ios.yml
+++ b/.github/workflows/mobile-ios.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 45
     defaults:
       run:
@@ -26,10 +26,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Select Xcode 16.2
+      # Xcode 26+ so the compiler(>=6.2)-gated Liquid Glass code compiles in CI
+      - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.2'
+          xcode-version: latest-stable
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -54,7 +55,7 @@ jobs:
         with:
           path: |
             ~/Library/Caches/Homebrew
-            /usr/local/Cellar/xcodegen
+            /opt/homebrew/Cellar/xcodegen
           key: brew-xcodegen-${{ runner.os }}
 
       - name: Install XcodeGen
@@ -82,6 +83,6 @@ jobs:
           xcodebuild build \
             -project Bissbilanz.xcodeproj \
             -scheme Bissbilanz \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO

--- a/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
@@ -66,6 +66,7 @@ struct QuickEntrySheet: View {
                 if let errorMessage { Text(errorMessage) }
             }
         }
+        .presentationDetents([.medium, .large])
     }
 
     private func macroField(_ label: String, text: Binding<String>, unit: String) -> some View {

--- a/mobile/iosApp/Bissbilanz/Views/ContentView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/ContentView.swift
@@ -59,23 +59,21 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
-            DashboardView()
-                .tabItem {
-                    Label(L10n.home, systemImage: "house")
-                }
-
-            ForEach(selectedTabs) { tab in
-                tab.destination
-                    .tabItem {
-                        Label(tab.label, systemImage: tab.icon)
-                    }
+            Tab(L10n.home, systemImage: "house") {
+                DashboardView()
             }
 
-            SettingsView()
-                .tabItem {
-                    Label(L10n.settings, systemImage: "gear")
+            ForEach(selectedTabs) { tab in
+                Tab(tab.label, systemImage: tab.icon) {
+                    tab.destination
                 }
+            }
+
+            Tab(L10n.settings, systemImage: "gear") {
+                SettingsView()
+            }
         }
+        .minimizableTabBar()
         // Only users who signed in initially are prompted — Local mode is
         // anonymous by choice and never sees this.
         .onChange(of: authManager.authState, initial: true) { _, state in

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -84,7 +84,7 @@ struct DashboardView: View {
                         }
                         .padding(12)
                         .background(.regularMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
 
                     if preferences.showWeightWidget, let weight = latestWeight {
@@ -241,7 +241,7 @@ struct DashboardView: View {
         }
         .padding(12)
         .background(.orange.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     // MARK: - Weight Widget
@@ -268,7 +268,7 @@ struct DashboardView: View {
         }
         .padding(12)
         .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     // MARK: - Supplements Widget
@@ -307,73 +307,66 @@ struct DashboardView: View {
         }
         .padding(12)
         .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     // MARK: - Empty State
 
     private var emptyState: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "fork.knife.circle")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-            Text(L10n.noEntriesYet)
-                .foregroundStyle(.secondary)
+        ContentUnavailableView {
+            Label(L10n.noEntriesYet, systemImage: "fork.knife.circle")
+        } description: {
             Text(L10n.tapToAdd)
-                .foregroundStyle(.secondary)
-
+        } actions: {
             if !selectedDate.isToday {
                 Button(L10n.copyYesterday) {
                     showCopyConfirmation = true
                 }
                 .buttonStyle(.bordered)
-                .padding(.top, 8)
             }
         }
-        .padding(.vertical, 48)
+        .padding(.vertical, 24)
     }
 
     // MARK: - FAB
 
     private var fab: some View {
-        VStack(spacing: 12) {
-            Button {
-                showScanner = true
-                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            } label: {
-                Image(systemName: "barcode.viewfinder")
-                    .font(.title3)
-                    .frame(width: 44, height: 44)
-                    .background(.thinMaterial)
-                    .clipShape(Circle())
-            }
+        FloatingControlGroup {
+            VStack(spacing: 12) {
+                Button {
+                    showScanner = true
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                } label: {
+                    Image(systemName: "barcode.viewfinder")
+                        .font(.title3)
+                        .frame(width: 44, height: 44)
+                }
+                .circularGlassBackground()
 
-            Button {
-                showQuickEntry = true
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            } label: {
-                Image(systemName: "bolt")
-                    .font(.title3)
-                    .frame(width: 44, height: 44)
-                    .background(.thinMaterial)
-                    .clipShape(Circle())
-            }
+                Button {
+                    showQuickEntry = true
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                } label: {
+                    Image(systemName: "bolt")
+                        .font(.title3)
+                        .frame(width: 44, height: 44)
+                }
+                .circularGlassBackground()
 
-            Button {
-                showFoodSearch = true
-                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            } label: {
-                Image(systemName: "plus")
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.white)
-                    .frame(width: 56, height: 56)
-                    .background(MacroColors.calories)
-                    .clipShape(Circle())
-                    .shadow(radius: 4)
+                Button {
+                    showFoodSearch = true
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                        .frame(width: 56, height: 56)
+                }
+                .circularGlassBackground(tint: MacroColors.calories)
             }
+            .padding()
         }
-        .padding()
     }
 
     // MARK: - Data Loading

--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -15,6 +15,7 @@ struct InsightsView: View {
     @State private var selectedRange = 7
     @State private var isLoading = true
     @State private var calendarMonth = Date()
+    @ScaledMetric(relativeTo: .largeTitle) private var streakNumberSize = 36.0
 
     var body: some View {
         NavigationStack {
@@ -132,7 +133,7 @@ struct InsightsView: View {
                     HStack(spacing: 32) {
                         VStack {
                             Text("\(streaks.currentStreak)")
-                                .font(.system(size: 36, weight: .bold))
+                                .font(.system(size: streakNumberSize, weight: .bold))
                                 .foregroundStyle(MacroColors.calories)
                             Text(L10n.currentStreak)
                                 .font(.caption)
@@ -140,7 +141,7 @@ struct InsightsView: View {
                         }
                         VStack {
                             Text("\(streaks.longestStreak)")
-                                .font(.system(size: 36, weight: .bold))
+                                .font(.system(size: streakNumberSize, weight: .bold))
                                 .foregroundStyle(MacroColors.fiber)
                             Text(L10n.longestStreak)
                                 .font(.caption)

--- a/mobile/iosApp/Bissbilanz/Views/LiquidGlass.swift
+++ b/mobile/iosApp/Bissbilanz/Views/LiquidGlass.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+// iOS 26 Liquid Glass adoption is double-gated: `#if compiler(>=6.2)` keeps
+// the project building with pre-iOS-26 SDKs (Xcode 16 locally and in the
+// CodeQL job), and `#available(iOS 26.0, *)` keeps the pre-26 appearance as
+// the runtime fallback on older systems.
+
+/// Groups floating glass controls so their shapes blend during transitions
+/// on iOS 26. Renders the content unchanged on older versions.
+struct FloatingControlGroup<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer { content }
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
+    }
+}
+
+extension View {
+    /// Chrome for a circular floating button: interactive Liquid Glass on
+    /// iOS 26, a material or tinted circle with shadow before.
+    @ViewBuilder
+    func circularGlassBackground(tint: Color? = nil) -> some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            if let tint {
+                glassEffect(.regular.tint(tint).interactive(), in: .circle)
+            } else {
+                glassEffect(.regular.interactive(), in: .circle)
+            }
+        } else {
+            legacyCircularBackground(tint: tint)
+        }
+        #else
+        legacyCircularBackground(tint: tint)
+        #endif
+    }
+
+    /// Lets the tab bar minimize while scrolling down on iOS 26; no-op before.
+    @ViewBuilder
+    func minimizableTabBar() -> some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            tabBarMinimizeBehavior(.onScrollDown)
+        } else {
+            self
+        }
+        #else
+        self
+        #endif
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func legacyCircularBackground(tint: Color?) -> some View {
+        if let tint {
+            background(tint)
+                .clipShape(Circle())
+                .shadow(radius: 4)
+        } else {
+            background(.thinMaterial)
+                .clipShape(Circle())
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Views/LoginView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/LoginView.swift
@@ -29,6 +29,7 @@ struct LoginView: View {
     @Environment(AuthManager.self) private var authManager
     @Environment(AppModeManager.self) private var appModeManager
     @State private var authSession: ASWebAuthenticationSession?
+    @ScaledMetric(relativeTo: .largeTitle) private var brandIconSize = 72.0
 
     var body: some View {
         VStack(spacing: 48) {
@@ -36,7 +37,7 @@ struct LoginView: View {
 
             VStack(spacing: 12) {
                 Image(systemName: "leaf.circle.fill")
-                    .font(.system(size: 72))
+                    .font(.system(size: brandIconSize))
                     .foregroundStyle(MacroColors.calories)
 
                 Text(L10n.appName)

--- a/mobile/iosApp/Bissbilanz/Views/MaintenanceView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/MaintenanceView.swift
@@ -8,6 +8,7 @@ struct MaintenanceView: View {
     @State private var result: MaintenanceResponse?
     @State private var isCalculating = false
     @State private var error: String?
+    @ScaledMetric(relativeTo: .largeTitle) private var heroNumberSize = 48.0
 
     private let weekOptions = [2, 4, 8, 12]
 
@@ -104,7 +105,7 @@ struct MaintenanceView: View {
                     .font(.headline)
 
                 Text("\(Int(result.maintenanceCalories))")
-                    .font(.system(size: 48, weight: .bold))
+                    .font(.system(size: heroNumberSize, weight: .bold))
                     .foregroundStyle(MacroColors.calories)
 
                 Text(L10n.kcalPerDay)

--- a/mobile/iosApp/Bissbilanz/Views/RecipeDetailView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/RecipeDetailView.swift
@@ -27,11 +27,13 @@ struct RecipeDetailView: View {
                     Button {
                         showLogSheet = true
                     } label: {
-                        Image(systemName: "plus.circle.fill")
-                            .font(.system(size: 52))
-                            .foregroundStyle(Color.white, Color.accentColor)
-                            .shadow(radius: 4, y: 2)
+                        Image(systemName: "plus")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.white)
+                            .frame(width: 56, height: 56)
                     }
+                    .circularGlassBackground(tint: Color.accentColor)
                     .padding(20)
                 }
             }

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -2,7 +2,7 @@ name: Bissbilanz
 options:
   bundleIdPrefix: com.bissbilanz
   deploymentTarget:
-    iOS: '17.0'
+    iOS: '18.0'
   xcodeVersion: '16.2'
 
 settings:
@@ -35,8 +35,13 @@ targets:
         NSCameraUsageDescription: 'Bissbilanz needs camera access to scan food barcodes'
         NSHealthShareUsageDescription: 'Bissbilanz reads your weight data to track trends'
         NSHealthUpdateUsageDescription: 'Bissbilanz saves nutrition and weight data to Health'
+    # properties must be declared here: xcodegen regenerates the entitlements
+    # file on every `xcodegen generate` and would otherwise write it empty
     entitlements:
       path: Bissbilanz/Bissbilanz.entitlements
+      properties:
+        com.apple.developer.healthkit: true
+        com.apple.developer.healthkit.access: []
     dependencies:
       - sdk: HealthKit.framework
 


### PR DESCRIPTION
Closes #257

## Audit summary

Reviewed all primary screens (Dashboard, Day Log, Food Search, Favorites, Insights, Weight, Supplements, Recipes, Settings, Login, sheets) against the iOS 26 HIG. The codebase was already in good shape — `NavigationStack` everywhere, semantic toolbar placements (`.confirmationAction`/`.cancellationAction`/`.primaryAction`), `foregroundStyle`, SF Symbols, materials, `ContentUnavailableView` in most empty states. The gaps were the legacy `tabItem` TabView API, custom floating-button chrome that fights Liquid Glass, a handful of fixed font sizes, and inconsistent card corner radii.

## Changes

### Latest SwiftUI equivalents (unconditional)

- **TabView migrated to the `Tab` API** (iOS 18) in `ContentView` — required bumping the deployment target 17.0 → 18.0 (`project.yml`). iOS 18 supports the identical device list as iOS 17, so no device is dropped.
- **Dashboard empty state → `ContentUnavailableView`**, matching the other screens.
- **Dynamic Type for fixed font sizes**: hero/stat numbers (Maintenance 48 pt, Insights streaks 36 pt) and the login brand icon (72 pt) now scale via `@ScaledMetric(relativeTo: .largeTitle)`, preserving the default visual size.
- **Quick Entry sheet** gets `presentationDetents([.medium, .large])` — half-height sheet for the most common quick task.
- **Card corner radius unified to 12** (Dashboard widgets were 10, everything else 12).
- **Recipe detail FAB** restyled to match the Dashboard FAB (56 pt tinted circle instead of a bare 52 pt `plus.circle.fill` glyph).

### Liquid Glass adoption (gated, new `LiquidGlass.swift`)

iOS 26 APIs are double-gated: `#if compiler(>=6.2)` so the project still builds with pre-26 SDKs (Xcode 16 locally and in the CodeQL job), and `if #available(iOS 26.0, *)` with the previous appearance as the runtime fallback.

- Floating buttons (Dashboard FAB stack, Recipe detail FAB) use `glassEffect(.regular.interactive(), in: .circle)` — tinted for the primary action — inside a `GlassEffectContainer` so adjacent shapes blend. Fallback keeps the existing material/tinted circles with shadow.
- `tabBarMinimizeBehavior(.onScrollDown)` lets the tab bar minimize while scrolling.
- No custom backgrounds/tints were applied to bars anywhere, so standard toolbars, tab bar, and sheets pick up Liquid Glass automatically when built with the iOS 26 SDK.

Deliberately *not* glassed: in-content controls (login buttons, cards, day chips) — per HIG, Liquid Glass is for the floating control layer, not the content layer.

### CI

`mobile-ios.yml` now runs on `macos-15` with the latest stable Xcode (26+), so the compiler-gated Liquid Glass paths actually compile in CI. The build destination is `generic/platform=iOS Simulator` (build-only job, no device/runtime coupling), and the Homebrew cache path was fixed for Apple Silicon runners (`/opt/homebrew`). The CodeQL swift job stays on Xcode 16.2 and exercises the fallback paths, so both sides of the gates are compile-verified.

## Verification

- `xcodebuild build` (Xcode 16.4, iOS 18 SDK): **succeeded**
- `xcodebuild test` (iPhone 16, iOS 18.6 sim): **TEST SUCCEEDED**, all cases passing
- Launched in the simulator and visually verified Login + Dashboard (incl. FAB, empty state, widgets) in **light and dark mode** — no regressions on the pre-26 appearance.
- `swiftformat --lint`: clean
- iOS 26 rendering can't be verified on this machine (Xcode 16.4 toolchain); the gated code follows Apple's documented Landmarks/Liquid-Glass adoption patterns and is compile-checked by the Xcode 26 CI job.
