### PR TITLE
feat(ios): Apple HealthKit sync settings subpage

### DIFF
--- a/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
@@ -87,13 +87,16 @@ final class EntryRepository {
         upsert(temp, date: create.date)
         save()
         syncManager.enqueue(.createEntry(body: create, localId: temp.id))
+        syncDayToHealth(create.date, knownFood: food)
         return temp
     }
 
     @discardableResult
     func updateEntry(id: String, _ update: EntryUpdate) async throws -> Entry {
         var local: Entry?
+        var previousDate: String?
         if let row = fetchRow(id: id), let existing = row.toEntry() {
+            previousDate = row.date
             let patch = (try? JSONPatch.dictionary(of: update)) ?? [:]
             let updated = (try? JSONPatch.merged(Entry.self, base: existing, patch: patch)) ?? existing
             row.update(from: updated, date: update.date ?? row.date)
@@ -106,6 +109,14 @@ final class EntryRepository {
         } else {
             syncManager.enqueue(.updateEntry(id: id, body: update))
         }
+        // Re-sync the affected day — both days when the entry moved dates.
+        let currentDate = update.date ?? previousDate
+        if let currentDate {
+            syncDayToHealth(currentDate)
+        }
+        if let previousDate, previousDate != currentDate {
+            syncDayToHealth(previousDate)
+        }
         if let local {
             return local
         }
@@ -113,12 +124,16 @@ final class EntryRepository {
     }
 
     func deleteEntry(id: String) async throws {
+        let date = fetchRow(id: id)?.date
         deleteRow(id: id)
         save()
         if LocalStore.isTempId(id) {
             syncManager.removeQueued(table: "entries", affectedId: id)
         } else {
             syncManager.enqueue(.deleteEntry(id: id))
+        }
+        if let date {
+            syncDayToHealth(date)
         }
     }
 
@@ -137,6 +152,7 @@ final class EntryRepository {
                 upsert(entry, date: entry.date ?? toDate)
             }
             save()
+            syncDayToHealth(toDate)
             return serverCopies.count
         }
         var copied = 0
@@ -169,6 +185,9 @@ final class EntryRepository {
             syncManager.enqueue(.createEntry(body: create, localId: copy.id))
             copied += 1
         }
+        if copied > 0 {
+            syncDayToHealth(toDate)
+        }
         return copied
     }
 
@@ -185,6 +204,35 @@ final class EntryRepository {
             let merged = (try? JSONPatch.merged(EntryCreate.self, base: body, patch: patch)) ?? body
             syncManager.replace(row, with: .createEntry(body: merged, localId: localId))
         }
+    }
+
+    // MARK: - Apple Health write-back
+
+    /// Rewrites the day's nutrition totals in Apple Health after a mutation.
+    /// Fire-and-forget like the weight and sleep write-backs — Health errors
+    /// never surface as logging failures.
+    private func syncDayToHealth(_ date: String, knownFood: Food? = nil) {
+        let healthKit = HealthKitService.shared
+        guard healthKit.isAvailable, HealthNutrient.anyEnabled else { return }
+        let dayEntries = entries(date: date)
+        var foods: [String: Food] = [:]
+        if let knownFood {
+            foods[knownFood.id] = knownFood
+        }
+        for id in Set(dayEntries.compactMap(\.foodId)) where foods[id] == nil {
+            if let food = fetchFoodRow(id: id)?.toFood() {
+                foods[id] = food
+            }
+        }
+        Task {
+            await healthKit.syncNutrition(date: date, entries: dayEntries, foods: foods)
+        }
+    }
+
+    private func fetchFoodRow(id: String) -> LocalFood? {
+        var descriptor = FetchDescriptor<LocalFood>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
     }
 
     // MARK: - Day properties

--- a/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
+++ b/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
@@ -34,25 +34,12 @@ final class HealthKitService {
         return types
     }()
 
+    /// Weight only — nutrition types are authorized per type via
+    /// `requestNutritionWriteAuthorization` so permissions stay lazy.
     private let writeTypes: Set<HKSampleType> = {
         var types = Set<HKSampleType>()
         if let weight = HKQuantityType.quantityType(forIdentifier: .bodyMass) {
             types.insert(weight)
-        }
-        if let energy = HKQuantityType.quantityType(forIdentifier: .dietaryEnergyConsumed) {
-            types.insert(energy)
-        }
-        if let protein = HKQuantityType.quantityType(forIdentifier: .dietaryProtein) {
-            types.insert(protein)
-        }
-        if let carbs = HKQuantityType.quantityType(forIdentifier: .dietaryCarbohydrates) {
-            types.insert(carbs)
-        }
-        if let fat = HKQuantityType.quantityType(forIdentifier: .dietaryFatTotal) {
-            types.insert(fat)
-        }
-        if let fiber = HKQuantityType.quantityType(forIdentifier: .dietaryFiber) {
-            types.insert(fiber)
         }
         return types
     }()
@@ -116,35 +103,106 @@ final class HealthKitService {
         let quantity = HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: weightKg)
         let sample = HKQuantitySample(type: type, quantity: quantity, start: date, end: date)
         try await healthStore.save(sample)
+        Self.markSynced(Self.weightWriteSyncKind)
     }
 
