### PR TITLE
feat(ios): swipe left/right to switch tabs on foods page

### DIFF
--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -22,7 +22,7 @@ struct FoodSearchView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Picker("", selection: $selectedTab) {
+            Picker("", selection: $selectedTab.animation()) {
                 Text(L10n.search).tag(0)
                 Text(L10n.recent).tag(1)
                 Text(L10n.favorites).tag(2)
@@ -31,16 +31,15 @@ struct FoodSearchView: View {
             .padding(.horizontal)
             .padding(.top, 8)
 
-            switch selectedTab {
-            case 0:
+            TabView(selection: $selectedTab) {
                 searchTab
-            case 1:
+                    .tag(0)
                 recentTab
-            case 2:
+                    .tag(1)
                 favoritesTab
-            default:
-                EmptyView()
+                    .tag(2)
             }
+            .tabViewStyle(.page(indexDisplayMode: .never))
         }
         .navigationTitle(L10n.foods)
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary

Adds horizontal swipe navigation between the Search / Recent / Favorites tabs on the Foods page in the iOS app.

- Replaces the static `switch selectedTab` content with a `TabView` using `.tabViewStyle(.page(indexDisplayMode: .never))`, giving native paged swipe gestures with smooth iOS-standard animation
- The segmented picker and the page selection share the same `selectedTab` state, so the tab bar selection stays in sync in both directions (swipe updates the picker, tapping the picker animates the page via `$selectedTab.animation()`)

Closes #260

## Testing

- Built successfully for iPhone 16 simulator (iOS 18.6, x86_64)
- Verified on the simulator via UI automation: swiping left advances Search → Recent → Favorites, swiping right goes back, the segmented picker selection stays in sync, and tapping a picker segment still switches pages with animation
- `swiftformat` passes on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)