### PR TITLE
feat(ios): tapping weight card on homescreen navigates to weight screen

### DIFF
--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -88,7 +88,12 @@ struct DashboardView: View {
                     }
 
                     if preferences.showWeightWidget, let weight = latestWeight {
-                        weightWidget(weight)
+                        NavigationLink {
+                            WeightView()
+                        } label: {
+                            weightWidget(weight)
+                        }
+                        .buttonStyle(.plain)
                     }
 
                     if preferences.showSupplementsWidget, !supplementChecklist.isEmpty {


### PR DESCRIPTION
Closes #259

## Summary
- Wraps the dashboard weight widget in a `NavigationLink` pushing `WeightView()`, so tapping it navigates to the weight tracking screen.
- Uses the same plain-button-styled push pattern as the meal cards on the dashboard and the existing Settings → Weight link, so the animation matches the rest of the app.

## Testing
- `xcodebuild` simulator build succeeds.
- `swiftformat --lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)