-    func saveNutrition(
-        calories: Double,
-        protein: Double,
-        carbs: Double,
-        fat: Double,
-        fiber: Double,
-        date: Date
-    ) async throws {
+    // MARK: - Nutrition
+
+    /// Requests share access for the given nutrient types only — permissions
+    /// stay lazy: nothing is asked for until the user enables a type.
+    func requestNutritionWriteAuthorization(_ nutrients: [HealthNutrient]) async -> Bool {
+        guard isAvailable else { return false }
+        var types = Set<HKSampleType>()
+        for nutrient in nutrients {
+            if let type = nutrient.quantityType {
+                types.insert(type)
+            }
+        }
+        guard !types.isEmpty else { return false }
+        do {
+            try await healthStore.requestAuthorization(toShare: types, read: [])
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Replaces the app's dietary samples for one day with fresh daily totals
+    /// for every enabled nutrient type. Delete-then-rewrite keeps Health
+    /// consistent through edits, deletes and copies without tracking sample
+    /// ids. Failures stay silent, matching the weight and sleep write-backs.
+    func syncNutrition(date: String, entries: [Entry], foods: [String: Food]) async {
+        guard isAvailable else { return }
+        let enabled = HealthNutrient.all.filter(\.isEnabled)
+        guard !enabled.isEmpty, let day = DateFormatting.date(from: date) else { return }
+
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: day)
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return }
+        // Daily totals carry no meal times — noon is a neutral anchor.
+        let sampleDate = dayStart.addingTimeInterval(12 * 60 * 60)
+
+        let totals = Self.nutrientTotals(entries: entries, foods: foods, nutrients: enabled)
+        let dayPredicate = HKQuery.predicateForSamples(withStart: dayStart, end: dayEnd, options: .strictStartDate)
+
         var samples: [HKQuantitySample] = []
-
-        let pairs: [(HKQuantityTypeIdentifier, Double, HKUnit)] = [
-            (.dietaryEnergyConsumed, calories, .kilocalorie()),
-            (.dietaryProtein, protein, .gram()),
-            (.dietaryCarbohydrates, carbs, .gram()),
-            (.dietaryFatTotal, fat, .gram()),
-            (.dietaryFiber, fiber, .gram()),
-        ]
-
-        for (identifier, value, unit) in pairs where value > 0 {
-            guard let type = HKQuantityType.quantityType(forIdentifier: identifier) else { continue }
-            let quantity = HKQuantity(unit: unit, doubleValue: value)
-            let sample = HKQuantitySample(type: type, quantity: quantity, start: date, end: date)
-            samples.append(sample)
+        var syncedKeys: [String] = []
+        for nutrient in enabled {
+            guard let type = nutrient.quantityType else { continue }
+            // Clear the app's own samples first (other apps' data can't be
+            // deleted anyway) so re-syncs replace instead of accumulate.
+            _ = try? await healthStore.deleteObjects(of: type, predicate: dayPredicate)
+            guard let value = totals[nutrient.key], value > 0 else { continue }
+            samples.append(HKQuantitySample(
+                type: type,
+                quantity: HKQuantity(unit: nutrient.unit.hkUnit, doubleValue: value),
+                start: sampleDate,
+                end: sampleDate
+            ))
+            syncedKeys.append(nutrient.key)
         }
 
         guard !samples.isEmpty else { return }
-        try await healthStore.save(samples)
+        do {
+            try await healthStore.save(samples)
+            for key in syncedKeys {
+                Self.markSynced(Self.nutrientWriteSyncKind(key))
+            }
+        } catch {
+            // Permission denied or Health unavailable — silent by design.
+        }
+    }
+
+    /// Day totals per nutrient key. Food-backed entries use the food's full
+    /// nutrient data; recipe and quick entries only carry resolved macros and
+    /// contribute nothing beyond the five core macros.
+    nonisolated static func nutrientTotals(
+        entries: [Entry],
+        foods: [String: Food],
+        nutrients: [HealthNutrient]
+    ) -> [String: Double] {
+        let requestedKeys = Set(nutrients.map(\.key))
+        var totals: [String: Double] = [:]
+        for entry in entries {
+            if let foodId = entry.foodId, let food = foods[foodId] {
+                for nutrient in nutrients {
+                    guard let perServing = nutrient.amount(food), perServing > 0 else { continue }
+                    totals[nutrient.key, default: 0] += perServing * entry.servings
+                }
+            } else {
+                let macros = [
+                    ("calories", entry.totalCalories),
+                    ("protein", entry.totalProtein),
+                    ("carbs", entry.totalCarbs),
+                    ("fat", entry.totalFat),
+                    ("fiber", entry.totalFiber),
+                ]
+                for (key, total) in macros where requestedKeys.contains(key) && total > 0 {
+                    totals[key, default: 0] += total
+                }
+            }
+        }
+        return totals
     }
 
     struct WeightSample {
@@ -161,7 +219,7 @@ final class HealthKitService {
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
         let ownBundleId = Bundle.main.bundleIdentifier
 
-        return try await withCheckedThrowingContinuation { continuation in
+        let weights: [WeightSample] = try await withCheckedThrowingContinuation { continuation in
             let query = HKSampleQuery(
                 sampleType: type,
                 predicate: predicate,
@@ -183,6 +241,8 @@ final class HealthKitService {
             }
             self.healthStore.execute(query)
         }
+        Self.markSynced(Self.weightReadSyncKind)
+        return weights
     }
 
     // MARK: - Sleep
@@ -224,6 +284,7 @@ final class HealthKitService {
             end: wakeTime
         )
         try await healthStore.save(sample)
+        Self.markSynced(Self.sleepWriteSyncKind)
     }
 
     /// All sleep-analysis samples overlapping the window, oldest first.
@@ -235,7 +296,7 @@ final class HealthKitService {
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
         let ownBundleId = Bundle.main.bundleIdentifier
 
-        return try await withCheckedThrowingContinuation { continuation in
+        let sleepSamples: [SleepSample] = try await withCheckedThrowingContinuation { continuation in
             let query = HKSampleQuery(
                 sampleType: type,
                 predicate: predicate,
@@ -257,6 +318,8 @@ final class HealthKitService {
             }
             self.healthStore.execute(query)
         }
+        Self.markSynced(Self.sleepReadSyncKind)
+        return sleepSamples
     }
 
     private nonisolated static func stage(for rawValue: Int) -> SleepStage? {
@@ -374,5 +437,41 @@ final class HealthKitService {
             }
             self.healthStore.execute(query)
         }
+    }
+
+    // MARK: - Last-synced timestamps
+
+    /// Timestamp kinds — one per data type and direction, shown on the Apple
+    /// Health settings page.
+    static let weightReadSyncKind = "read_bodyMass"
+    static let weightWriteSyncKind = "write_bodyMass"
+    static let sleepReadSyncKind = "read_sleepAnalysis"
+    static let sleepWriteSyncKind = "write_sleepAnalysis"
+
+    static func nutrientWriteSyncKind(_ key: String) -> String {
+        "write_\(key)"
+    }
+
+    /// When the given data type last synced successfully, or nil if it never
+    /// has.
+    static func lastSync(_ kind: String) -> Date? {
+        let timestamp = UserDefaults.standard.double(forKey: "healthkit_last_sync_\(kind)")
+        guard timestamp > 0 else { return nil }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    static func markSynced(_ kind: String) {
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "healthkit_last_sync_\(kind)")
+    }
+
+    /// True when any Health sync toggle (weight, sleep or a nutrient) is on —
+    /// the app-side definition of "connected".
+    static var isAnySyncEnabled: Bool {
+        let defaults = UserDefaults.standard
+        return defaults.bool(forKey: syncEnabledKey)
+            || defaults.bool(forKey: writeWeightEnabledKey)
+            || defaults.bool(forKey: readSleepEnabledKey)
+            || defaults.bool(forKey: writeSleepEnabledKey)
+            || HealthNutrient.anyEnabled
     }
 }

--- a/mobile/iosApp/Bissbilanz/Services/HealthSyncTypes.swift
+++ b/mobile/iosApp/Bissbilanz/Services/HealthSyncTypes.swift
@@ -1,0 +1,152 @@
+import Foundation
+import HealthKit
+
+// MARK: - Sync Direction
+
+/// Direction of a Health sync data type, relative to the app.
+enum HealthSyncDirection {
+    /// Health → app (import).
+    case read
+    /// App → Health (export).
+    case write
+
+    var icon: String {
+        switch self {
+        case .read: "arrow.down.circle"
+        case .write: "arrow.up.circle"
+        }
+    }
+}
+
+// MARK: - Nutrient Units
+
+/// Unit the app stores a nutrient value in, mapped to the HealthKit unit the
+/// sample is written with.
+enum HealthNutrientUnit {
+    case kilocalorie
+    case gram
+    case milligram
+    case microgram
+    /// The app stores water in grams; Health expects a volume — 1 g ≈ 1 ml.
+    case milliliter
+
+    var hkUnit: HKUnit {
+        switch self {
+        case .kilocalorie: .kilocalorie()
+        case .gram: .gram()
+        case .milligram: .gramUnit(with: .milli)
+        case .microgram: .gramUnit(with: .micro)
+        case .milliliter: .literUnit(with: .milli)
+        }
+    }
+}
+
+// MARK: - Nutrient Catalog
+
+/// One nutrient the app can write to Apple Health as part of the daily
+/// totals sync. `amount` extracts the per-serving value from a food.
+struct HealthNutrient: Identifiable {
+    let key: String
+    let name: String
+    let identifier: HKQuantityTypeIdentifier
+    let unit: HealthNutrientUnit
+    let amount: @Sendable (Food) -> Double?
+
+    var id: String {
+        key
+    }
+
+    /// Per-type opt-in flag — nutrients are individually enabled, off by
+    /// default, and only enabled types ever request Health permission.
+    var defaultsKey: String {
+        "healthkit_write_nutrition_\(key)"
+    }
+
+    var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: defaultsKey)
+    }
+
+    var quantityType: HKQuantityType? {
+        HKQuantityType.quantityType(forIdentifier: identifier)
+    }
+}
+
+extension HealthNutrient {
+    static var anyEnabled: Bool {
+        all.contains(where: \.isEnabled)
+    }
+
+    static let all: [HealthNutrient] = categories.flatMap(\.nutrients)
+
+    /// Every nutrient HealthKit can store that the app tracks, grouped like
+    /// the visible-nutrients page. Trans fat, omega-3/6, added sugars, sugar
+    /// alcohols, starch, fluoride, alcohol and salt have no HealthKit dietary
+    /// type and are deliberately absent.
+    static let categories: [(name: String, nutrients: [HealthNutrient])] = [
+        ("Macronutrients", [
+            make("calories", "Energy", .dietaryEnergyConsumed, .kilocalorie) { $0.calories },
+            make("protein", "Protein", .dietaryProtein, .gram) { $0.protein },
+            make("carbs", "Carbohydrates", .dietaryCarbohydrates, .gram) { $0.carbs },
+            make("fat", "Total Fat", .dietaryFatTotal, .gram) { $0.fat },
+            make("fiber", "Dietary Fiber", .dietaryFiber, .gram) { $0.fiber },
+            make("sugar", "Sugar", .dietarySugar, .gram) { $0.sugar },
+        ]),
+        ("Fat Breakdown", [
+            make("saturatedFat", "Saturated Fat", .dietaryFatSaturated, .gram) { $0.saturatedFat },
+            make("monounsaturatedFat", "Monounsaturated Fat", .dietaryFatMonounsaturated, .gram) {
+                $0.monounsaturatedFat
+            },
+            make("polyunsaturatedFat", "Polyunsaturated Fat", .dietaryFatPolyunsaturated, .gram) {
+                $0.polyunsaturatedFat
+            },
+            make("cholesterol", "Cholesterol", .dietaryCholesterol, .milligram) { $0.cholesterol },
+        ]),
+        ("Minerals", [
+            make("sodium", "Sodium", .dietarySodium, .milligram) { $0.sodium },
+            make("potassium", "Potassium", .dietaryPotassium, .milligram) { $0.potassium },
+            make("calcium", "Calcium", .dietaryCalcium, .milligram) { $0.calcium },
+            make("iron", "Iron", .dietaryIron, .milligram) { $0.iron },
+            make("magnesium", "Magnesium", .dietaryMagnesium, .milligram) { $0.magnesium },
+            make("phosphorus", "Phosphorus", .dietaryPhosphorus, .milligram) { $0.phosphorus },
+            make("zinc", "Zinc", .dietaryZinc, .milligram) { $0.zinc },
+            make("copper", "Copper", .dietaryCopper, .milligram) { $0.copper },
+            make("manganese", "Manganese", .dietaryManganese, .milligram) { $0.manganese },
+            make("selenium", "Selenium", .dietarySelenium, .microgram) { $0.selenium },
+            make("iodine", "Iodine", .dietaryIodine, .microgram) { $0.iodine },
+            make("chromium", "Chromium", .dietaryChromium, .microgram) { $0.chromium },
+            make("molybdenum", "Molybdenum", .dietaryMolybdenum, .microgram) { $0.molybdenum },
+            make("chloride", "Chloride", .dietaryChloride, .milligram) { $0.chloride },
+        ]),
+        ("Vitamins", [
+            make("vitaminA", "Vitamin A", .dietaryVitaminA, .microgram) { $0.vitaminA },
+            make("vitaminB1", "Vitamin B1 (Thiamine)", .dietaryThiamin, .milligram) { $0.vitaminB1 },
+            make("vitaminB2", "Vitamin B2 (Riboflavin)", .dietaryRiboflavin, .milligram) { $0.vitaminB2 },
+            make("vitaminB3", "Vitamin B3 (Niacin)", .dietaryNiacin, .milligram) { $0.vitaminB3 },
+            make("vitaminB5", "Vitamin B5 (Pantothenic Acid)", .dietaryPantothenicAcid, .milligram) {
+                $0.vitaminB5
+            },
+            make("vitaminB6", "Vitamin B6", .dietaryVitaminB6, .milligram) { $0.vitaminB6 },
+            make("vitaminB7", "Vitamin B7 (Biotin)", .dietaryBiotin, .microgram) { $0.vitaminB7 },
+            make("vitaminB9", "Vitamin B9 (Folate)", .dietaryFolate, .microgram) { $0.vitaminB9 },
+            make("vitaminB12", "Vitamin B12", .dietaryVitaminB12, .microgram) { $0.vitaminB12 },
+            make("vitaminC", "Vitamin C", .dietaryVitaminC, .milligram) { $0.vitaminC },
+            make("vitaminD", "Vitamin D", .dietaryVitaminD, .microgram) { $0.vitaminD },
+            make("vitaminE", "Vitamin E", .dietaryVitaminE, .milligram) { $0.vitaminE },
+            make("vitaminK", "Vitamin K", .dietaryVitaminK, .microgram) { $0.vitaminK },
+        ]),
+        ("Other", [
+            make("caffeine", "Caffeine", .dietaryCaffeine, .milligram) { $0.caffeine },
+            make("water", "Water", .dietaryWater, .milliliter) { $0.water },
+        ]),
+    ]
+
+    private static func make(
+        _ key: String,
+        _ name: String,
+        _ identifier: HKQuantityTypeIdentifier,
+        _ unit: HealthNutrientUnit,
+        _ amount: @escaping @Sendable (Food) -> Double?
+    ) -> HealthNutrient {
+        HealthNutrient(key: key, name: name, identifier: identifier, unit: unit, amount: amount)
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -677,47 +677,87 @@ enum L10n {
         )
     }
 
-    static var healthKit: String {
-        localized("health_kit", en: "Health Integration", de: "Health-Integration")
+    static var appleHealth: String {
+        localized("apple_health", en: "Apple Health", de: "Apple Health")
     }
 
-    static var healthWriteWeight: String {
+    static var healthConnected: String {
+        localized("health_connected", en: "Connected", de: "Verbunden")
+    }
+
+    static var healthNotConnected: String {
+        localized("health_not_connected", en: "Not connected", de: "Nicht verbunden")
+    }
+
+    static var healthConnect: String {
+        localized("health_connect", en: "Connect", de: "Verbinden")
+    }
+
+    static var healthDisconnect: String {
+        localized("health_disconnect", en: "Disconnect", de: "Trennen")
+    }
+
+    static var healthReadingSection: String {
+        localized("health_reading_section", en: "Reading from Health", de: "Aus Health lesen")
+    }
+
+    static var healthWritingSection: String {
+        localized("health_writing_section", en: "Writing to Health", de: "In Health schreiben")
+    }
+
+    static var healthNutrientsSection: String {
         localized(
-            "health_write_weight",
-            en: "Write weight to Apple Health",
-            de: "Gewicht in Apple Health schreiben"
+            "health_nutrients_section",
+            en: "Nutrients (Writing to Health)",
+            de: "Nährstoffe (in Health schreiben)"
         )
     }
 
-    static var healthSyncFooter: String {
+    static func healthLastSynced(_ when: String) -> String {
         localized(
-            "health_sync_footer",
-            en: "Weights from Apple Health are imported automatically. Enable writing only if you log weight here and want it in Apple Health — leave it off if your scale already syncs to Health.",
-            de: "Gewichte aus Apple Health werden automatisch importiert. Aktiviere das Schreiben nur, wenn du dein Gewicht hier erfasst und es in Apple Health haben möchtest — lass es aus, wenn deine Waage bereits mit Health synchronisiert."
+            "health_last_synced",
+            en: "Last synced \(when)",
+            de: "Zuletzt synchronisiert \(when)"
         )
     }
 
-    static var healthReadSleep: String {
+    static var healthConnectFooter: String {
         localized(
-            "health_read_sleep",
-            en: "Read sleep from Apple Health",
-            de: "Schlaf aus Apple Health lesen"
+            "health_connect_footer",
+            en: "Connecting enables the weight import from Apple Health. Each data type below can be enabled individually — its permission is requested when you turn it on.",
+            de: "Beim Verbinden wird der Gewichtsimport aus Apple Health aktiviert. Jeder Datentyp unten lässt sich einzeln aktivieren — die Berechtigung wird erst beim Einschalten angefragt."
         )
     }
 
-    static var healthWriteSleep: String {
+    static var healthDisconnectFooter: String {
         localized(
-            "health_write_sleep",
-            en: "Write sleep to Apple Health",
-            de: "Schlaf in Apple Health schreiben"
+            "health_disconnect_footer",
+            en: "Disconnecting turns off all syncing with Apple Health. To revoke granted permissions, use the Health app.",
+            de: "Beim Trennen wird die gesamte Synchronisierung mit Apple Health deaktiviert. Um erteilte Berechtigungen zu widerrufen, verwende die Health-App."
         )
     }
 
-    static var healthSleepFooter: String {
+    static var healthReadingFooter: String {
         localized(
-            "health_sleep_footer",
-            en: "Reading imports nights recorded in Apple Health (e.g. by Apple Watch) into your sleep log with a neutral quality rating you can edit. Writing saves sleep you log here with bed and wake times to Apple Health — leave it off if your Watch already records sleep.",
-            de: "Beim Lesen werden in Apple Health aufgezeichnete Nächte (z. B. von der Apple Watch) mit einer neutralen, editierbaren Qualitätsbewertung in dein Schlafprotokoll importiert. Beim Schreiben wird hier erfasster Schlaf mit Schlafens- und Aufwachzeit in Apple Health gespeichert — lass es aus, wenn deine Watch bereits Schlaf aufzeichnet."
+            "health_reading_footer",
+            en: "Data recorded in Apple Health (e.g. by a smart scale or Apple Watch) is imported automatically. Sleep arrives with a neutral quality rating you can edit.",
+            de: "In Apple Health aufgezeichnete Daten (z. B. von einer smarten Waage oder der Apple Watch) werden automatisch importiert. Schlaf erhält eine neutrale, editierbare Qualitätsbewertung."
+        )
+    }
+
+    static var healthWritingFooter: String {
+        localized(
+            "health_writing_footer",
+            en: "Weight and sleep logged in the app are saved to Apple Health. Leave these off if another device already records them — you would get duplicates.",
+            de: "In der App erfasstes Gewicht und erfasster Schlaf werden in Apple Health gespeichert. Lass dies aus, wenn ein anderes Gerät sie bereits aufzeichnet — sonst entstehen Duplikate."
+        )
+    }
+
+    static var healthNutrientsFooter: String {
+        localized(
+            "health_nutrients_footer",
+            en: "Daily totals for enabled nutrients are written to Apple Health whenever you log, edit or delete food entries.",
+            de: "Tagessummen aktivierter Nährstoffe werden in Apple Health geschrieben, sobald du Einträge erfasst, bearbeitest oder löschst."
         )
     }
 
@@ -1108,24 +1148,6 @@ enum L10n {
 
     static var avgCalories: String {
         localized("avg_calories", en: "Avg Calories", de: "Ø Kalorien")
-    }
-
-    // MARK: - HealthKit (additional)
-
-    static var permissionsGranted: String {
-        localized(
-            "permissions_granted",
-            en: "Permissions granted",
-            de: "Berechtigungen erteilt"
-        )
-    }
-
-    static var grantPermissions: String {
-        localized(
-            "grant_permissions",
-            en: "Grant Permissions",
-            de: "Berechtigungen erteilen"
-        )
     }
 
     // MARK: - Visible Nutrients (additional)

--- a/mobile/iosApp/Bissbilanz/Views/AppleHealthSettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/AppleHealthSettingsView.swift
@@ -1,0 +1,273 @@
+import HealthKit
+import SwiftUI
+
+/// Settings subpage for the Apple Health integration: connection status plus
+/// per-data-type sync toggles grouped by direction. Permissions are requested
+/// lazily — only when a type is enabled.
+struct AppleHealthSettingsView: View {
+    private let healthKit = HealthKitService.shared
+
+    // Weight and sleep reuse the pre-existing defaults keys so settings made
+    // before this page existed carry over unchanged.
+    @State private var weightRead = UserDefaults.standard.bool(forKey: HealthKitService.syncEnabledKey)
+    @State private var weightWrite = UserDefaults.standard.bool(forKey: HealthKitService.writeWeightEnabledKey)
+    @State private var sleepRead = UserDefaults.standard.bool(forKey: HealthKitService.readSleepEnabledKey)
+    @State private var sleepWrite = UserDefaults.standard.bool(forKey: HealthKitService.writeSleepEnabledKey)
+    @State private var nutrientsEnabled: [String: Bool] = Dictionary(
+        uniqueKeysWithValues: HealthNutrient.all.map { ($0.key, $0.isEnabled) }
+    )
+
+    private var isConnected: Bool {
+        weightRead || weightWrite || sleepRead || sleepWrite || nutrientsEnabled.values.contains(true)
+    }
+
+    var body: some View {
+        List {
+            statusSection
+            readingSection
+            writingSection
+            nutrientHeaderSection
+            ForEach(HealthNutrient.categories, id: \.name) { category in
+                Section(category.name) {
+                    ForEach(category.nutrients) { nutrient in
+                        syncRow(
+                            name: nutrient.name,
+                            identifier: nutrient.identifier.rawValue,
+                            direction: .write,
+                            lastSyncKind: HealthKitService.nutrientWriteSyncKind(nutrient.key),
+                            isOn: nutrientBinding(nutrient)
+                        )
+                    }
+                }
+            }
+        }
+        .navigationTitle(L10n.appleHealth)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Status
+
+    private var statusSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                Image(systemName: "heart.fill")
+                    .font(.title2)
+                    .foregroundStyle(.red)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L10n.appleHealth)
+                        .font(.headline)
+                    Text(isConnected ? L10n.healthConnected : L10n.healthNotConnected)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: isConnected ? "checkmark.circle.fill" : "circle.dashed")
+                    .foregroundStyle(isConnected ? AnyShapeStyle(.green) : AnyShapeStyle(.secondary))
+            }
+            if isConnected {
+                Button(role: .destructive) {
+                    disconnect()
+                } label: {
+                    Label(L10n.healthDisconnect, systemImage: "heart.slash")
+                }
+            } else {
+                Button {
+                    connect()
+                } label: {
+                    Label(L10n.healthConnect, systemImage: "heart.circle")
+                }
+            }
+        } footer: {
+            Text(isConnected ? L10n.healthDisconnectFooter : L10n.healthConnectFooter)
+        }
+    }
+
+    // MARK: - Reading from Health
+
+    private var readingSection: some View {
+        Section {
+            syncRow(
+                name: L10n.weight,
+                identifier: HKQuantityTypeIdentifier.bodyMass.rawValue,
+                direction: .read,
+                lastSyncKind: HealthKitService.weightReadSyncKind,
+                isOn: toggleBinding($weightRead, key: HealthKitService.syncEnabledKey) {
+                    await healthKit.requestReadAuthorization()
+                }
+            )
+            syncRow(
+                name: L10n.sleep,
+                identifier: HKCategoryTypeIdentifier.sleepAnalysis.rawValue,
+                direction: .read,
+                lastSyncKind: HealthKitService.sleepReadSyncKind,
+                isOn: toggleBinding($sleepRead, key: HealthKitService.readSleepEnabledKey) {
+                    await healthKit.requestSleepReadAuthorization()
+                }
+            )
+        } header: {
+            Text(L10n.healthReadingSection)
+        } footer: {
+            Text(L10n.healthReadingFooter)
+        }
+    }
+
+    // MARK: - Writing to Health
+
+    private var writingSection: some View {
+        Section {
+            syncRow(
+                name: L10n.weight,
+                identifier: HKQuantityTypeIdentifier.bodyMass.rawValue,
+                direction: .write,
+                lastSyncKind: HealthKitService.weightWriteSyncKind,
+                isOn: toggleBinding($weightWrite, key: HealthKitService.writeWeightEnabledKey) {
+                    await healthKit.requestWriteAuthorization()
+                }
+            )
+            syncRow(
+                name: L10n.sleep,
+                identifier: HKCategoryTypeIdentifier.sleepAnalysis.rawValue,
+                direction: .write,
+                lastSyncKind: HealthKitService.sleepWriteSyncKind,
+                isOn: toggleBinding($sleepWrite, key: HealthKitService.writeSleepEnabledKey) {
+                    await healthKit.requestSleepWriteAuthorization()
+                }
+            )
+        } header: {
+            Text(L10n.healthWritingSection)
+        } footer: {
+            Text(L10n.healthWritingFooter)
+        }
+    }
+
+    // MARK: - Nutrients
+
+    private var nutrientHeaderSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                Button(L10n.selectAll) {
+                    setAllNutrients(true)
+                }
+                .buttonStyle(.bordered)
+                .frame(maxWidth: .infinity)
+
+                Button(L10n.deselectAll) {
+                    setAllNutrients(false)
+                }
+                .buttonStyle(.bordered)
+                .frame(maxWidth: .infinity)
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
+        } header: {
+            Text(L10n.healthNutrientsSection)
+        } footer: {
+            Text(L10n.healthNutrientsFooter)
+        }
+    }
+
+    // MARK: - Rows
+
+    /// One data type: name, direction icon, raw HealthKit identifier, last
+    /// synced timestamp and the enable toggle.
+    private func syncRow(
+        name: String,
+        identifier: String,
+        direction: HealthSyncDirection,
+        lastSyncKind: String,
+        isOn: Binding<Bool>
+    ) -> some View {
+        Toggle(isOn: isOn) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Image(systemName: direction.icon)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(name)
+                }
+                Text(identifier)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let lastSync = HealthKitService.lastSync(lastSyncKind) {
+                    Text(L10n.healthLastSynced(lastSync.formatted(.relative(presentation: .named))))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Bindings
+
+    /// Persists the toggle and lazily requests the type's permission when it
+    /// is switched on.
+    private func toggleBinding(
+        _ source: Binding<Bool>,
+        key: String,
+        onEnable: @escaping () async -> Bool
+    ) -> Binding<Bool> {
+        Binding(
+            get: { source.wrappedValue },
+            set: { enabled in
+                source.wrappedValue = enabled
+                UserDefaults.standard.set(enabled, forKey: key)
+                if enabled {
+                    Task { _ = await onEnable() }
+                }
+            }
+        )
+    }
+
+    private func nutrientBinding(_ nutrient: HealthNutrient) -> Binding<Bool> {
+        Binding(
+            get: { nutrientsEnabled[nutrient.key] ?? false },
+            set: { enabled in
+                nutrientsEnabled[nutrient.key] = enabled
+                UserDefaults.standard.set(enabled, forKey: nutrient.defaultsKey)
+                if enabled {
+                    Task { _ = await healthKit.requestNutritionWriteAuthorization([nutrient]) }
+                }
+            }
+        )
+    }
+
+    // MARK: - Actions
+
+    /// Mirrors the old master toggle: connecting turns on the weight import
+    /// and asks for read permission. Everything else stays opt-in below.
+    private func connect() {
+        weightRead = true
+        UserDefaults.standard.set(true, forKey: HealthKitService.syncEnabledKey)
+        Task { _ = await healthKit.requestReadAuthorization() }
+    }
+
+    /// HealthKit has no API to revoke permissions — disconnecting turns every
+    /// sync toggle off; revocation lives in the Health app (see footer).
+    private func disconnect() {
+        weightRead = false
+        weightWrite = false
+        sleepRead = false
+        sleepWrite = false
+        let defaults = UserDefaults.standard
+        defaults.set(false, forKey: HealthKitService.syncEnabledKey)
+        defaults.set(false, forKey: HealthKitService.writeWeightEnabledKey)
+        defaults.set(false, forKey: HealthKitService.readSleepEnabledKey)
+        defaults.set(false, forKey: HealthKitService.writeSleepEnabledKey)
+        setAllNutrients(false)
+    }
+
+    /// All nutrient toggles at once — enabling requests one combined
+    /// permission sheet instead of forty individual ones.
+    private func setAllNutrients(_ enabled: Bool) {
+        let defaults = UserDefaults.standard
+        for nutrient in HealthNutrient.all {
+            nutrientsEnabled[nutrient.key] = enabled
+            defaults.set(enabled, forKey: nutrient.defaultsKey)
+        }
+        if enabled {
+            Task { _ = await healthKit.requestNutritionWriteAuthorization(HealthNutrient.all) }
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -22,13 +22,6 @@ struct SettingsView: View {
     @State private var newMealTypeName = ""
     @State private var errorMessage: String?
     private let healthKitService = HealthKitService.shared
-    @State private var healthSyncEnabled: Bool = UserDefaults.standard.bool(forKey: HealthKitService.syncEnabledKey)
-    @State private var healthWriteWeightEnabled: Bool = UserDefaults.standard
-        .bool(forKey: HealthKitService.writeWeightEnabledKey)
-    @State private var healthReadSleepEnabled: Bool = UserDefaults.standard
-        .bool(forKey: HealthKitService.readSleepEnabledKey)
-    @State private var healthWriteSleepEnabled: Bool = UserDefaults.standard
-        .bool(forKey: HealthKitService.writeSleepEnabledKey)
     @AppStorage("selected_tabs") private var selectedTabsRaw: String = "foods,favorites,insights"
 
     private var selectedTabNames: String {
@@ -106,76 +99,22 @@ struct SettingsView: View {
                     }
                 }
 
-                // HealthKit section
+                // Apple Health — all sync controls live on the subpage.
                 if healthKitService.isAvailable {
-                    Section {
-                        Toggle(L10n.healthKit, isOn: $healthSyncEnabled)
-                            .onChange(of: healthSyncEnabled) { _, enabled in
-                                UserDefaults.standard.set(enabled, forKey: HealthKitService.syncEnabledKey)
-                                if enabled {
-                                    Task {
-                                        _ = await healthKitService.requestReadAuthorization()
-                                    }
-                                }
-                            }
-                        if healthSyncEnabled {
-                            Toggle(L10n.healthWriteWeight, isOn: $healthWriteWeightEnabled)
-                                .onChange(of: healthWriteWeightEnabled) { _, enabled in
-                                    UserDefaults.standard.set(enabled, forKey: HealthKitService.writeWeightEnabledKey)
-                                    if enabled {
-                                        Task {
-                                            _ = await healthKitService.requestWriteAuthorization()
-                                        }
-                                    }
-                                }
-                        }
-                        // Sleep read/write are independently optional — each
-                        // direction only requests its own permission when the
-                        // user opts in.
-                        Toggle(L10n.healthReadSleep, isOn: $healthReadSleepEnabled)
-                            .onChange(of: healthReadSleepEnabled) { _, enabled in
-                                UserDefaults.standard.set(enabled, forKey: HealthKitService.readSleepEnabledKey)
-                                if enabled {
-                                    Task {
-                                        _ = await healthKitService.requestSleepReadAuthorization()
-                                    }
-                                }
-                            }
-                        Toggle(L10n.healthWriteSleep, isOn: $healthWriteSleepEnabled)
-                            .onChange(of: healthWriteSleepEnabled) { _, enabled in
-                                UserDefaults.standard.set(enabled, forKey: HealthKitService.writeSleepEnabledKey)
-                                if enabled {
-                                    Task {
-                                        _ = await healthKitService.requestSleepWriteAuthorization()
-                                    }
-                                }
-                            }
-                        if healthKitService.isAuthorized {
+                    Section(L10n.appleHealth) {
+                        NavigationLink {
+                            AppleHealthSettingsView()
+                        } label: {
                             HStack {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.green)
-                                Text(L10n.permissionsGranted)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        } else if healthSyncEnabled {
-                            Button {
-                                Task { _ = await healthKitService.requestReadAuthorization() }
-                            } label: {
-                                Label(L10n.grantPermissions, systemImage: "heart.circle")
-                            }
-                        }
-                    } header: {
-                        Text(L10n.healthKit)
-                    } footer: {
-                        if healthSyncEnabled || healthReadSleepEnabled || healthWriteSleepEnabled {
-                            VStack(alignment: .leading, spacing: 8) {
-                                if healthSyncEnabled {
-                                    Text(L10n.healthSyncFooter)
-                                }
-                                if healthReadSleepEnabled || healthWriteSleepEnabled {
-                                    Text(L10n.healthSleepFooter)
-                                }
+                                Label(L10n.appleHealth, systemImage: "heart")
+                                Spacer()
+                                Text(
+                                    HealthKitService.isAnySyncEnabled
+                                        ? L10n.healthConnected
+                                        : L10n.healthNotConnected
+                                )
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                             }
                         }
                     }

--- a/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
+++ b/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
@@ -279,3 +279,162 @@ struct SleepNightAggregationTests {
         #expect(nights.map(\.entryDate) == ["2026-06-02", "2026-06-03"])
     }
 }
+
+@Suite("Health Nutrient Catalog Tests")
+struct HealthNutrientCatalogTests {
+    @Test("Every catalog entry resolves to a real HealthKit quantity type")
+    func identifiersResolve() {
+        for nutrient in HealthNutrient.all {
+            #expect(nutrient.quantityType != nil, "\(nutrient.key) should map to a HealthKit type")
+        }
+    }
+
+    @Test("Catalog keys and identifiers are unique")
+    func catalogUnique() {
+        let keys = HealthNutrient.all.map(\.key)
+        let identifiers = HealthNutrient.all.map(\.identifier.rawValue)
+        #expect(Set(keys).count == keys.count)
+        #expect(Set(identifiers).count == identifiers.count)
+    }
+
+    @Test("Catalog covers macros, minerals, vitamins and water")
+    func catalogCoverage() {
+        let keys = Set(HealthNutrient.all.map(\.key))
+        let expected = [
+            "calories", "protein", "carbs", "fat", "fiber", "sugar",
+            "saturatedFat", "cholesterol", "sodium", "iron", "selenium",
+            "vitaminA", "vitaminB12", "vitaminK", "caffeine", "water",
+        ]
+        for key in expected {
+            #expect(keys.contains(key), "\(key) missing from catalog")
+        }
+    }
+}
+
+@Suite("Nutrient Totals Tests")
+struct NutrientTotalsTests {
+    @Test("Food-backed entries multiply nutrients by servings")
+    func foodEntryTotals() {
+        let food = makeNutrientFood(id: "f1", calories: 100, protein: 10, magnesium: 50, vitaminC: 20)
+        let entry = makeNutrientEntry(foodId: "f1", servings: 2)
+
+        let totals = HealthKitService.nutrientTotals(
+            entries: [entry],
+            foods: ["f1": food],
+            nutrients: HealthNutrient.all
+        )
+
+        #expect(totals["calories"] == 200)
+        #expect(totals["protein"] == 20)
+        #expect(totals["magnesium"] == 100)
+        #expect(totals["vitaminC"] == 40)
+        #expect(totals["iron"] == nil)
+    }
+
+    @Test("Quick entries contribute resolved macros only")
+    func quickEntryTotals() {
+        let entry = makeNutrientEntry(foodId: nil, servings: 1, quickCalories: 250, quickProtein: 30)
+
+        let totals = HealthKitService.nutrientTotals(
+            entries: [entry],
+            foods: [:],
+            nutrients: HealthNutrient.all
+        )
+
+        #expect(totals["calories"] == 250)
+        #expect(totals["protein"] == 30)
+        #expect(totals["magnesium"] == nil)
+    }
+
+    @Test("Entries whose food is missing fall back to resolved macros")
+    func missingFoodFallsBack() {
+        let entry = makeNutrientEntry(foodId: "gone", servings: 2, calories: 100, protein: 5)
+
+        let totals = HealthKitService.nutrientTotals(
+            entries: [entry],
+            foods: [:],
+            nutrients: HealthNutrient.all
+        )
+
+        #expect(totals["calories"] == 200)
+        #expect(totals["protein"] == 10)
+    }
+
+    @Test("Only requested nutrients are totalled")
+    func onlyRequestedNutrients() {
+        let food = makeNutrientFood(id: "f1", calories: 100, protein: 10, magnesium: 50, vitaminC: 20)
+        let entry = makeNutrientEntry(foodId: "f1", servings: 1)
+        let calorieOnly = HealthNutrient.all.filter { $0.key == "calories" }
+
+        let totals = HealthKitService.nutrientTotals(entries: [entry], foods: ["f1": food], nutrients: calorieOnly)
+
+        #expect(totals == ["calories": 100])
+    }
+
+    @Test("Multiple entries accumulate into one day total")
+    func multipleEntriesAccumulate() {
+        let food = makeNutrientFood(id: "f1", calories: 100, protein: 10, magnesium: 50, vitaminC: 20)
+        let foodEntry = makeNutrientEntry(foodId: "f1", servings: 1)
+        let quickEntry = makeNutrientEntry(foodId: nil, servings: 2, quickCalories: 50, quickProtein: 5)
+
+        let totals = HealthKitService.nutrientTotals(
+            entries: [foodEntry, quickEntry],
+            foods: ["f1": food],
+            nutrients: HealthNutrient.all
+        )
+
+        #expect(totals["calories"] == 200)
+        #expect(totals["protein"] == 20)
+        #expect(totals["magnesium"] == 50)
+    }
+}
+
+// MARK: - Nutrient test helpers
+
+private func makeNutrientFood(
+    id: String,
+    calories: Double,
+    protein: Double,
+    magnesium: Double? = nil,
+    vitaminC: Double? = nil
+) -> Food {
+    Food(
+        id: id, userId: "u1", name: "Test Food", brand: nil,
+        servingSize: 100, servingUnit: .g,
+        calories: calories, protein: protein, carbs: 0, fat: 0, fiber: 0,
+        saturatedFat: nil, monounsaturatedFat: nil, polyunsaturatedFat: nil,
+        transFat: nil, cholesterol: nil, omega3: nil, omega6: nil,
+        sugar: nil, addedSugars: nil, sugarAlcohols: nil, starch: nil,
+        sodium: nil, potassium: nil, calcium: nil, iron: nil,
+        magnesium: magnesium, phosphorus: nil, zinc: nil, copper: nil,
+        manganese: nil, selenium: nil, iodine: nil, fluoride: nil,
+        chromium: nil, molybdenum: nil, chloride: nil,
+        vitaminA: nil, vitaminC: vitaminC, vitaminD: nil, vitaminE: nil,
+        vitaminK: nil, vitaminB1: nil, vitaminB2: nil, vitaminB3: nil,
+        vitaminB5: nil, vitaminB6: nil, vitaminB7: nil, vitaminB9: nil,
+        vitaminB12: nil, caffeine: nil, alcohol: nil, water: nil, salt: nil,
+        barcode: nil, isFavorite: false, nutriScore: nil, novaGroup: nil,
+        additives: nil, ingredientsText: nil, imageUrl: nil,
+        createdAt: nil, updatedAt: nil
+    )
+}
+
+private func makeNutrientEntry(
+    foodId: String?,
+    servings: Double,
+    calories: Double? = nil,
+    protein: Double? = nil,
+    quickCalories: Double? = nil,
+    quickProtein: Double? = nil
+) -> Entry {
+    Entry(
+        id: "e1", mealType: "lunch", servings: servings, notes: nil,
+        foodId: foodId, recipeId: nil,
+        quickName: nil, quickCalories: quickCalories,
+        quickProtein: quickProtein, quickCarbs: nil, quickFat: nil, quickFiber: nil,
+        foodName: nil, calories: calories, protein: protein,
+        carbs: nil, fat: nil, fiber: nil,
+        servingSize: nil, servingUnit: nil,
+        date: "2026-06-11", eatenAt: nil, createdAt: nil, updatedAt: nil
+    )
+}


### PR DESCRIPTION
## Summary

Adds a dedicated **Apple Health** subpage under Settings (iOS only), giving full visibility and control over what is read from and written to HealthKit.

Closes #268

### Settings subpage (`AppleHealthSettingsView`)
- New **Apple Health** section on the main Settings screen with a NavigationLink showing the connection status (Connected / Not connected)
- Status header with **Connect** / **Disconnect** actions — connect enables the weight import and requests read permission (mirroring the old master toggle); disconnect turns every sync toggle off (HealthKit offers no API to revoke permissions, the footer points to the Health app)
- **Reading from Health** section: body weight and sleep imports
- **Writing to Health** section: body weight and sleep write-back
- **Nutrients (Writing to Health)**: every dietary type HealthKit supports — macros, fat breakdown, 14 minerals, 13 vitamins, caffeine and water — grouped like the visible-nutrients page, with Select All / Deselect All
- Each row shows the display name, the raw HealthKit identifier, a read/write direction icon and the last-synced timestamp (when available)
- Existing UserDefaults keys are reused, so pre-existing weight/sleep settings carry over unchanged

### Nutrition write-back (new)
- `HealthNutrient` catalog (`HealthSyncTypes.swift`) maps app nutrient fields to `HKQuantityTypeIdentifier`s with the right units (g/mg/µg/kcal; water g→ml). Trans fat, omega-3/6, added sugars, sugar alcohols, starch, fluoride, alcohol and salt have no HealthKit dietary type and are deliberately absent
- `HealthKitService.syncNutrition` rewrites the app's own dietary samples for a day with fresh daily totals (delete-then-rewrite keeps Health consistent through edits, deletes and copies)
- `EntryRepository` triggers the day re-sync after create/update/delete/copy mutations, resolving micronutrients from the locally cached foods; recipe and quick entries contribute their resolved core macros
- Permissions are requested lazily — only when a type is enabled, one combined sheet for Select All

### Notes
- Issue's technical notes mention KMP `expect`/`actual` + SQLDelight, but the iOS app is pure SwiftUI without the KMP framework — preferences live in UserDefaults next to the existing HealthKit keys, matching current plumbing from #291
- Nutrient *reading* from Health isn't wired into the food log: imported nutrient samples have no food entries to attach to. Reads remain weight + sleep; nutrients are write-only (direction is indicated per row)
- Old unused `saveNutrition` plumbing removed; weight write authorization now requests body mass only

## Testing
- `xcodebuild build` (app + widget extension) succeeds for iPhone 16 simulator
- `xcodebuild test`: 263 tests pass (5 new suites/tests for the nutrient catalog and day-total aggregation)
- Verified on the simulator via UI automation: subpage renders (en/de), toggles persist across app restarts, connect/disconnect updates status and the Settings row
- swiftformat clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)