### PR TITLE
ci: connect deploy job to home network via WireGuard

### DIFF
--- a/.github/workflows/deploy-connectivity.yml
+++ b/.github/workflows/deploy-connectivity.yml
@@ -45,11 +45,19 @@ jobs:
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT || '22' }}
         run: |
           echo "Probing $DEPLOY_HOST:$DEPLOY_PORT over the WireGuard tunnel..."
-          if ! banner=$(timeout 10 bash -c "exec 3<>/dev/tcp/$DEPLOY_HOST/$DEPLOY_PORT; head -1 <&3"); then
-            echo "::error::$DEPLOY_HOST:$DEPLOY_PORT is not reachable over the tunnel. Check the OPNsense outbound NAT (wg_ci net -> WAN) and the wg_ci pass rule (-> $DEPLOY_HOST:$DEPLOY_PORT)."
-            exit 1
+          if banner=$(timeout 10 bash -c "exec 3<>/dev/tcp/$DEPLOY_HOST/$DEPLOY_PORT; head -1 <&3"); then
+            echo "Reachable. Server responded: $banner"
+            exit 0
           fi
-          echo "Reachable. Server responded: $banner"
+          echo "Probe failed — diagnosing tunnel state:"
+          sudo wg show wg0
+          received=$(sudo wg show wg0 transfer | awk '{print $2}')
+          if [ "${received:-0}" -eq 0 ] 2>/dev/null; then
+            echo "::error::WireGuard handshake never completed (0 B received from the endpoint). The tunnel is not establishing, which is upstream of any NAT/firewall pass rule. On OPNsense check: (1) the github-ci peer is linked to the wg_ci instance, (2) the peer public key matches the runner's, (3) the instance is enabled and the service restarted, (4) the WAN rule allowing UDP to the wg_ci listen port is applied."
+          else
+            echo "::error::Tunnel is up (handshake OK) but $DEPLOY_HOST:$DEPLOY_PORT is unreachable. Check the OPNsense outbound NAT (wg_ci net -> WAN address) and the wg_ci pass rule (-> $DEPLOY_HOST:$DEPLOY_PORT)."
+          fi
+          exit 1
 
       - name: Disconnect WireGuard
         if: always() && steps.guard.outputs.available == 'true'

--- a/.github/workflows/deploy-connectivity.yml
+++ b/.github/workflows/deploy-connectivity.yml
@@ -1,0 +1,56 @@
+name: Deploy connectivity check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/docker.yml
+      - .github/workflows/deploy-connectivity.yml
+
+permissions: {}
+
+jobs:
+  connectivity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check secrets are available
+        id: guard
+        env:
+          WIREGUARD_CONFIG: ${{ secrets.WIREGUARD_CONFIG }}
+        run: |
+          if [ -z "$WIREGUARD_CONFIG" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Secrets unavailable (likely a fork PR) — skipping connectivity check."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Connect to home network via WireGuard
+        if: steps.guard.outputs.available == 'true'
+        env:
+          WIREGUARD_CONFIG: ${{ secrets.WIREGUARD_CONFIG }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wireguard-tools
+          umask 077
+          printf '%s' "$WIREGUARD_CONFIG" | base64 -d | sudo tee /etc/wireguard/wg0.conf > /dev/null
+          sudo wg-quick up wg0
+          sudo wg show
+
+      - name: Probe the server over the tunnel
+        if: steps.guard.outputs.available == 'true'
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT || '22' }}
+        run: |
+          echo "Probing $DEPLOY_HOST:$DEPLOY_PORT over the WireGuard tunnel..."
+          if ! banner=$(timeout 10 bash -c "exec 3<>/dev/tcp/$DEPLOY_HOST/$DEPLOY_PORT; head -1 <&3"); then
+            echo "::error::$DEPLOY_HOST:$DEPLOY_PORT is not reachable over the tunnel. Check the OPNsense outbound NAT (wg_ci net -> WAN) and the wg_ci pass rule (-> $DEPLOY_HOST:$DEPLOY_PORT)."
+            exit 1
+          fi
+          echo "Reachable. Server responded: $banner"
+
+      - name: Disconnect WireGuard
+        if: always() && steps.guard.outputs.available == 'true'
+        run: sudo wg-quick down wg0 || true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,10 +68,34 @@ jobs:
     if: github.event_name == 'release'
 
     steps:
+      - name: Connect to home network via WireGuard
+        env:
+          WIREGUARD_CONFIG: ${{ secrets.WIREGUARD_CONFIG }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wireguard-tools
+          umask 077
+          printf '%s' "$WIREGUARD_CONFIG" | base64 -d | sudo tee /etc/wireguard/wg0.conf > /dev/null
+          sudo wg-quick up wg0
+
       - name: Deploy to server
-        uses: appleboy/ssh-action@v1.2.5
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_KEY }}
-          script: deploy bissbilanz
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT || '22' }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          umask 077
+          printf '%s' "$DEPLOY_KEY" > deploy_key
+          chmod 600 deploy_key
+          ssh -i deploy_key \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new \
+            -o ConnectTimeout=30 \
+            -p "$DEPLOY_PORT" \
+            "$DEPLOY_USER@$DEPLOY_HOST" \
+            'deploy bissbilanz'
+
+      - name: Disconnect WireGuard
+        if: always()
+        run: sudo wg-quick down wg0 || true


### PR DESCRIPTION
## What

The release `deploy` job now connects through a WireGuard tunnel to the home OPNsense before SSHing to the server, instead of connecting directly via `appleboy/ssh-action`.

## Why

The server's firewall only allows SSH from the home public IP. The GitHub-hosted runner connects from arbitrary IPs, so the direct deploy was being blocked. Routing the deploy traffic through a dedicated WireGuard peer on the home network makes it egress via the whitelisted home IP (OPNsense outbound NAT), while a single-host firewall rule keeps the runner off the rest of the LAN.

## Changes

- Replace `appleboy/ssh-action` with native `ssh` (Docker container actions don't see the host's WireGuard interface).
- Bring up `wg-quick` from a base64 `WIREGUARD_CONFIG` secret, deploy, then tear the tunnel down (`if: always()`).
- Secrets read via `env:` (not interpolated into `run:`).

## Required secrets

- `WIREGUARD_CONFIG` (new) — base64 of the runner's WireGuard config; `AllowedIPs` scoped to the server IP only.
- `DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_KEY` — unchanged.
- `DEPLOY_PORT` (optional) — defaults to `22`.

## OPNsense side (one-time, done)

Dedicated `wg_ci` instance + single peer, WAN rule for the listen port, outbound NAT (`wg_ci net` → WAN address), and a single `wg_ci` pass rule to the server on port 22. Implicit deny blocks LAN access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)