### PR TITLE
feat(ios): HealthKit sleep integration (read/write, both optional)

### DIFF
--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -187,6 +187,27 @@ final class BissbilanzAPI {
         try await deleteRequest("/api/weight/\(id)")
     }
 
+    // MARK: - Sleep
+
+    func getSleepEntries() async throws -> [SleepEntry] {
+        let response: SleepEntriesResponse = try await get("/api/sleep")
+        return response.entries
+    }
+
+    func createSleepEntry(_ entry: SleepCreate) async throws -> SleepEntry {
+        let response: SleepEntryResponse = try await post("/api/sleep", body: entry)
+        return response.entry
+    }
+
+    func updateSleepEntry(id: String, _ update: SleepUpdate) async throws -> SleepEntry {
+        let response: SleepEntryResponse = try await patch("/api/sleep/\(id)", body: update)
+        return response.entry
+    }
+
+    func deleteSleepEntry(id: String) async throws {
+        try await deleteRequest("/api/sleep/\(id)")
+    }
+
     // MARK: - Supplements
 
     func getSupplements() async throws -> [Supplement] {

--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -42,6 +42,7 @@ struct BissbilanzApp: App {
     @State private var foodRepository: FoodRepository
     @State private var recipeRepository: RecipeRepository
     @State private var weightRepository: WeightRepository
+    @State private var sleepRepository: SleepRepository
     @State private var supplementRepository: SupplementRepository
     @State private var goalsRepository: GoalsRepository
     @State private var preferencesRepository: PreferencesRepository
@@ -95,6 +96,9 @@ struct BissbilanzApp: App {
         _weightRepository = State(wrappedValue: WeightRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
         ))
+        _sleepRepository = State(wrappedValue: SleepRepository(
+            context: context, api: api, appMode: appMode, syncManager: sync
+        ))
         _supplementRepository = State(wrappedValue: SupplementRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
         ))
@@ -128,6 +132,7 @@ struct BissbilanzApp: App {
             .environment(foodRepository)
             .environment(recipeRepository)
             .environment(weightRepository)
+            .environment(sleepRepository)
             .environment(supplementRepository)
             .environment(goalsRepository)
             .environment(preferencesRepository)

--- a/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
+++ b/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
@@ -8,6 +8,7 @@ struct MigrationPlan {
     let recipes: Int
     let entries: Int
     let weights: Int
+    let sleepEntries: Int
     let supplements: Int
     let supplementLogs: Int
     let dayProperties: Int
@@ -15,7 +16,7 @@ struct MigrationPlan {
     let hasPreferences: Bool
 
     var total: Int {
-        foods + recipes + entries + weights + supplements + supplementLogs
+        foods + recipes + entries + weights + sleepEntries + supplements + supplementLogs
             + dayProperties + (hasGoals ? 1 : 0) + (hasPreferences ? 1 : 0)
     }
 }
@@ -26,6 +27,7 @@ enum MigrationStep: String {
     case recipes
     case entries
     case weights
+    case sleep
     case supplements
     case supplementLogs = "supplement_logs"
     case goals
@@ -106,6 +108,7 @@ final class LocalDataMigrator {
             recipes: count(LocalRecipe.self),
             entries: count(LocalEntry.self),
             weights: count(LocalWeightEntry.self),
+            sleepEntries: count(LocalSleepEntry.self),
             supplements: count(LocalSupplement.self),
             supplementLogs: count(LocalSupplementLog.self),
             dayProperties: count(LocalDayProperties.self),
@@ -140,6 +143,7 @@ final class LocalDataMigrator {
             done = try await uploadRecipes(done: done, total: total)
             done = try await uploadEntries(done: done, total: total)
             done = try await uploadWeights(done: done, total: total)
+            done = try await uploadSleep(done: done, total: total)
             done = try await uploadSupplements(done: done, total: total)
             done = try await uploadSupplementLogs(done: done, total: total)
             done = try await uploadGoals(done: done, total: total)
@@ -171,6 +175,7 @@ final class LocalDataMigrator {
         try? context.delete(model: LocalFood.self)
         try? context.delete(model: LocalRecipe.self)
         try? context.delete(model: LocalWeightEntry.self)
+        try? context.delete(model: LocalSleepEntry.self)
         try? context.delete(model: LocalSupplement.self)
         try? context.delete(model: LocalSupplementLog.self)
         try? context.delete(model: LocalGoals.self)
@@ -237,6 +242,14 @@ final class LocalDataMigrator {
                 LocalRemap.replaceWeight(id: row.id, with: patched, in: context)
             }
         }
+        for row in fetchAll(LocalSleepEntry.self) where !LocalStore.isTempId(row.id) {
+            let newId = LocalStore.makeTempId()
+            if let entry = row.toSleepEntry(),
+               let patched = try? JSONPatch.merged(SleepEntry.self, base: entry, patch: ["id": newId])
+            {
+                LocalRemap.replaceSleep(id: row.id, with: patched, in: context)
+            }
+        }
         try? context.save()
         defaults.set(true, forKey: Self.normalizedMarkerKey)
     }
@@ -247,6 +260,7 @@ final class LocalDataMigrator {
             + fetchAll(LocalRecipe.self).count { !LocalStore.isTempId($0.id) }
             + fetchAll(LocalEntry.self).count { !LocalStore.isTempId($0.id) }
             + fetchAll(LocalWeightEntry.self).count { !LocalStore.isTempId($0.id) }
+            + fetchAll(LocalSleepEntry.self).count { !LocalStore.isTempId($0.id) }
             + fetchAll(LocalSupplement.self).count { !LocalStore.isTempId($0.id) }
             + fetchAll(LocalSupplementLog.self).count { !LocalStore.isTempId($0.id) }
     }
@@ -329,6 +343,29 @@ final class LocalDataMigrator {
             LocalRemap.replaceWeight(id: row.id, with: server, in: context)
             done += 1
             progress(done, total, .weights)
+        }
+        return done
+    }
+
+    private func uploadSleep(done startDone: Int, total: Int) async throws -> Int {
+        var done = startDone
+        progress(done, total, .sleep)
+        for row in fetchAll(LocalSleepEntry.self) where LocalStore.isTempId(row.id) {
+            guard let entry = row.toSleepEntry() else {
+                throw MigrationError.unreadableRow("sleep entry from \(row.entryDate)")
+            }
+            let server = try await api.createSleepEntry(SleepCreate(
+                durationMinutes: entry.durationMinutes,
+                quality: entry.quality,
+                entryDate: entry.entryDate,
+                bedtime: entry.bedtime,
+                wakeTime: entry.wakeTime,
+                wakeUps: entry.wakeUps,
+                notes: entry.notes
+            ))
+            LocalRemap.replaceSleep(id: row.id, with: server, in: context)
+            done += 1
+            progress(done, total, .sleep)
         }
         return done
     }

--- a/mobile/iosApp/Bissbilanz/Models/Sleep.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Sleep.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct SleepEntry: Codable, Identifiable {
+    let id: String
+    let userId: String
+    let entryDate: String
+    let durationMinutes: Int
+    let quality: Int
+    let bedtime: String?
+    let wakeTime: String?
+    let wakeUps: Int?
+    let sleepLatencyMinutes: Int?
+    let deepSleepMinutes: Int?
+    let lightSleepMinutes: Int?
+    let remSleepMinutes: Int?
+    let source: String?
+    let notes: String?
+    let loggedAt: String?
+    let createdAt: String?
+    let updatedAt: String?
+}
+
+struct SleepCreate: Codable {
+    let durationMinutes: Int
+    let quality: Int
+    let entryDate: String
+    var bedtime: String?
+    var wakeTime: String?
+    var wakeUps: Int?
+    var notes: String?
+}
+
+struct SleepUpdate: Codable {
+    var durationMinutes: Int?
+    var quality: Int?
+    var entryDate: String?
+    var bedtime: String?
+    var wakeTime: String?
+    var wakeUps: Int?
+    var notes: String?
+}
+
+struct SleepEntriesResponse: Codable {
+    let entries: [SleepEntry]
+}
+
+struct SleepEntryResponse: Codable {
+    let entry: SleepEntry
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalModels.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalModels.swift
@@ -202,6 +202,36 @@ final class LocalWeightEntry {
     }
 }
 
+// MARK: - Sleep
+
+@Model
+final class LocalSleepEntry {
+    @Attribute(.unique) var id: String
+    var entryDate: String
+    var durationMinutes: Int
+    var quality: Int
+    var jsonData: Data
+
+    init(entry: SleepEntry) {
+        id = entry.id
+        entryDate = entry.entryDate
+        durationMinutes = entry.durationMinutes
+        quality = entry.quality
+        jsonData = LocalStoreCoding.encode(entry)
+    }
+
+    func update(from entry: SleepEntry) {
+        entryDate = entry.entryDate
+        durationMinutes = entry.durationMinutes
+        quality = entry.quality
+        jsonData = LocalStoreCoding.encode(entry)
+    }
+
+    func toSleepEntry() -> SleepEntry? {
+        LocalStoreCoding.decode(SleepEntry.self, from: jsonData)
+    }
+}
+
 // MARK: - Supplements
 
 @Model

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalRemap.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalRemap.swift
@@ -44,6 +44,14 @@ enum LocalRemap {
         try? context.save()
     }
 
+    static func replaceSleep(id oldId: String, with entry: SleepEntry, in context: ModelContext) {
+        if let row = sleepRow(id: oldId, in: context), entry.id != oldId {
+            context.delete(row)
+        }
+        upsertSleep(entry, in: context)
+        try? context.save()
+    }
+
     static func replaceSupplement(
         id oldId: String,
         with supplement: Supplement,
@@ -159,6 +167,14 @@ enum LocalRemap {
         }
     }
 
+    static func upsertSleep(_ entry: SleepEntry, in context: ModelContext) {
+        if let row = sleepRow(id: entry.id, in: context) {
+            row.update(from: entry)
+        } else {
+            context.insert(LocalSleepEntry(entry: entry))
+        }
+    }
+
     static func upsertSupplement(_ supplement: Supplement, in context: ModelContext) {
         if let row = supplementRow(id: supplement.id, in: context) {
             row.update(from: supplement)
@@ -189,6 +205,12 @@ enum LocalRemap {
 
     static func weightRow(id: String, in context: ModelContext) -> LocalWeightEntry? {
         var descriptor = FetchDescriptor<LocalWeightEntry>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    static func sleepRow(id: String, in context: ModelContext) -> LocalSleepEntry? {
+        var descriptor = FetchDescriptor<LocalSleepEntry>(predicate: #Predicate { $0.id == id })
         descriptor.fetchLimit = 1
         return (try? context.fetch(descriptor))?.first
     }

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalStore.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalStore.swift
@@ -15,6 +15,7 @@ enum LocalStore {
             LocalFood.self,
             LocalRecipe.self,
             LocalWeightEntry.self,
+            LocalSleepEntry.self,
             LocalSupplement.self,
             LocalSupplementLog.self,
             LocalGoals.self,

--- a/mobile/iosApp/Bissbilanz/Persistence/SleepRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/SleepRepository.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Local-first repository for sleep entries. Reads come from SwiftData
+/// (sorted by entry date, newest first); `refresh()` upserts the server list
+/// by id and drops rows deleted elsewhere. Writes are SwiftData-first with
+/// the upload queued via the sync manager.
+@MainActor
+@Observable
+final class SleepRepository {
+    private let context: ModelContext
+    private let api: BissbilanzAPI
+    private let appMode: AppModeManager
+    private let syncManager: SyncManager
+
+    init(context: ModelContext, api: BissbilanzAPI, appMode: AppModeManager, syncManager: SyncManager) {
+        self.context = context
+        self.api = api
+        self.appMode = appMode
+        self.syncManager = syncManager
+    }
+
+    // MARK: - Reads (local)
+
+    func entries() -> [SleepEntry] {
+        let descriptor = FetchDescriptor<LocalSleepEntry>(sortBy: [
+            SortDescriptor(\.entryDate, order: .reverse),
+        ])
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toSleepEntry() }
+    }
+
+    /// One page of entries, newest first — backs the paginated history list.
+    func entries(offset: Int, limit: Int) -> [SleepEntry] {
+        var descriptor = FetchDescriptor<LocalSleepEntry>(sortBy: [
+            SortDescriptor(\.entryDate, order: .reverse),
+        ])
+        descriptor.fetchOffset = offset
+        descriptor.fetchLimit = limit
+        let rows = (try? context.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toSleepEntry() }
+    }
+
+    func latest() -> SleepEntry? {
+        var descriptor = FetchDescriptor<LocalSleepEntry>(sortBy: [
+            SortDescriptor(\.entryDate, order: .reverse),
+        ])
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first?.toSleepEntry()
+    }
+
+    // MARK: - Refresh (API → store)
+
+    func refresh() async throws {
+        guard !appMode.isLocal else { return }
+        let fetched = try await api.getSleepEntries()
+        let serverIds = Set(fetched.map(\.id))
+        for stale in entries() where !serverIds.contains(stale.id) && !LocalStore.isTempId(stale.id) {
+            deleteRow(id: stale.id)
+        }
+        for entry in fetched {
+            upsert(entry)
+        }
+        save()
+    }
+
+    // MARK: - Writes (local first + queued upload)
+
+    @discardableResult
+    func createEntry(_ create: SleepCreate) async throws -> SleepEntry {
+        let temp = makeEntry(from: create, id: LocalStore.makeTempId())
+        upsert(temp)
+        save()
+        syncManager.enqueue(.createSleep(body: create, localId: temp.id))
+        return temp
+    }
+
+    @discardableResult
+    func updateEntry(id: String, _ update: SleepUpdate) async throws -> SleepEntry {
+        var optimistic: SleepEntry?
+        if let row = fetchRow(id: id), let existing = row.toSleepEntry() {
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let updated = (try? JSONPatch.merged(SleepEntry.self, base: existing, patch: patch)) ?? existing
+            row.update(from: updated)
+            save()
+            optimistic = updated
+        }
+        if LocalStore.isTempId(id) {
+            coalesceQueuedCreate(tempId: id, update: update)
+        } else {
+            syncManager.enqueue(.updateSleep(id: id, body: update))
+        }
+        if let optimistic {
+            return optimistic
+        }
+        throw APIError.notFound
+    }
+
+    func deleteEntry(id: String) async throws {
+        deleteRow(id: id)
+        save()
+        if LocalStore.isTempId(id) {
+            syncManager.removeQueued(table: "sleep", affectedId: id)
+        } else {
+            syncManager.enqueue(.deleteSleep(id: id))
+        }
+    }
+
+    /// Rewrites the still-queued create for a temp-id sleep entry so the
+    /// eventual upload carries the edited values.
+    private func coalesceQueuedCreate(tempId: String, update: SleepUpdate) {
+        for row in syncManager.queuedOperations(table: "sleep", affectedId: tempId) {
+            guard let operation = row.operation(),
+                  case let .createSleep(body, localId) = operation
+            else { continue }
+            let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
+            let merged = (try? JSONPatch.merged(SleepCreate.self, base: body, patch: patch)) ?? body
+            syncManager.replace(row, with: .createSleep(body: merged, localId: localId))
+        }
+    }
+
+    // MARK: - Conversion helpers
+
+    private func makeEntry(from create: SleepCreate, id: String) -> SleepEntry {
+        let now = ISO8601DateFormatter().string(from: Date())
+        return SleepEntry(
+            id: id,
+            userId: "",
+            entryDate: create.entryDate,
+            durationMinutes: create.durationMinutes,
+            quality: create.quality,
+            bedtime: create.bedtime,
+            wakeTime: create.wakeTime,
+            wakeUps: create.wakeUps,
+            sleepLatencyMinutes: nil,
+            deepSleepMinutes: nil,
+            lightSleepMinutes: nil,
+            remSleepMinutes: nil,
+            source: nil,
+            notes: create.notes,
+            loggedAt: now,
+            createdAt: now,
+            updatedAt: nil
+        )
+    }
+
+    // MARK: - Store helpers
+
+    private func fetchRow(id: String) -> LocalSleepEntry? {
+        var descriptor = FetchDescriptor<LocalSleepEntry>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    private func upsert(_ entry: SleepEntry) {
+        if let row = fetchRow(id: entry.id) {
+            row.update(from: entry)
+        } else {
+            context.insert(LocalSleepEntry(entry: entry))
+        }
+    }
+
+    private func deleteRow(id: String) {
+        if let row = fetchRow(id: id) {
+            context.delete(row)
+        }
+    }
+
+    private func save() {
+        try? context.save()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
+++ b/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
@@ -11,6 +11,13 @@ final class HealthKitService {
     /// Opt-in write-back of app-logged weights to Health. Off by default —
     /// users whose scale already syncs to Health would get duplicates.
     static let writeWeightEnabledKey = "healthkit_write_weight_enabled"
+    /// Opt-in import of Apple Health sleep into the app (Watch users). Off by
+    /// default and independent of the weight integration above.
+    static let readSleepEnabledKey = "healthkit_read_sleep_enabled"
+    /// Opt-in write-back of app-logged sleep to Health (manual-entry users).
+    /// Off by default — users whose Watch already records sleep would get
+    /// duplicates.
+    static let writeSleepEnabledKey = "healthkit_write_sleep_enabled"
 
     private let healthStore = HKHealthStore()
     var isAvailable: Bool {
@@ -69,6 +76,35 @@ final class HealthKitService {
         do {
             try await healthStore.requestAuthorization(toShare: writeTypes, read: readTypes)
             isAuthorized = true
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Sleep authorization
+
+    /// Sleep permissions are requested per direction and separately from the
+    /// weight/nutrition types: each toggle is independently optional and only
+    /// the direction the user opted into is ever requested.
+    func requestSleepReadAuthorization() async -> Bool {
+        guard isAvailable, let sleep = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis) else {
+            return false
+        }
+        do {
+            try await healthStore.requestAuthorization(toShare: [], read: [sleep])
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func requestSleepWriteAuthorization() async -> Bool {
+        guard isAvailable, let sleep = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis) else {
+            return false
+        }
+        do {
+            try await healthStore.requestAuthorization(toShare: [sleep], read: [])
             return true
         } catch {
             return false
@@ -147,6 +183,171 @@ final class HealthKitService {
             }
             self.healthStore.execute(query)
         }
+    }
+
+    // MARK: - Sleep
+
+    enum SleepStage {
+        case inBed
+        case asleep
+        case awake
+    }
+
+    struct SleepSample {
+        let start: Date
+        let end: Date
+        let stage: SleepStage
+    }
+
+    /// One aggregated night of sleep, derived from raw Health samples.
+    struct SleepNight {
+        /// The wake day (yyyy-MM-dd) — the app keys sleep entries by the
+        /// morning the night ends on.
+        let entryDate: String
+        let bedtime: Date
+        let wakeTime: Date
+        let asleepMinutes: Int
+        let wakeUps: Int
+    }
+
+    /// Writes one sleep session to Health. Only called for entries with known
+    /// bed and wake times — duration-only entries have no real interval and
+    /// fabricating one would pollute Health.
+    func saveSleep(bedtime: Date, wakeTime: Date) async throws {
+        guard let type = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis),
+              bedtime < wakeTime
+        else { return }
+        let sample = HKCategorySample(
+            type: type,
+            value: HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue,
+            start: bedtime,
+            end: wakeTime
+        )
+        try await healthStore.save(sample)
+    }
+
+    /// All sleep-analysis samples overlapping the window, oldest first.
+    /// Samples written by this app are excluded so write-back can never echo
+    /// our own entries back into the app as imports.
+    func fetchSleepSamples(since startDate: Date) async throws -> [SleepSample] {
+        guard let type = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis) else { return [] }
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: nil)
+        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
+        let ownBundleId = Bundle.main.bundleIdentifier
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: [sortDescriptor]
+            ) { _, samples, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let mapped = (samples ?? [])
+                    .compactMap { $0 as? HKCategorySample }
+                    .filter { $0.sourceRevision.source.bundleIdentifier != ownBundleId }
+                    .compactMap { sample -> SleepSample? in
+                        guard let stage = Self.stage(for: sample.value) else { return nil }
+                        return SleepSample(start: sample.startDate, end: sample.endDate, stage: stage)
+                    }
+                continuation.resume(returning: mapped)
+            }
+            self.healthStore.execute(query)
+        }
+    }
+
+    private nonisolated static func stage(for rawValue: Int) -> SleepStage? {
+        guard let value = HKCategoryValueSleepAnalysis(rawValue: rawValue) else { return nil }
+        switch value {
+        case .inBed:
+            return .inBed
+        case .awake:
+            return .awake
+        case .asleepUnspecified, .asleepCore, .asleepDeep, .asleepREM:
+            return .asleep
+        @unknown default:
+            return nil
+        }
+    }
+
+    /// Sleep sessions are split where samples are more than this far apart —
+    /// far larger than the gaps inside a recorded night, far smaller than the
+    /// distance between a night and an afternoon nap.
+    nonisolated static let sessionGapSeconds: TimeInterval = 2 * 60 * 60
+
+    /// Sessions shorter than this are ignored — micro-naps aren't a night.
+    nonisolated static let minimumNightMinutes = 30
+
+    /// Groups raw samples into per-night aggregates: samples closer than
+    /// `sessionGapSeconds` form a session; each session is keyed by the day it
+    /// ends on (the wake day) and the longest session per day wins (the main
+    /// night beats naps). Overlapping samples (iPhone + Watch both recording)
+    /// are unioned so duration is never double-counted; stage samples count as
+    /// asleep while in-bed-only recordings fall back to the in-bed time.
+    nonisolated static func nights(from samples: [SleepSample]) -> [SleepNight] {
+        let sorted = samples.sorted { $0.start < $1.start }
+        var sessions: [[SleepSample]] = []
+        for sample in sorted {
+            if var current = sessions.last,
+               let sessionEnd = current.map(\.end).max(),
+               sample.start.timeIntervalSince(sessionEnd) <= sessionGapSeconds
+            {
+                current.append(sample)
+                sessions[sessions.count - 1] = current
+            } else {
+                sessions.append([sample])
+            }
+        }
+
+        var bestPerDay: [String: SleepNight] = [:]
+        for session in sessions {
+            guard let bedtime = session.map(\.start).min(),
+                  let wakeTime = session.map(\.end).max()
+            else { continue }
+
+            let asleep = mergedIntervals(session.filter { $0.stage == .asleep })
+            let inBed = mergedIntervals(session.filter { $0.stage == .inBed })
+            let awake = mergedIntervals(session.filter { $0.stage == .awake })
+            let asleepMinutes = asleep.isEmpty ? totalMinutes(of: inBed) : totalMinutes(of: asleep)
+            guard asleepMinutes >= minimumNightMinutes else { continue }
+
+            let night = SleepNight(
+                entryDate: DateFormatting.isoString(from: wakeTime),
+                bedtime: bedtime,
+                wakeTime: wakeTime,
+                asleepMinutes: min(asleepMinutes, 1440),
+                wakeUps: awake.count
+            )
+            if let existing = bestPerDay[night.entryDate], existing.asleepMinutes >= night.asleepMinutes {
+                continue
+            }
+            bestPerDay[night.entryDate] = night
+        }
+        return bestPerDay.values.sorted { $0.wakeTime < $1.wakeTime }
+    }
+
+    /// Overlapping or touching intervals merged into disjoint ones.
+    private nonisolated static func mergedIntervals(_ samples: [SleepSample]) -> [(start: Date, end: Date)] {
+        let sorted = samples.sorted { $0.start < $1.start }
+        var merged: [(start: Date, end: Date)] = []
+        for sample in sorted {
+            if let last = merged.last, sample.start <= last.end {
+                if sample.end > last.end {
+                    merged[merged.count - 1].end = sample.end
+                }
+            } else {
+                merged.append((sample.start, sample.end))
+            }
+        }
+        return merged
+    }
+
+    private nonisolated static func totalMinutes(of intervals: [(start: Date, end: Date)]) -> Int {
+        let seconds = intervals.reduce(0.0) { $0 + $1.end.timeIntervalSince($1.start) }
+        return Int((seconds / 60).rounded())
     }
 
     func fetchLatestWeight() async throws -> Double? {

--- a/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
@@ -283,6 +283,21 @@ final class SyncManager {
         case let .deleteWeight(id):
             try await api.deleteWeightEntry(id: id)
 
+        case let .createSleep(body, localId):
+            let server = try await api.createSleepEntry(body)
+            guard LocalRemap.sleepRow(id: localId, in: context) != nil else {
+                enqueue(.deleteSleep(id: server.id))
+                return
+            }
+            LocalRemap.replaceSleep(id: localId, with: server, in: context)
+            remapQueuedReferences(from: localId, to: server.id)
+
+        case let .updateSleep(id, body):
+            _ = try await api.updateSleepEntry(id: id, body)
+
+        case let .deleteSleep(id):
+            try await api.deleteSleepEntry(id: id)
+
         case let .createSupplement(body, localId):
             let server = try await api.createSupplement(body)
             guard LocalRemap.supplementRow(id: localId, in: context) != nil else {

--- a/mobile/iosApp/Bissbilanz/Sync/SyncOperation.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/SyncOperation.swift
@@ -19,6 +19,9 @@ enum SyncOperation: Codable {
     case createWeight(body: WeightCreate, localId: String)
     case updateWeight(id: String, body: WeightUpdate)
     case deleteWeight(id: String)
+    case createSleep(body: SleepCreate, localId: String)
+    case updateSleep(id: String, body: SleepUpdate)
+    case deleteSleep(id: String)
     case createSupplement(body: SupplementCreate, localId: String)
     case updateSupplement(id: String, body: SupplementUpdate)
     case deleteSupplement(id: String)
@@ -45,6 +48,9 @@ enum SyncOperation: Codable {
         case .createWeight: "create_weight"
         case .updateWeight: "update_weight"
         case .deleteWeight: "delete_weight"
+        case .createSleep: "create_sleep"
+        case .updateSleep: "update_sleep"
+        case .deleteSleep: "delete_sleep"
         case .createSupplement: "create_supplement"
         case .updateSupplement: "update_supplement"
         case .deleteSupplement: "delete_supplement"
@@ -63,6 +69,7 @@ enum SyncOperation: Codable {
         case .createRecipe, .updateRecipe, .deleteRecipe: "recipes"
         case .setGoals: "goals"
         case .createWeight, .updateWeight, .deleteWeight: "weight"
+        case .createSleep, .updateSleep, .deleteSleep: "sleep"
         case .createSupplement, .updateSupplement, .deleteSupplement,
              .logSupplement, .unlogSupplement: "supplements"
         case .setDayProperties, .deleteDayProperties: "day_properties"
@@ -74,12 +81,13 @@ enum SyncOperation: Codable {
         switch self {
         case let .createFood(_, localId), let .createEntry(_, localId),
              let .createRecipe(_, localId), let .createWeight(_, localId),
-             let .createSupplement(_, localId):
+             let .createSleep(_, localId), let .createSupplement(_, localId):
             localId
         case let .updateFood(id, _), let .deleteFood(id), let .toggleFavorite(id, _),
              let .updateEntry(id, _), let .deleteEntry(id),
              let .updateRecipe(id, _), let .deleteRecipe(id),
              let .updateWeight(id, _), let .deleteWeight(id),
+             let .updateSleep(id, _), let .deleteSleep(id),
              let .updateSupplement(id, _), let .deleteSupplement(id):
             id
         case let .logSupplement(supplementId, _), let .unlogSupplement(supplementId, _):
@@ -151,6 +159,12 @@ enum SyncOperation: Codable {
 
         case let .deleteWeight(id) where id == oldId:
             return .deleteWeight(id: newId)
+
+        case let .updateSleep(id, body) where id == oldId:
+            return .updateSleep(id: newId, body: body)
+
+        case let .deleteSleep(id) where id == oldId:
+            return .deleteSleep(id: newId)
 
         case let .createSupplement(body, localId):
             guard let ingredients = Self.remapSupplementIngredients(body.ingredients, from: oldId, to: newId)
@@ -234,6 +248,9 @@ enum SyncOperation: Codable {
         case .createWeight: "create weight entry"
         case let .updateWeight(id, _): "update weight entry \(id)"
         case let .deleteWeight(id): "delete weight entry \(id)"
+        case .createSleep: "create sleep entry"
+        case let .updateSleep(id, _): "update sleep entry \(id)"
+        case let .deleteSleep(id): "delete sleep entry \(id)"
         case .createSupplement: "create supplement"
         case let .updateSupplement(id, _): "update supplement \(id)"
         case let .deleteSupplement(id): "delete supplement \(id)"

--- a/mobile/iosApp/Bissbilanz/Utilities/DateFormatting.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/DateFormatting.swift
@@ -20,8 +20,47 @@ enum DateFormatting {
         return f
     }()
 
+    private static let isoDateTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    private static let isoDateTimeFractionalFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f
+    }()
+
     static func isoString(from date: Date) -> String {
         isoFormatter.string(from: date)
+    }
+
+    /// UTC ISO-8601 timestamp ("2026-06-12T05:30:00Z") — the wire format for
+    /// `bedtime`/`wakeTime`.
+    static func isoDateTimeString(from date: Date) -> String {
+        isoDateTimeFormatter.string(from: date)
+    }
+
+    /// Parses ISO-8601 timestamps with or without fractional seconds (the
+    /// server serializes with milliseconds, the app writes without).
+    static func isoDateTime(from string: String) -> Date? {
+        isoDateTimeFractionalFormatter.date(from: string) ?? isoDateTimeFormatter.date(from: string)
+    }
+
+    static func timeString(from date: Date) -> String {
+        timeFormatter.string(from: date)
     }
 
     static func date(from isoString: String) -> Date? {

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -697,6 +697,30 @@ enum L10n {
         )
     }
 
+    static var healthReadSleep: String {
+        localized(
+            "health_read_sleep",
+            en: "Read sleep from Apple Health",
+            de: "Schlaf aus Apple Health lesen"
+        )
+    }
+
+    static var healthWriteSleep: String {
+        localized(
+            "health_write_sleep",
+            en: "Write sleep to Apple Health",
+            de: "Schlaf in Apple Health schreiben"
+        )
+    }
+
+    static var healthSleepFooter: String {
+        localized(
+            "health_sleep_footer",
+            en: "Reading imports nights recorded in Apple Health (e.g. by Apple Watch) into your sleep log with a neutral quality rating you can edit. Writing saves sleep you log here with bed and wake times to Apple Health — leave it off if your Watch already records sleep.",
+            de: "Beim Lesen werden in Apple Health aufgezeichnete Nächte (z. B. von der Apple Watch) mit einer neutralen, editierbaren Qualitätsbewertung in dein Schlafprotokoll importiert. Beim Schreiben wird hier erfasster Schlaf mit Schlafens- und Aufwachzeit in Apple Health gespeichert — lass es aus, wenn deine Watch bereits Schlaf aufzeichnet."
+        )
+    }
+
     // MARK: - Scanner
 
     static var scanBarcode: String {
@@ -895,6 +919,8 @@ enum L10n {
             localized("migration_step_entries", en: "Uploading entries", de: "Einträge hochladen")
         case .weights:
             localized("migration_step_weights", en: "Uploading weight entries", de: "Gewichtseinträge hochladen")
+        case .sleep:
+            localized("migration_step_sleep", en: "Uploading sleep entries", de: "Schlafeinträge hochladen")
         case .supplements:
             localized("migration_step_supplements", en: "Uploading supplements", de: "Supplements hochladen")
         case .supplementLogs:
@@ -994,6 +1020,64 @@ enum L10n {
 
     static var notes: String {
         localized("notes", en: "Notes", de: "Notizen")
+    }
+
+    // MARK: - Sleep
+
+    static var sleep: String {
+        localized("sleep", en: "Sleep", de: "Schlaf")
+    }
+
+    static var logSleep: String {
+        localized("log_sleep", en: "Log Sleep", de: "Schlaf erfassen")
+    }
+
+    static var sleepDuration: String {
+        localized("sleep_duration", en: "Duration", de: "Dauer")
+    }
+
+    static var sleepQuality: String {
+        localized("sleep_quality", en: "Quality", de: "Qualität")
+    }
+
+    static var sleepQualityPoor: String {
+        localized("sleep_quality_poor", en: "Poor", de: "Schlecht")
+    }
+
+    static var sleepQualityGreat: String {
+        localized("sleep_quality_great", en: "Great", de: "Gut")
+    }
+
+    static var bedtime: String {
+        localized("sleep_bedtime", en: "Bedtime", de: "Schlafenszeit")
+    }
+
+    static var wakeTime: String {
+        localized("sleep_wake_time", en: "Wake time", de: "Aufwachzeit")
+    }
+
+    static var wakeUps: String {
+        localized("sleep_wake_ups", en: "Wake-ups", de: "Aufwachphasen")
+    }
+
+    static var bedAndWakeTimes: String {
+        localized("bed_and_wake_times", en: "Bed & wake times", de: "Schlafens- & Aufwachzeit")
+    }
+
+    static var lastNight: String {
+        localized("last_night", en: "Last night", de: "Letzte Nacht")
+    }
+
+    static var sevenDayAverage: String {
+        localized("seven_day_average", en: "7d average", de: "7T-Schnitt")
+    }
+
+    static var hours: String {
+        localized("hours", en: "Hours", de: "Stunden")
+    }
+
+    static var minutes: String {
+        localized("minutes", en: "Minutes", de: "Minuten")
     }
 
     // MARK: - Insights (additional)

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -25,6 +25,10 @@ struct SettingsView: View {
     @State private var healthSyncEnabled: Bool = UserDefaults.standard.bool(forKey: HealthKitService.syncEnabledKey)
     @State private var healthWriteWeightEnabled: Bool = UserDefaults.standard
         .bool(forKey: HealthKitService.writeWeightEnabledKey)
+    @State private var healthReadSleepEnabled: Bool = UserDefaults.standard
+        .bool(forKey: HealthKitService.readSleepEnabledKey)
+    @State private var healthWriteSleepEnabled: Bool = UserDefaults.standard
+        .bool(forKey: HealthKitService.writeSleepEnabledKey)
     @AppStorage("selected_tabs") private var selectedTabsRaw: String = "foods,favorites,insights"
 
     private var selectedTabNames: String {
@@ -82,6 +86,9 @@ struct SettingsView: View {
                     NavigationLink { WeightView() } label: {
                         Label(L10n.weight, systemImage: "scalemass")
                     }
+                    NavigationLink { SleepView() } label: {
+                        Label(L10n.sleep, systemImage: "bed.double")
+                    }
                     NavigationLink { SupplementsView() } label: {
                         Label(L10n.supplements, systemImage: "pills")
                     }
@@ -122,6 +129,27 @@ struct SettingsView: View {
                                     }
                                 }
                         }
+                        // Sleep read/write are independently optional — each
+                        // direction only requests its own permission when the
+                        // user opts in.
+                        Toggle(L10n.healthReadSleep, isOn: $healthReadSleepEnabled)
+                            .onChange(of: healthReadSleepEnabled) { _, enabled in
+                                UserDefaults.standard.set(enabled, forKey: HealthKitService.readSleepEnabledKey)
+                                if enabled {
+                                    Task {
+                                        _ = await healthKitService.requestSleepReadAuthorization()
+                                    }
+                                }
+                            }
+                        Toggle(L10n.healthWriteSleep, isOn: $healthWriteSleepEnabled)
+                            .onChange(of: healthWriteSleepEnabled) { _, enabled in
+                                UserDefaults.standard.set(enabled, forKey: HealthKitService.writeSleepEnabledKey)
+                                if enabled {
+                                    Task {
+                                        _ = await healthKitService.requestSleepWriteAuthorization()
+                                    }
+                                }
+                            }
                         if healthKitService.isAuthorized {
                             HStack {
                                 Image(systemName: "checkmark.circle.fill")
@@ -140,8 +168,15 @@ struct SettingsView: View {
                     } header: {
                         Text(L10n.healthKit)
                     } footer: {
-                        if healthSyncEnabled {
-                            Text(L10n.healthSyncFooter)
+                        if healthSyncEnabled || healthReadSleepEnabled || healthWriteSleepEnabled {
+                            VStack(alignment: .leading, spacing: 8) {
+                                if healthSyncEnabled {
+                                    Text(L10n.healthSyncFooter)
+                                }
+                                if healthReadSleepEnabled || healthWriteSleepEnabled {
+                                    Text(L10n.healthSleepFooter)
+                                }
+                            }
                         }
                     }
                 }

--- a/mobile/iosApp/Bissbilanz/Views/SleepView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SleepView.swift
@@ -1,0 +1,694 @@
+import Charts
+import SwiftUI
+
+/// Sleep duration in "7h 30m" form — shared by the cards, rows and chart.
+func formatSleepDuration(_ minutes: Int) -> String {
+    let hours = minutes / 60
+    let remainder = minutes % 60
+    return remainder == 0 ? "\(hours)h" : "\(hours)h \(remainder)m"
+}
+
+struct SleepView: View {
+    @Environment(SleepRepository.self) private var sleepRepository
+
+    @State private var entries: [SleepEntry] = []
+    @State private var isLoading = true
+    @State private var showAddSheet = false
+    @State private var editingEntry: SleepEntry?
+    @State private var selectedRange = 30
+    @State private var errorMessage: String?
+
+    /// Imported Health nights carry no subjective rating — they get the
+    /// neutral middle of the 1–10 scale, editable afterwards.
+    static let importedQuality = 5
+
+    private enum RangeOption: Int, CaseIterable, Identifiable {
+        case week = 7
+        case month = 30
+        case quarter = 90
+        case all = 0
+
+        var id: Int {
+            rawValue
+        }
+
+        var label: String {
+            switch self {
+            case .week: "7d"
+            case .month: "30d"
+            case .quarter: "90d"
+            case .all: L10n.history
+            }
+        }
+    }
+
+    private var chartEntries: [SleepEntry] {
+        let sorted = entries.sorted { entryA, entryB in
+            guard let dateA = DateFormatting.date(from: entryA.entryDate),
+                  let dateB = DateFormatting.date(from: entryB.entryDate)
+            else { return false }
+            return dateA < dateB
+        }
+        guard selectedRange > 0 else { return sorted }
+        let cutoff = Date().adding(days: -selectedRange)
+        return sorted.filter { entry in
+            guard let date = DateFormatting.date(from: entry.entryDate) else { return false }
+            return date >= cutoff
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    LoadingView()
+                } else if entries.isEmpty {
+                    ContentUnavailableView(
+                        L10n.sleep,
+                        systemImage: "bed.double",
+                        description: Text(L10n.noEntriesYet)
+                    )
+                } else {
+                    List {
+                        statsSection
+                        if chartEntries.count >= 2 { chartSection }
+                        historySection
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle(L10n.sleep)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showAddSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAddSheet) {
+                AddSleepSheet {
+                    Task { await loadEntries() }
+                }
+            }
+            .sheet(item: $editingEntry) { entry in
+                AddSleepSheet(existingEntry: entry) {
+                    Task { await loadEntries() }
+                }
+            }
+            .refreshable { await loadEntries() }
+            .task { await loadEntries(showSpinner: true) }
+            // Cheap local re-read when popping back from the history subpage,
+            // where entries can be edited or deleted.
+            .onAppear { entries = sleepRepository.entries() }
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
+                Button(L10n.ok, role: .cancel) {}
+            } message: {
+                if let errorMessage { Text(errorMessage) }
+            }
+        }
+    }
+
+    // MARK: - Summary Cards
+
+    /// Entries from the last 7 calendar days, backing the average card.
+    private var recentEntries: [SleepEntry] {
+        let cutoff = Date().adding(days: -7)
+        return entries.filter { entry in
+            guard let date = DateFormatting.date(from: entry.entryDate) else { return false }
+            return date >= cutoff
+        }
+    }
+
+    private var statsSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                lastNightCard
+                averageCard
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
+        }
+    }
+
+    private var lastNightCard: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.lastNight)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(formatSleepDuration(entries.first?.durationMinutes ?? 0))
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundStyle(.indigo)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            Text(latestDateText)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.indigo.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var latestDateText: String {
+        guard let latest = entries.first else { return "" }
+        if let date = DateFormatting.date(from: latest.entryDate) {
+            return DateFormatting.displayString(from: date)
+        }
+        return latest.entryDate
+    }
+
+    private var averageCard: some View {
+        let recent = recentEntries
+        let avgMinutes = recent.isEmpty
+            ? 0
+            : recent.map(\.durationMinutes).reduce(0, +) / recent.count
+        let avgQuality = recent.isEmpty
+            ? 0
+            : Double(recent.map(\.quality).reduce(0, +)) / Double(recent.count)
+        return VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.sevenDayAverage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(recent.isEmpty ? "—" : formatSleepDuration(avgMinutes))
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundStyle(.purple)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            Text(recent.isEmpty ? "" : "\(L10n.sleepQuality) \(String(format: "%.1f", avgQuality))/10")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.purple.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Chart Section
+
+    private var chartSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(L10n.trend)
+                    .font(.headline)
+
+                Picker("Range", selection: $selectedRange) {
+                    ForEach(RangeOption.allCases) { option in
+                        Text(option.label).tag(option.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Chart {
+                    ForEach(chartEntries) { entry in
+                        if let date = DateFormatting.date(from: entry.entryDate) {
+                            BarMark(
+                                x: .value("Date", date, unit: .day),
+                                y: .value(L10n.sleepDuration, Double(entry.durationMinutes) / 60)
+                            )
+                            .foregroundStyle(.indigo)
+                            .cornerRadius(2)
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        AxisValueLabel {
+                            if let hours = value.as(Double.self) {
+                                Text("\(hours, specifier: "%.0f")h")
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine()
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+                        AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        AxisGridLine()
+                    }
+                }
+                .frame(height: 200)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - History Section
+
+    private static let historyPreviewCount = 5
+
+    private var historySection: some View {
+        Section(L10n.history) {
+            ForEach(entries.prefix(Self.historyPreviewCount)) { entry in
+                SleepEntryRow(entry: entry) {
+                    editingEntry = entry
+                } onDelete: {
+                    Task { await deleteEntry(entry) }
+                }
+            }
+            if entries.count > Self.historyPreviewCount {
+                NavigationLink {
+                    SleepHistoryView()
+                } label: {
+                    HStack {
+                        Text(L10n.showAll)
+                        Spacer()
+                        Text("\(entries.count)")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Data Loading
+
+    /// showSpinner only on first load: flipping isLoading during pull-to-refresh
+    /// swaps the List out for LoadingView, which kills the refresh gesture and
+    /// leaves the spinner stuck.
+    private func loadEntries(showSpinner: Bool = false) async {
+        entries = sleepRepository.entries()
+        if showSpinner { isLoading = entries.isEmpty }
+
+        try? await sleepRepository.refresh()
+        entries = sleepRepository.entries()
+
+        isLoading = false
+
+        if UserDefaults.standard.bool(forKey: HealthKitService.readSleepEnabledKey) {
+            await importFromHealthKit()
+        }
+    }
+
+    /// Import nights from Apple Health that the app doesn't have yet
+    /// (read-only — never writes back to Health from here).
+    private func importFromHealthKit() async {
+        let healthKit = HealthKitService.shared
+        guard healthKit.isAvailable else { return }
+        let since = Date().adding(days: -90)
+        guard let samples = try? await healthKit.fetchSleepSamples(since: since), !samples.isEmpty else { return }
+
+        let existingDates = Set(entries.map(\.entryDate))
+        var imported = false
+        for night in HealthKitService.nights(from: samples) where !existingDates.contains(night.entryDate) {
+            let create = SleepCreate(
+                durationMinutes: night.asleepMinutes,
+                quality: Self.importedQuality,
+                entryDate: night.entryDate,
+                bedtime: DateFormatting.isoDateTimeString(from: night.bedtime),
+                wakeTime: DateFormatting.isoDateTimeString(from: night.wakeTime),
+                wakeUps: night.wakeUps,
+                notes: nil
+            )
+            if await (try? sleepRepository.createEntry(create)) != nil {
+                imported = true
+            }
+        }
+
+        if imported {
+            entries = sleepRepository.entries()
+        }
+    }
+
+    private func deleteEntry(_ entry: SleepEntry) async {
+        do {
+            try await sleepRepository.deleteEntry(id: entry.id)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        entries = sleepRepository.entries()
+    }
+}
+
+// MARK: - Entry Row
+
+/// One history row — shared by the preview list on the sleep page and the
+/// full history subpage.
+struct SleepEntryRow: View {
+    let entry: SleepEntry
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        Button(action: onEdit) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    if let date = DateFormatting.date(from: entry.entryDate) {
+                        Text(DateFormatting.displayString(from: date))
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                    } else {
+                        Text(entry.entryDate)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                    }
+                    if let notes = entry.notes, !notes.isEmpty {
+                        Text(notes)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(formatSleepDuration(entry.durationMinutes))
+                        .foregroundStyle(.secondary)
+                    Text("\(entry.quality)/10")
+                        .font(.caption)
+                        .foregroundStyle(.purple)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive, action: onDelete) {
+                Label(L10n.delete, systemImage: "trash")
+            }
+        }
+    }
+}
+
+// MARK: - Full History
+
+/// All sleep entries, loaded page-wise from the local store as the list
+/// scrolls — List rows are lazy, so reaching the last loaded row triggers
+/// the next page fetch.
+struct SleepHistoryView: View {
+    @Environment(SleepRepository.self) private var sleepRepository
+
+    @State private var entries: [SleepEntry] = []
+    @State private var hasMore = true
+    @State private var editingEntry: SleepEntry?
+    @State private var errorMessage: String?
+
+    private static let pageSize = 50
+
+    var body: some View {
+        List {
+            ForEach(entries) { entry in
+                SleepEntryRow(entry: entry) {
+                    editingEntry = entry
+                } onDelete: {
+                    Task { await deleteEntry(entry) }
+                }
+                .onAppear {
+                    if entry.id == entries.last?.id {
+                        loadNextPage()
+                    }
+                }
+            }
+        }
+        .navigationTitle(L10n.history)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            if entries.isEmpty { loadNextPage() }
+        }
+        .sheet(item: $editingEntry) { entry in
+            AddSleepSheet(existingEntry: entry) {
+                reloadLoadedWindow()
+            }
+        }
+        .alert(
+            L10n.error,
+            isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+        ) {
+            Button(L10n.ok, role: .cancel) {}
+        } message: {
+            if let errorMessage { Text(errorMessage) }
+        }
+    }
+
+    private func loadNextPage() {
+        guard hasMore else { return }
+        let page = sleepRepository.entries(offset: entries.count, limit: Self.pageSize)
+        entries += page
+        hasMore = page.count == Self.pageSize
+    }
+
+    /// Re-reads everything loaded so far in one fetch — an edit can change an
+    /// entry's date and therefore its position in the ordering.
+    private func reloadLoadedWindow() {
+        let limit = max(entries.count, Self.pageSize)
+        entries = sleepRepository.entries(offset: 0, limit: limit)
+        hasMore = entries.count == limit
+    }
+
+    private func deleteEntry(_ entry: SleepEntry) async {
+        do {
+            try await sleepRepository.deleteEntry(id: entry.id)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            entries.removeAll { $0.id == entry.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Add / Edit Sleep Sheet
+
+struct AddSleepSheet: View {
+    @Environment(SleepRepository.self) private var sleepRepository
+    @Environment(\.dismiss) private var dismiss
+
+    let existingEntry: SleepEntry?
+    let onSaved: () -> Void
+
+    @State private var hoursText = "7"
+    @State private var minutesText = "30"
+    @State private var quality = 7.0
+    @State private var date = Date()
+    @State private var timesEnabled = false
+    @State private var bedtimeTime = Calendar.current.date(
+        bySettingHour: 23, minute: 0, second: 0, of: Date()
+    ) ?? Date()
+    @State private var wakeTimeTime = Calendar.current.date(
+        bySettingHour: 7, minute: 0, second: 0, of: Date()
+    ) ?? Date()
+    @State private var wakeUpsText = ""
+    @State private var notes = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(existingEntry: SleepEntry? = nil, onSaved: @escaping () -> Void) {
+        self.existingEntry = existingEntry
+        self.onSaved = onSaved
+    }
+
+    private var durationMinutes: Int {
+        (Int(hoursText) ?? 0) * 60 + (Int(minutesText) ?? 0)
+    }
+
+    private var isValid: Bool {
+        durationMinutes > 0 && durationMinutes <= 1440
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(L10n.sleepDuration) {
+                    HStack {
+                        TextField("7", text: $hoursText)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                        Text(L10n.hours)
+                            .foregroundStyle(.secondary)
+                        TextField("30", text: $minutesText)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                        Text(L10n.minutes)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section {
+                    HStack {
+                        Text(L10n.sleepQuality)
+                        Spacer()
+                        Text("\(Int(quality))/10")
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.purple)
+                    }
+                    HStack(spacing: 8) {
+                        Text(L10n.sleepQualityPoor)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Slider(value: $quality, in: 1 ... 10, step: 1)
+                        Text(L10n.sleepQualityGreat)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section {
+                    DatePicker(L10n.today, selection: $date, displayedComponents: .date)
+                }
+
+                Section {
+                    Toggle(L10n.bedAndWakeTimes, isOn: $timesEnabled)
+                    if timesEnabled {
+                        DatePicker(L10n.bedtime, selection: $bedtimeTime, displayedComponents: .hourAndMinute)
+                        DatePicker(L10n.wakeTime, selection: $wakeTimeTime, displayedComponents: .hourAndMinute)
+                    }
+                }
+
+                Section {
+                    HStack {
+                        Text(L10n.wakeUps)
+                        Spacer()
+                        TextField("0", text: $wakeUpsText)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 80)
+                    }
+                    TextField(L10n.notes, text: $notes)
+                }
+            }
+            .navigationTitle(existingEntry != nil ? L10n.edit : L10n.logSleep)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.cancel) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.save) {
+                        Task { await save() }
+                    }
+                    .disabled(!isValid || isSaving)
+                    .fontWeight(.semibold)
+                }
+            }
+            .onAppear { prefill() }
+            .onChange(of: timesEnabled) { _, enabled in
+                if enabled { syncDurationFromTimes() }
+            }
+            .onChange(of: bedtimeTime) { _, _ in
+                if timesEnabled { syncDurationFromTimes() }
+            }
+            .onChange(of: wakeTimeTime) { _, _ in
+                if timesEnabled { syncDurationFromTimes() }
+            }
+            .alert(
+                L10n.error,
+                isPresented: .init(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+            ) {
+                Button(L10n.ok, role: .cancel) {}
+            } message: {
+                if let errorMessage { Text(errorMessage) }
+            }
+        }
+    }
+
+    // MARK: - Time helpers
+
+    /// Absolute bed/wake timestamps anchored on the entry date (the wake day);
+    /// a bedtime at or after the wake time-of-day belongs to the prior evening.
+    private func resolvedTimes() -> (bedtime: Date, wakeTime: Date)? {
+        guard timesEnabled else { return nil }
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: date)
+        let bedComponents = calendar.dateComponents([.hour, .minute], from: bedtimeTime)
+        let wakeComponents = calendar.dateComponents([.hour, .minute], from: wakeTimeTime)
+        guard let wake = calendar.date(byAdding: wakeComponents, to: dayStart),
+              var bed = calendar.date(byAdding: bedComponents, to: dayStart)
+        else { return nil }
+        if bed >= wake {
+            bed = bed.adding(days: -1)
+        }
+        return (bed, wake)
+    }
+
+    private func syncDurationFromTimes() {
+        guard let (bed, wake) = resolvedTimes() else { return }
+        let minutes = Int(wake.timeIntervalSince(bed) / 60)
+        hoursText = "\(minutes / 60)"
+        minutesText = "\(minutes % 60)"
+    }
+
+    // MARK: - Health write-back
+
+    /// Best effort, create-only and gated on the independent write toggle —
+    /// duration-only entries are skipped because Health needs a real interval.
+    private func writeToHealthIfEnabled(bedtime: Date?, wakeTime: Date?) async {
+        guard UserDefaults.standard.bool(forKey: HealthKitService.writeSleepEnabledKey),
+              HealthKitService.shared.isAvailable,
+              let bedtime, let wakeTime
+        else { return }
+        try? await HealthKitService.shared.saveSleep(bedtime: bedtime, wakeTime: wakeTime)
+    }
+
+    // MARK: - Prefill / Save
+
+    private func prefill() {
+        guard let entry = existingEntry else { return }
+        hoursText = "\(entry.durationMinutes / 60)"
+        minutesText = "\(entry.durationMinutes % 60)"
+        quality = Double(entry.quality)
+        if let d = DateFormatting.date(from: entry.entryDate) {
+            date = d
+        }
+        if let bedtimeString = entry.bedtime, let bed = DateFormatting.isoDateTime(from: bedtimeString),
+           let wakeString = entry.wakeTime, let wake = DateFormatting.isoDateTime(from: wakeString)
+        {
+            timesEnabled = true
+            bedtimeTime = bed
+            wakeTimeTime = wake
+        }
+        if let wakeUps = entry.wakeUps {
+            wakeUpsText = "\(wakeUps)"
+        }
+        notes = entry.notes ?? ""
+    }
+
+    private func save() async {
+        guard isValid else { return }
+        isSaving = true
+        let dateStr = DateFormatting.isoString(from: date)
+        let times = resolvedTimes()
+        let bedtimeIso = times.map { DateFormatting.isoDateTimeString(from: $0.bedtime) }
+        let wakeTimeIso = times.map { DateFormatting.isoDateTimeString(from: $0.wakeTime) }
+        let wakeUps = wakeUpsText.isEmpty ? nil : Int(wakeUpsText)
+
+        do {
+            if let existing = existingEntry {
+                let update = SleepUpdate(
+                    durationMinutes: durationMinutes,
+                    quality: Int(quality),
+                    entryDate: dateStr,
+                    bedtime: bedtimeIso,
+                    wakeTime: wakeTimeIso,
+                    wakeUps: wakeUps,
+                    notes: notes.isEmpty ? nil : notes
+                )
+                try await sleepRepository.updateEntry(id: existing.id, update)
+            } else {
+                let create = SleepCreate(
+                    durationMinutes: durationMinutes,
+                    quality: Int(quality),
+                    entryDate: dateStr,
+                    bedtime: bedtimeIso,
+                    wakeTime: wakeTimeIso,
+                    wakeUps: wakeUps,
+                    notes: notes.isEmpty ? nil : notes
+                )
+                try await sleepRepository.createEntry(create)
+                await writeToHealthIfEnabled(bedtime: times?.bedtime, wakeTime: times?.wakeTime)
+            }
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            onSaved()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSaving = false
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
+++ b/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
@@ -169,3 +169,113 @@ struct HealthKitSortTests {
         #expect(sortDescriptor.ascending == false)
     }
 }
+
+@Suite("Sleep Night Aggregation Tests")
+struct SleepNightAggregationTests {
+    @Test("Sleep analysis category type exists")
+    func sleepAnalysisTypeExists() {
+        let type = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis)
+        #expect(type != nil)
+    }
+
+    /// Local-calendar date builder — `entryDate` is derived in local time.
+    private func date(_ day: Int, _ hour: Int, _ minute: Int = 0) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 6
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return Calendar.current.date(from: components)!
+    }
+
+    private func sample(
+        from start: Date,
+        to end: Date,
+        stage: HealthKitService.SleepStage = .asleep
+    ) -> HealthKitService.SleepSample {
+        HealthKitService.SleepSample(start: start, end: end, stage: stage)
+    }
+
+    @Test("One night sums asleep stages and keys by the wake day")
+    func singleNightAggregation() throws {
+        let samples = [
+            sample(from: date(1, 23, 0), to: date(2, 1, 0)),
+            sample(from: date(2, 1, 0), to: date(2, 1, 20), stage: .awake),
+            sample(from: date(2, 1, 20), to: date(2, 7, 0)),
+        ]
+
+        let nights = HealthKitService.nights(from: samples)
+
+        #expect(nights.count == 1)
+        let night = try #require(nights.first)
+        #expect(night.entryDate == "2026-06-02")
+        #expect(night.bedtime == date(1, 23, 0))
+        #expect(night.wakeTime == date(2, 7, 0))
+        // 23:00–01:00 plus 01:20–07:00 — the awake gap doesn't count.
+        #expect(night.asleepMinutes == 460)
+        #expect(night.wakeUps == 1)
+    }
+
+    @Test("Overlapping samples from two sources are not double-counted")
+    func overlappingSamplesUnioned() {
+        // Watch and iPhone both recorded the same hour.
+        let samples = [
+            sample(from: date(2, 0, 0), to: date(2, 6, 0)),
+            sample(from: date(2, 2, 0), to: date(2, 3, 0)),
+        ]
+
+        let nights = HealthKitService.nights(from: samples)
+
+        #expect(nights.first?.asleepMinutes == 360)
+    }
+
+    @Test("In-bed-only recordings fall back to the in-bed duration")
+    func inBedFallback() {
+        let samples = [
+            sample(from: date(1, 23, 0), to: date(2, 7, 0), stage: .inBed),
+        ]
+
+        let nights = HealthKitService.nights(from: samples)
+
+        #expect(nights.count == 1)
+        #expect(nights.first?.asleepMinutes == 480)
+    }
+
+    @Test("A gap larger than the session threshold splits sessions")
+    func gapSplitsSessions() {
+        let samples = [
+            sample(from: date(1, 23, 0), to: date(2, 7, 0)),
+            // Afternoon nap, ends the same day — a separate session.
+            sample(from: date(2, 14, 0), to: date(2, 15, 0)),
+        ]
+
+        let nights = HealthKitService.nights(from: samples)
+
+        // Both end on day 2 — the longer night wins over the nap.
+        #expect(nights.count == 1)
+        #expect(nights.first?.asleepMinutes == 480)
+        #expect(nights.first?.bedtime == date(1, 23, 0))
+    }
+
+    @Test("Micro-naps below the minimum are dropped")
+    func microNapsDropped() {
+        let samples = [
+            sample(from: date(2, 14, 0), to: date(2, 14, 20)),
+        ]
+
+        #expect(HealthKitService.nights(from: samples).isEmpty)
+    }
+
+    @Test("Consecutive nights produce one entry per wake day")
+    func consecutiveNights() {
+        let samples = [
+            sample(from: date(1, 23, 0), to: date(2, 7, 0)),
+            sample(from: date(2, 22, 30), to: date(3, 6, 30)),
+        ]
+
+        let nights = HealthKitService.nights(from: samples)
+
+        #expect(nights.map(\.entryDate) == ["2026-06-02", "2026-06-03"])
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
+++ b/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
@@ -610,6 +610,80 @@ struct RepositoryTests {
         #expect(entries.first?.weightKg == 74.2)
     }
 
+    // MARK: Sleep
+
+    @Test("Sleep refresh upserts by id and drops rows deleted on the server")
+    func sleepRefreshUpsertsById() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.sleepRepository
+        try harness.context.insert(LocalSleepEntry(entry: harness.sleepEntry(
+            id: "s1", date: "2026-06-01", durationMinutes: 400
+        )))
+        try harness.context.insert(LocalSleepEntry(entry: harness.sleepEntry(id: "gone", date: "2026-05-31")))
+        try harness.context.save()
+        harness.stub("GET", "/api/sleep", json: """
+        {"entries": [
+            {"id": "s1", "userId": "u1", "entryDate": "2026-06-01", "durationMinutes": 430, "quality": 8},
+            {"id": "s2", "userId": "u1", "entryDate": "2026-06-02", "durationMinutes": 465, "quality": 6}
+        ]}
+        """)
+
+        try await repo.refresh()
+
+        let entries = repo.entries()
+        #expect(entries.map(\.id) == ["s2", "s1"]) // newest first
+        #expect(entries.last?.durationMinutes == 430)
+        #expect(repo.latest()?.id == "s2")
+    }
+
+    @Test("Drained sleep create replaces the temp row with the server record")
+    func sleepCreateDrainReplacesTempId() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.sleepRepository
+        harness.stub("POST", "/api/sleep", json: """
+        {"entry": {"id": "s-server", "userId": "u1", "entryDate": "2026-06-01", "durationMinutes": 450, "quality": 7}}
+        """)
+
+        let temp = try await repo.createEntry(SleepCreate(durationMinutes: 450, quality: 7, entryDate: "2026-06-01"))
+        #expect(LocalStore.isTempId(temp.id))
+        await harness.syncManager.drainPendingQueue()
+
+        #expect(repo.entries().map(\.id) == ["s-server"])
+    }
+
+    @Test("Sleep create keeps the temp row when the upload fails")
+    func sleepCreateKeepsTempRowOnFailure() async throws {
+        let harness = try RepositoryHarness()
+        let repo = harness.sleepRepository
+        harness.stub("POST", "/api/sleep", status: 500, json: #"{"error": "boom"}"#)
+
+        _ = try await repo.createEntry(SleepCreate(durationMinutes: 450, quality: 7, entryDate: "2026-06-01"))
+        await harness.syncManager.drainPendingQueue()
+
+        let entries = repo.entries()
+        #expect(entries.count == 1)
+        #expect(LocalStore.isTempId(entries.first?.id ?? ""))
+        #expect(entries.first?.durationMinutes == 450)
+    }
+
+    @Test("Editing a queued sleep create coalesces into the pending upload")
+    func sleepUpdateCoalescesQueuedCreate() async throws {
+        let harness = try RepositoryHarness(online: false)
+        let repo = harness.sleepRepository
+
+        let temp = try await repo.createEntry(SleepCreate(durationMinutes: 450, quality: 7, entryDate: "2026-06-01"))
+        _ = try await repo.updateEntry(id: temp.id, SleepUpdate(durationMinutes: 480, quality: 9))
+
+        let rows = harness.syncManager.queuedRows()
+        #expect(rows.count == 1)
+        guard case let .createSleep(body, _)? = rows.first?.operation() else {
+            Issue.record("Expected a coalesced createSleep operation")
+            return
+        }
+        #expect(body.durationMinutes == 480)
+        #expect(body.quality == 9)
+    }
+
     // MARK: Supplements
 
     @Test("Supplement log writes the local row and queues; the row survives upload failure")

--- a/mobile/iosApp/BissbilanzTests/TestSupport.swift
+++ b/mobile/iosApp/BissbilanzTests/TestSupport.swift
@@ -202,6 +202,10 @@ struct RepositoryHarness {
         WeightRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
     }
 
+    var sleepRepository: SleepRepository {
+        SleepRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
+    }
+
     var supplementRepository: SupplementRepository {
         SupplementRepository(context: context, api: api, appMode: appMode, syncManager: syncManager)
     }
@@ -284,6 +288,16 @@ struct RepositoryHarness {
             "userId": "u1",
             "weightKg": kg,
             "entryDate": date,
+        ])
+    }
+
+    func sleepEntry(id: String, date: String, durationMinutes: Int = 450, quality: Int = 7) throws -> SleepEntry {
+        try JSONPatch.decode(SleepEntry.self, from: [
+            "id": id,
+            "userId": "u1",
+            "entryDate": date,
+            "durationMinutes": durationMinutes,
+            "quality": quality,
         ])
     }
 

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -33,8 +33,8 @@ targets:
           - CFBundleURLSchemes:
               - bissbilanz
         NSCameraUsageDescription: 'Bissbilanz needs camera access to scan food barcodes'
-        NSHealthShareUsageDescription: 'Bissbilanz reads your weight data to track trends'
-        NSHealthUpdateUsageDescription: 'Bissbilanz saves nutrition and weight data to Health'
+        NSHealthShareUsageDescription: 'Bissbilanz reads your weight and sleep data to track trends'
+        NSHealthUpdateUsageDescription: 'Bissbilanz saves nutrition, weight and sleep data to Health'
     # properties must be declared here: xcodegen regenerates the entitlements
     # file on every `xcodegen generate` and would otherwise write it empty
     entitlements:


### PR DESCRIPTION
## Summary

Closes #262

Brings sleep tracking to the iOS app (backed by the existing server sleep API) with optional two-way Apple Health integration. Both HealthKit directions are independently opt-in and nothing requires HealthKit for normal use.

### Sleep feature (iOS)
- New **SleepView** (Settings → Sleep): last-night / 7-day-average cards, duration bar chart with 7d/30d/90d/all ranges, paginated history, swipe-to-delete
- Add/edit sheet: duration, quality slider (1–10), date, optional bed & wake times (auto-derives duration, wraps midnight), wake-ups, notes
- `SleepRepository` (local-first SwiftData + offline sync queue), `Sleep` models matching the OpenAPI schema, API client methods for `/api/sleep`
- Sync queue (`createSleep`/`updateSleep`/`deleteSleep`) with temp-id coalescing and remapping, login migration upload + local-data wipe — all mirroring the weight feature

### HealthKit read (Watch / Apple Health users)
- Opt-in toggle "Read sleep from Apple Health" — requests **read-only** sleep permission when enabled
- Health sleep-analysis samples are aggregated into nights: sessions split on >2h gaps, overlapping samples (iPhone + Watch) unioned so duration is never double-counted, awake segments counted as wake-ups, in-bed-only recordings fall back to in-bed time, naps filtered, longest session per wake day wins
- Imported nights get a neutral quality (5/10) the user can edit; entries dedupe by date; samples written by the app itself are excluded so write-back can never echo

### HealthKit write (manual-entry users)
- Opt-in toggle "Write sleep to Apple Health" — requests **share-only** sleep permission when enabled
- Manually logged sleep with bed & wake times is saved to Health on create; duration-only entries are skipped (no real interval to write)

### Plumbing
- HealthKit usage strings in `project.yml` updated to mention sleep (project regenerated with XcodeGen)
- New localization strings (en/de)

## Testing
- `xcodebuild build` for iPhone 16 simulator: succeeds
- `xcodebuild test`: 250 tests pass, including new suites for night aggregation (stage summing, overlap union, session splitting, nap filtering, wake-day keying) and sleep repository sync (refresh upsert, temp-id replacement, failure retention, queued-create coalescing)
- swiftformat clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)