### PR TITLE
fix(ci): untap unused Homebrew taps in Swift CodeQL job

### DIFF
--- a/.github/workflows/codeql-mobile.yml
+++ b/.github/workflows/codeql-mobile.yml
@@ -120,7 +120,14 @@ jobs:
           key: brew-xcodegen-${{ runner.os }}
 
       - name: Install XcodeGen
-        run: brew install --formula xcodegen
+        run: |
+          # The macOS runner ships unused aws/tap and azure/bicep taps that
+          # trigger untrusted-tap warnings as Homebrew moves to require tap
+          # trust. We only need xcodegen from the core tap, so drop them.
+          for tap in aws/tap azure/bicep; do
+            brew untap "$tap" 2>/dev/null || true
+          done
+          brew install --formula xcodegen
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
 


### PR DESCRIPTION
## What

The Swift CodeQL job's **Install XcodeGen** step emitted a Homebrew warning on every run:

> The following taps are not trusted: aws/tap azure/bicep …

The `macos-14` runner ships `aws/tap` and `azure/bicep` pre-installed. We don't use either — we only install `xcodegen` from the trusted core tap. As Homebrew transitions to `HOMEBREW_REQUIRE_TAP_TRUST` becoming the default (5.2 / 6.0), these pre-installed taps trigger the warning.

## Why this approach

Homebrew offers three paths: trust the taps, untap them, or set the deprecated `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`. Since we don't use these taps and the env-var workaround is explicitly "not recommended and will be removed," untapping is the forward-compatible fix. The per-tap `2>/dev/null || true` keeps it resilient to future runner images where a tap may already be absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)