### PR TITLE
feat(ios): fancier macro progress circles on homescreen

### DIFF
--- a/mobile/iosApp/Bissbilanz/Components/MacroRingView.swift
+++ b/mobile/iosApp/Bissbilanz/Components/MacroRingView.swift
@@ -6,6 +6,13 @@ struct MacroRingView: View {
     let goal: Double
     let color: Color
     var showGoal: Bool = false
+    /// Staggers the fill animation so a row of rings cascades into place.
+    var animationDelay: Double = 0
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var animatedProgress: Double = 0
 
     private var progress: Double {
         guard goal > 0 else { return 0 }
@@ -16,37 +23,70 @@ struct MacroRingView: View {
         goal > 0 && current > goal
     }
 
+    private var ringColor: Color {
+        isOver ? .red : color
+    }
+
+    /// Subtle sweep from a muted shade to the full macro color, so the ring
+    /// gains depth as it fills without straying from the macro color coding.
+    private var ringGradient: AngularGradient {
+        AngularGradient(
+            gradient: Gradient(colors: [ringColor.opacity(0.65), ringColor]),
+            center: .center,
+            startAngle: .degrees(0),
+            endAngle: .degrees(360)
+        )
+    }
+
+    private var fillAnimation: Animation {
+        .spring(response: 0.8, dampingFraction: 0.85).delay(animationDelay)
+    }
+
     var body: some View {
         VStack(spacing: 4) {
             ZStack {
                 Circle()
-                    .stroke(color.opacity(0.15), lineWidth: 6)
+                    .stroke(color.opacity(colorScheme == .dark ? 0.2 : 0.12), lineWidth: 6)
+
                 Circle()
-                    .trim(from: 0, to: progress)
-                    .stroke(
-                        isOver ? Color.red : color,
-                        style: StrokeStyle(lineWidth: 6, lineCap: .round)
-                    )
+                    .trim(from: 0, to: animatedProgress)
+                    .stroke(ringGradient, style: StrokeStyle(lineWidth: 6, lineCap: .round))
                     .rotationEffect(.degrees(-90))
-                    .animation(.easeInOut(duration: 0.5), value: progress)
+                    .shadow(color: ringColor.opacity(colorScheme == .dark ? 0.4 : 0.25), radius: 3)
 
                 VStack(spacing: 0) {
                     Text("\(Int(current))")
                         .font(.caption)
                         .fontWeight(.semibold)
+                        .monospacedDigit()
+                        .contentTransition(.numericText(value: current))
                         .foregroundStyle(isOver ? .red : color)
                     if showGoal {
                         Text("/\(Int(goal))")
                             .font(.system(size: 8))
+                            .monospacedDigit()
                             .foregroundStyle(.secondary)
                     }
                 }
+                .animation(reduceMotion ? nil : fillAnimation, value: current)
             }
             .frame(width: 56, height: 56)
 
             Text(label)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+        }
+        .onAppear { syncProgress() }
+        .onChange(of: progress) { _, _ in syncProgress() }
+    }
+
+    private func syncProgress() {
+        if reduceMotion {
+            animatedProgress = progress
+        } else {
+            withAnimation(fillAnimation) {
+                animatedProgress = progress
+            }
         }
     }
 }

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -207,22 +207,32 @@ struct DashboardView: View {
                 current: totalProtein,
                 goal: goals.proteinGoal,
                 color: MacroColors.protein,
-                showGoal: true
+                showGoal: true,
+                animationDelay: 0.05
             )
             MacroRingView(
                 label: "C",
                 current: totalCarbs,
                 goal: goals.carbGoal,
                 color: MacroColors.carbs,
-                showGoal: true
+                showGoal: true,
+                animationDelay: 0.1
             )
-            MacroRingView(label: "F", current: totalFat, goal: goals.fatGoal, color: MacroColors.fat, showGoal: true)
+            MacroRingView(
+                label: "F",
+                current: totalFat,
+                goal: goals.fatGoal,
+                color: MacroColors.fat,
+                showGoal: true,
+                animationDelay: 0.15
+            )
             MacroRingView(
                 label: "Fb",
                 current: totalFiber,
                 goal: goals.fiberGoal,
                 color: MacroColors.fiber,
-                showGoal: true
+                showGoal: true,
+                animationDelay: 0.2
             )
         }
     }


### PR DESCRIPTION
## Summary

Polishes the five macro progress rings on the iOS homescreen (DashboardView) for a more premium feel, in line with the brand direction (refined, purposeful, trustworthy).

Closes #263

## Changes

**`MacroRingView`** (evolved in place, no parallel component):
- Subtle in-hue angular gradient on the progress arc (muted shade sweeping to the full macro color) — adds depth without straying from the macro color coding or introducing aggressive gradients
- Soft color-matched glow behind the arc, tuned separately for light and dark mode
- Spring fill animation on load with an optional `animationDelay` so a row of rings cascades into place; subsequent data changes re-animate smoothly
- Numeric value changes animate via `contentTransition(.numericText)` with monospaced digits (no layout jitter)
- Track opacity adapted for dark mode visibility
- All motion respects the Reduce Motion accessibility setting

**`DashboardView`**: passes staggered delays (0–0.2s) to the five rings.

## Acceptance criteria

- [x] Circles feel noticeably more premium (gradient depth, glow, cascade load-in, animated numerals)
- [x] Verified in both light and dark mode on iPhone 16 simulator
- [x] Animations are plain SwiftUI springs on five small shapes — smooth, no jank; Reduce Motion honored
- [x] Macro color coding preserved (Blue=Calories, Red=Protein, Orange=Carbs, Yellow=Fat, Green=Fiber)

🤖 Generated with [Claude Code](https://claude.com/claude-code)