### PR TITLE
feat(ios): swipe left/right to switch tabs on insights screen

### DIFF
--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -19,35 +19,52 @@ struct InsightsView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(spacing: 16) {
-                    if isLoading {
-                        LoadingView()
-                    } else {
-                        dateRangePicker
-                        streaksCard
-                        calorieTrendChart
-                        macroTrendsCard
-                        macroRadarCard
-                        mealBreakdownChart
-                        goalAchievementCard
-                        calendarHeatmapCard
-                        comparisonCard
-                        topFoodsCard
-                    }
+            VStack(spacing: 0) {
+                dateRangePicker
+                    .padding(.horizontal)
+                    .padding(.top, 8)
+
+                TabView(selection: $selectedRange) {
+                    rangePage
+                        .tag(7)
+                    rangePage
+                        .tag(30)
+                    rangePage
+                        .tag(90)
                 }
-                .padding()
+                .tabViewStyle(.page(indexDisplayMode: .never))
             }
             .navigationTitle(L10n.insights)
-            .refreshable { await loadAll() }
             .task { await loadAll() }
         }
+    }
+
+    private var rangePage: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                if isLoading {
+                    LoadingView()
+                } else {
+                    streaksCard
+                    calorieTrendChart
+                    macroTrendsCard
+                    macroRadarCard
+                    mealBreakdownChart
+                    goalAchievementCard
+                    calendarHeatmapCard
+                    comparisonCard
+                    topFoodsCard
+                }
+            }
+            .padding()
+        }
+        .refreshable { await loadAll() }
     }
 
     // MARK: - Date Range Picker
 
     private var dateRangePicker: some View {
-        Picker(L10n.period, selection: $selectedRange) {
+        Picker(L10n.period, selection: $selectedRange.animation()) {
             Text("7d").tag(7)
             Text("30d").tag(30)
             Text("90d").tag(90)


### PR DESCRIPTION
## Summary

Adds horizontal swipe gestures to the iOS Insights screen, following the same pattern as the foods page (#289).

The Insights screen's tab control is the segmented date-range picker (7d / 30d / 90d). The static scroll content is now wrapped in a `TabView(selection: $selectedRange)` with `.tabViewStyle(.page(indexDisplayMode: .never))`, so swiping left/right pages between adjacent ranges with the native interactive paging animation. The segmented picker is bound to `$selectedRange.animation()` so taps animate the page transition and the picker stays in sync with swipes.

- Range picker moved above the paging `TabView` (matching the foods page layout) so it stays fixed while pages swipe underneath
- Each page keeps its own `ScrollView` with pull-to-refresh; the existing `onChange(of: selectedRange)` data reload now also fires on swipe
- Verified with a simulator Debug build (`xcodegen generate` + `xcodebuild`, iPhone 16, x86_64) — build succeeded; swiftformat clean

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)