### PR TITLE
feat(ios): swipe left/right on homescreen to change the date

### DIFF
--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -18,6 +18,10 @@ struct DashboardView: View {
     @State private var showCopyConfirmation = false
     @State private var toastMessage: String?
     @State private var isFastingDay = false
+    /// Edge the incoming day content is pushed in from when the date changes.
+    @State private var slideEdge: Edge = .trailing
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Widget data
     @State private var supplementChecklist: [SupplementChecklist] = []
@@ -61,58 +65,18 @@ struct DashboardView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     dateNavigator
-                    macroRings
 
-                    if totalCalories == 0 {
-                        HStack {
-                            Image(systemName: "fork.knife")
-                                .foregroundStyle(.secondary)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(L10n.fastingDay)
-                                    .font(.subheadline)
-                                    .fontWeight(.medium)
-                                Text(L10n.fastingDayDescription)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Toggle("", isOn: Binding(
-                                get: { isFastingDay },
-                                set: { _ in Task { await toggleFastingDay() } }
-                            ))
-                            .labelsHidden()
-                        }
-                        .padding(12)
-                        .background(.regularMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                    }
-
-                    if preferences.showWeightWidget, let weight = latestWeight {
-                        NavigationLink {
-                            WeightView()
-                        } label: {
-                            weightWidget(weight)
-                        }
-                        .buttonStyle(.plain)
-                    }
-
-                    if preferences.showSupplementsWidget, !supplementChecklist.isEmpty {
-                        supplementsWidget
-                    }
-
-                    if mealGroups.isEmpty, !isLoading {
-                        emptyState
-                    } else {
-                        ForEach(mealGroups, id: \.0) { meal, mealEntries in
-                            NavigationLink(value: dateString) {
-                                MealCard(mealType: meal, entries: mealEntries) {}
-                            }
-                            .buttonStyle(.plain)
-                        }
+                    // ZStack so the outgoing and incoming day overlap during
+                    // the push transition instead of stacking vertically.
+                    ZStack {
+                        dayContent
+                            .id(dateString)
+                            .transition(.push(from: slideEdge))
                     }
                 }
                 .padding()
             }
+            .simultaneousGesture(dateSwipeGesture)
             .navigationTitle(L10n.appName)
             .navigationDestination(for: String.self) { date in
                 DayLogView(date: date)
@@ -149,13 +113,106 @@ struct DashboardView: View {
         }
     }
 
+    // MARK: - Day Content
+
+    /// Everything below the date navigator; swapped out with a directional
+    /// push transition when the selected date changes.
+    private var dayContent: some View {
+        VStack(spacing: 16) {
+            macroRings
+
+            if totalCalories == 0 {
+                HStack {
+                    Image(systemName: "fork.knife")
+                        .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L10n.fastingDay)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Text(L10n.fastingDayDescription)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { isFastingDay },
+                        set: { _ in Task { await toggleFastingDay() } }
+                    ))
+                    .labelsHidden()
+                }
+                .padding(12)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+
+            if preferences.showWeightWidget, let weight = latestWeight {
+                NavigationLink {
+                    WeightView()
+                } label: {
+                    weightWidget(weight)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if preferences.showSupplementsWidget, !supplementChecklist.isEmpty {
+                supplementsWidget
+            }
+
+            if mealGroups.isEmpty, !isLoading {
+                emptyState
+            } else {
+                ForEach(mealGroups, id: \.0) { meal, mealEntries in
+                    NavigationLink(value: dateString) {
+                        MealCard(mealType: meal, entries: mealEntries) {}
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - Date Navigation
+
+    /// Horizontal swipe anywhere on the dashboard changes the day. Runs
+    /// simultaneously with the vertical scroll gesture; the dominance check in
+    /// `onEnded` keeps scrolling and pull-to-refresh unaffected, and the
+    /// minimum distance keeps taps intact.
+    private var dateSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onEnded { value in
+                let horizontal = value.translation.width
+                let vertical = value.translation.height
+                guard abs(horizontal) > 60, abs(horizontal) > abs(vertical) else { return }
+                changeDay(by: horizontal < 0 ? 1 : -1)
+            }
+    }
+
+    /// Moves the selected date by `delta` days with a directional push
+    /// animation. Moving past today is blocked — no future dates.
+    private func changeDay(by delta: Int) {
+        guard delta != 0 else { return }
+        if delta > 0, selectedDate.isToday { return }
+        slideEdge = delta > 0 ? .trailing : .leading
+        withAnimation(reduceMotion ? nil : .snappy(duration: 0.3)) {
+            selectedDate = selectedDate.adding(days: delta)
+        }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    private func goToToday() {
+        slideEdge = .trailing
+        withAnimation(reduceMotion ? nil : .snappy(duration: 0.3)) {
+            selectedDate = Date()
+        }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
     // MARK: - Date Navigator
 
     private var dateNavigator: some View {
         HStack {
             Button {
-                selectedDate = selectedDate.adding(days: -1)
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                changeDay(by: -1)
             } label: {
                 Image(systemName: "chevron.left")
                     .font(.title3)
@@ -170,7 +227,7 @@ struct DashboardView: View {
                     .fontWeight(.semibold)
                 if !selectedDate.isToday {
                     Button(L10n.goToToday) {
-                        selectedDate = Date()
+                        goToToday()
                     }
                     .font(.caption)
                 }
@@ -179,8 +236,7 @@ struct DashboardView: View {
             Spacer()
 
             Button {
-                selectedDate = selectedDate.adding(days: 1)
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                changeDay(by: 1)
             } label: {
                 Image(systemName: "chevron.right")
                     .font(.title3)


### PR DESCRIPTION
## Summary

Adds horizontal swipe navigation for the selected day on the iOS dashboard:

- **Swipe right** → previous day, **swipe left** → next day
- Swiping left on today is **blocked** — no future dates
- Day changes (swipe, chevron buttons, "go to today") animate with a directional push transition; respects Reduce Motion
- Light haptic on every day change, matching the existing chevron behavior

## Approach

`DashboardView.swift` only:

- A `DragGesture(minimumDistance: 20)` is attached to the dashboard `ScrollView` via `.simultaneousGesture`. A horizontal-dominance check in `onEnded` (`|w| > 60` and `|w| > |h|`) means vertical scrolling and pull-to-refresh are completely unaffected, and the minimum distance keeps tap targets intact. A paged `TabView` was deliberately avoided since the date sequence is unbounded and it would have required restructuring per-page state.
- Everything below the date navigator is extracted into `dayContent`, wrapped in a `ZStack` with `.id(dateString)` and `.transition(.push(from:))` so the outgoing/incoming day slide directionally without stacking in the layout.
- Chevron buttons and "go to today" now share the same `changeDay`/`goToToday` helpers, so all date changes animate consistently. The future-block lives in `changeDay`, in addition to the existing disabled right chevron.

## Verification

Built and ran on the iPhone 16 simulator (iOS 18.6) with UI automation:

- Swipe right: Today → 11 Jun → 10 Jun ✓
- Swipe left: 10 Jun → 11 Jun → Today ✓
- Swipe left on Today: blocked, stays on Today ✓
- Vertical scroll gestures: no date change ✓
- Tap targets (chevrons, FAB, sheets) still work ✓; the meal-card automation tap quirk reproduces identically on main, so it is pre-existing and unrelated
- `swiftformat --lint` clean

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)