### PR TITLE
feat(mobile): Sentry error monitoring integration

### DIFF
--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -396,7 +396,20 @@ final class BissbilanzAPI {
         let _: EmptyResponse = try await performRequest(request)
     }
 
+    /// Single funnel for every API call: report failures to Sentry here so
+    /// callers that recover (cache fallback, sync retries, `try?` lookups)
+    /// don't silently swallow real defects. `ErrorReporter` filters expected
+    /// noise (unauthorized, offline, not-found).
     private func performRequest<T: Decodable>(_ request: URLRequest) async throws -> T {
+        do {
+            return try await executeRequest(request)
+        } catch {
+            ErrorReporter.capture(error)
+            throw error
+        }
+    }
+
+    private func executeRequest<T: Decodable>(_ request: URLRequest) async throws -> T {
         var req = request
         if let token = authManager.accessToken {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")

--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -49,6 +49,9 @@ struct BissbilanzApp: App {
     private let modelContainer: ModelContainer
 
     init() {
+        // Start crash reporting before anything else can fail.
+        ErrorReporter.start()
+
         let auth = AuthManager()
         let api = BissbilanzAPI(authManager: auth)
         let appMode = AppModeManager()
@@ -61,7 +64,8 @@ struct BissbilanzApp: App {
         } catch {
             // The on-disk store is unusable (e.g. failed migration). Fall back
             // to an in-memory store rather than crashing — data refreshes from
-            // the API while the app is online.
+            // the API while the app is online. Still worth knowing about.
+            ErrorReporter.capture(error)
             do {
                 container = try LocalStore.makeContainer(inMemory: true)
             } catch {

--- a/mobile/iosApp/Bissbilanz/Services/ErrorReporter.swift
+++ b/mobile/iosApp/Bissbilanz/Services/ErrorReporter.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Sentry
+
+/// Central Sentry wrapper — the iOS counterpart of the Android app's
+/// `SentryErrorReporter`. Crashes and unhandled errors are captured by the
+/// SDK's crash handler; handled errors funnel through `capture(_:)`, which
+/// applies the same noise filtering as Android:
+/// - auth failures are an expected state (session expired), not a defect
+/// - transient network failures (offline, flaky cellular) are not actionable
+///
+/// The DSN is injected at build time via the `SENTRY_DSN` build setting
+/// (surfaced in Info.plist as `SentryDSN`). When it is empty — every local
+/// and CI debug build — Sentry stays completely disabled.
+enum ErrorReporter {
+    /// Whether the Sentry SDK was started with a DSN.
+    static var isEnabled: Bool {
+        SentrySDK.isEnabled
+    }
+
+    /// Starts Sentry if a DSN was baked into the build. Must run before any
+    /// `capture(_:)` call — the app calls it first thing in its initializer.
+    static func start() {
+        guard let dsn = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String,
+              !dsn.isEmpty
+        else {
+            return
+        }
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.attachScreenshot = true
+            options.attachViewHierarchy = true
+            options.tracesSampleRate = 0.2
+            #if DEBUG
+            options.environment = "development"
+            #else
+            options.environment = "production"
+            #endif
+        }
+    }
+
+    /// Reports a handled error, unless it is expected noise.
+    static func capture(_ error: Error) {
+        guard isEnabled, !shouldIgnore(error) else { return }
+        SentrySDK.capture(error: error)
+    }
+
+    /// Sends a message event to verify the pipeline end-to-end (debug builds
+    /// expose this from the settings screen).
+    static func sendTestEvent() {
+        SentrySDK.capture(message: "Bissbilanz iOS test event")
+    }
+
+    private static func shouldIgnore(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        // Plain connectivity failures outside the API layer.
+        if error is URLError {
+            return true
+        }
+        switch error as? APIError {
+        case .unauthorized:
+            // Session is dead — the UI prompts to sign in again.
+            return true
+        case .networkError:
+            // Offline, timeout, DNS hiccup — mirrors Android's IOException filter.
+            return true
+        case .notFound:
+            // Lookups (barcode, latest weight) legitimately miss.
+            return true
+        case .badRequest, .serverError, .decodingError, nil:
+            return false
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -350,6 +350,14 @@ struct SettingsView: View {
                         Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
                             .foregroundStyle(.secondary)
                     }
+                    #if DEBUG
+                    // Developer-only: verify the Sentry pipeline end-to-end.
+                    // Greyed out unless the build was made with a SENTRY_DSN.
+                    Button("Send Sentry Test Event") {
+                        ErrorReporter.sendTestEvent()
+                    }
+                    .disabled(!ErrorReporter.isEnabled)
+                    #endif
                 }
             }
             .navigationTitle(L10n.settings)

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -5,11 +5,19 @@ options:
     iOS: '18.0'
   xcodeVersion: '16.2'
 
+packages:
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    exactVersion: 9.17.1
+
 settings:
   base:
     SWIFT_VERSION: '6.0'
     CODE_SIGNING_ALLOWED: 'NO'
     GENERATE_INFOPLIST_FILE: 'YES'
+    # Sentry DSN is injected at build time (e.g. `xcodebuild SENTRY_DSN=...`).
+    # Empty default keeps Sentry disabled for local/CI debug builds.
+    SENTRY_DSN: ''
     INFOPLIST_KEY_UIApplicationSceneManifest_Generation: 'YES'
     INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: 'YES'
     INFOPLIST_KEY_UILaunchScreen_Generation: 'YES'
@@ -35,6 +43,7 @@ targets:
         NSCameraUsageDescription: 'Bissbilanz needs camera access to scan food barcodes'
         NSHealthShareUsageDescription: 'Bissbilanz reads your weight and sleep data to track trends'
         NSHealthUpdateUsageDescription: 'Bissbilanz saves nutrition, weight and sleep data to Health'
+        SentryDSN: $(SENTRY_DSN)
     # properties must be declared here: xcodegen regenerates the entitlements
     # file on every `xcodegen generate` and would otherwise write it empty
     entitlements:
@@ -44,6 +53,7 @@ targets:
         com.apple.developer.healthkit.access: []
     dependencies:
       - sdk: HealthKit.framework
+      - package: Sentry
 
   BissbilanzTests:
     type: bundle.unit-test


### PR DESCRIPTION
Closes #265

## Audit (per the issue's "check first" instruction)

| Layer | State before this PR |
| --- | --- |
| Shared KMP | Already integrated: `ErrorReporter` interface in `commonMain`, injected via Koin into all repositories + `SyncManager`, which report handled errors around API/cache fallbacks. |
| Android app | Already integrated: `sentry-android` 8.40.0, `SentryAndroid.init` in `BissbilanzApplication` (crash handler, ANR, screenshots, view hierarchy, 0.2 traces), DSN from `BuildConfig.SENTRY_DSN` (Gradle property / env, empty = disabled). `SentryErrorReporter` filters unauthorized + transient network errors. |
| iOS app | **Missing** — no Sentry at all (the iOS app is pure SwiftUI and does not link the KMP framework, so the shared `ErrorReporter` cannot cover it). |

This PR adds the missing iOS half, mirroring the Android setup.

## Changes (iOS only)

- **`project.yml`**: add `sentry-cocoa` 9.17.1 via SPM (exact-pinned), a `SENTRY_DSN` build setting (empty default), and surface it in Info.plist as `SentryDSN`
- **`Services/ErrorReporter.swift`** (new): iOS counterpart of Android's `SentryErrorReporter` — starts the SDK only when a DSN was baked into the build, and filters the same noise on handled-error capture (unauthorized/session-expired, transient network failures, not-found lookups, cancellation)
- **`BissbilanzApp.swift`**: start Sentry first thing in `init()`; report the swallowed SwiftData store-corruption fallback
- **`BissbilanzAPI.swift`**: report failures once at the single `performRequest` funnel, so callers that recover (cache fallback, sync retries, `try?` lookups) don't silently swallow real defects — the iOS equivalent of the shared KMP repositories reporting through `ErrorReporter` on Android
- **`SettingsView.swift`**: debug-only "Send Sentry Test Event" button in the About section (disabled when the build has no DSN) to satisfy the test-event acceptance criterion

## DSN configuration (no secrets in source)

- Identical model to Android: empty DSN ⇒ Sentry fully disabled (all local + CI builds)
- Inject at build time: `xcodebuild ... SENTRY_DSN="$SENTRY_DSN"` — when an iOS release pipeline is added, pass the existing `SENTRY_DSN` repo secret the same way `mobile-release.yml` already does for the Android AAB
- Verified locally: built app Info.plist contains an empty `SentryDSN` by default, and the injected value when `SENTRY_DSN` is passed to `xcodebuild`

## Verification

- `xcodegen generate` + `xcodebuild` (iOS Simulator, Debug): **BUILD SUCCEEDED**, with and without an injected DSN
- `./gradlew :shared:ktlintCheck :androidApp:ktlintCheck :androidApp:assembleDebug`: passes (Android untouched)
- `swiftformat` clean on all changed Swift files

🤖 Generated with [Claude Code](https://claude.com/claude-code)