### PR TITLE
ci: publish iOS app to TestFlight on release

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -95,3 +95,137 @@ jobs:
           releaseFiles: mobile/androidApp/build/outputs/bundle/release/*.aab
           track: internal
           status: draft
+
+  ios-release:
+    runs-on: macos-15
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: mobile/iosApp
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # latest-stable Xcode, matching the iOS PR build (mobile-ios.yml).
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache Homebrew packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/xcodegen
+          key: brew-xcodegen-${{ runner.os }}
+
+      - name: Install XcodeGen
+        # Link explicitly: a cache-restored Cellar makes `brew install` skip
+        # linking, leaving xcodegen off PATH (see mobile-ios.yml).
+        run: |
+          brew install --formula xcodegen
+          brew link --overwrite xcodegen
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+
+      - name: Determine version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then
+            RAW="$REF_NAME"
+          else
+            RAW="$INPUT_VERSION"
+          fi
+          # CFBundleShortVersionString must be a numeric x.y.z — strip a leading v.
+          echo "marketing=${RAW#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Set up App Store Connect API key
+        env:
+          API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          # xcodebuild cloud signing and `altool` both auto-discover the key at
+          # ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8
+          echo "$API_KEY_BASE64" | openssl base64 -d \
+            > ~/.appstoreconnect/private_keys/AuthKey_"$KEY_ID".p8
+
+      - name: Inject team ID into ExportOptions.plist
+        env:
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          /usr/libexec/PlistBuddy -c "Add :teamID string $TEAM_ID" ExportOptions.plist \
+            || /usr/libexec/PlistBuddy -c "Set :teamID $TEAM_ID" ExportOptions.plist
+
+      - name: Archive
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          MARKETING_VERSION: ${{ steps.version.outputs.marketing }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        # -allowProvisioningUpdates + the API key = cloud signing: Xcode creates
+        # and manages the distribution cert and both app/widget profiles itself.
+        # CODE_SIGNING_ALLOWED=YES overrides the project default (NO) used by the
+        # unsigned PR/simulator build. The build number is the monotonic CI run
+        # number, so every upload is unique within a marketing version; it is
+        # applied to app and widget alike (their CFBundleVersion must match).
+        run: |
+          xcodebuild archive \
+            -project Bissbilanz.xcodeproj \
+            -scheme Bissbilanz \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/Bissbilanz.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_"$KEY_ID".p8 \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
+            CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGN_STYLE=Automatic \
+            DEVELOPMENT_TEAM="$TEAM_ID" \
+            MARKETING_VERSION="$MARKETING_VERSION" \
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+            SENTRY_DSN="$SENTRY_DSN"
+
+      - name: Export IPA
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Bissbilanz.xcarchive" \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_"$KEY_ID".p8 \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID"
+
+      - name: Upload to TestFlight
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          IPA=$(ls "$RUNNER_TEMP"/export/*.ipa | head -n1)
+          echo "Uploading $IPA"
+          xcrun altool --upload-app -f "$IPA" -t ios \
+            --apiKey "$KEY_ID" --apiIssuer "$ISSUER_ID"
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-ipa
+          path: ${{ runner.temp }}/export/*.ipa

--- a/mobile/iosApp/ExportOptions.plist
+++ b/mobile/iosApp/ExportOptions.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- TestFlight and App Store distribution share this export method. -->
+	<key>method</key>
+	<string>app-store-connect</string>
+	<!-- Cloud signing: Xcode creates and manages the distribution certificate
+	     and the app + widget provisioning profiles from the App Store Connect
+	     API key passed to xcodebuild. teamID is injected from a secret in CI
+	     (kept out of the repo). -->
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<!-- The build number is set explicitly in CI (CURRENT_PROJECT_VERSION from
+	     the run number); don't let export rewrite it. -->
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+	<!-- Upload dSYMs so Sentry / Xcode Organizer can symbolicate crashes. -->
+	<key>uploadSymbols</key>
+	<true/>
+	<key>destination</key>
+	<string>export</string>
+</dict>
+</plist>

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -51,6 +51,10 @@ targets:
         NSHealthShareUsageDescription: 'Bissbilanz reads your weight and sleep data to track trends'
         NSHealthUpdateUsageDescription: 'Bissbilanz saves nutrition, weight and sleep data to Health'
         SentryDSN: $(SENTRY_DSN)
+        # Only standard (exempt) HTTPS encryption is used, so declare no
+        # non-exempt encryption — TestFlight then skips the per-build
+        # export-compliance prompt that would otherwise block each upload.
+        ITSAppUsesNonExemptEncryption: false
     # properties must be declared here: xcodegen regenerates the entitlements
     # file on every `xcodegen generate` and would otherwise write it empty
     entitlements:


### PR DESCRIPTION
## What

Adds an iOS lane to the **Mobile Release** workflow that archives the SwiftUI app + widget extension with cloud-managed signing and uploads the build to **TestFlight** via the App Store Connect API. Runs in parallel with the existing Android lane.

## How to trigger

Same as Android: publish a GitHub release tagged `v*` (e.g. `v1.0.0`), or **Actions → Mobile Release → Run workflow**. After ~5–15 min of Apple processing, the build appears in App Store Connect → TestFlight; add it to an Internal Testing group to push to testers.

## Required GitHub secrets (all configured ✅)

| Secret | Purpose |
|---|---|
| `APP_STORE_CONNECT_API_KEY_BASE64` | base64 of the `.p8` API key |
| `APP_STORE_CONNECT_KEY_ID` | API Key ID |
| `APP_STORE_CONNECT_ISSUER_ID` | API Issuer ID |
| `APPLE_TEAM_ID` | `UJK3G8UPRQ` |
| `SENTRY_DSN` | optional — reused from Android, enables crash reports |

## Apple-side prerequisites (done)

- App Group `group.com.bissbilanz`
- App ID `com.bissbilanz.ios` — HealthKit + App Groups
- App ID `com.bissbilanz.ios.widgets` — App Groups
- App Store Connect app record + App Manager API key

## Files

- `.github/workflows/mobile-release.yml` — iOS archive + TestFlight upload job
- `mobile/iosApp/ExportOptions.plist` — App Store export config
- `mobile/iosApp/project.yml` — Sentry DSN injection + export-compliance flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)