### PR TITLE
fix(ios): improve supplement list items on homescreen

### DIFF
--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -288,21 +288,25 @@ struct DashboardView: View {
                     .foregroundStyle(taken == supplementChecklist.count ? .green : .secondary)
             }
 
-            ForEach(supplementChecklist) { item in
-                Button {
-                    Task { await toggleSupplement(item) }
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: item.taken ? "checkmark.circle.fill" : "circle")
-                            .foregroundStyle(item.taken ? .green : .secondary)
-                        Text(item.supplement.name)
-                            .font(.subheadline)
-                            .foregroundStyle(.primary)
-                            .strikethrough(item.taken)
-                        Spacer()
+            VStack(spacing: 0) {
+                ForEach(supplementChecklist) { item in
+                    Button {
+                        Task { await toggleSupplement(item) }
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: item.taken ? "checkmark.circle.fill" : "circle")
+                                .font(.title3)
+                                .foregroundStyle(item.taken ? .green : .secondary)
+                            Text(item.supplement.name)
+                                .font(.subheadline)
+                                .foregroundStyle(item.taken ? .secondary : .primary)
+                            Spacer()
+                        }
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             }
         }
         .padding(12)


### PR DESCRIPTION
## Summary
- Supplement checklist rows on the dashboard now have a 44pt minimum height and a full-width tap area (`contentShape`), so checking items off is comfortable per Apple HIG tap-target guidance
- Slightly larger check circle (`.title3`) for visibility
- Taken supplements no longer use strikethrough — completion is conveyed by the green check and muted (secondary) text color
- Rows are stacked with zero spacing so the card stays compact despite the taller rows

Fixes #258

## Test plan
- Built for iOS Simulator with Xcode 16.4 — compiles clean (only pre-existing warnings in BarcodeScannerView)
- Manual: dashboard supplement card — tap anywhere on a row toggles it; checked items show green check + muted text, no strikethrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)