### PR TITLE
fix(ios): use menu picker for meal type in entry sheets

### DIFF
--- a/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
@@ -29,20 +29,20 @@ struct EntryEditSheet: View {
                         .font(.headline)
                 }
 
-                Section(L10n.servings) {
+                Section {
                     Stepper(value: $servings, in: 0.25 ... 50, step: 0.25) {
-                        Text("\(servings, specifier: "%.2g")x")
-                            .fontWeight(.medium)
+                        HStack {
+                            Text(L10n.servings)
+                            Spacer()
+                            Text("\(servings, specifier: "%.2g")x")
+                                .fontWeight(.medium)
+                        }
                     }
-                }
-
-                Section(L10n.meal) {
                     Picker(L10n.meal, selection: $mealType) {
                         ForEach(mealTypes, id: \.self) { meal in
                             Text(L10n.mealName(meal)).tag(meal)
                         }
                     }
-                    .pickerStyle(.segmented)
                 }
             }
             .navigationTitle(L10n.editEntry)

--- a/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
@@ -24,15 +24,11 @@ struct QuickEntrySheet: View {
             Form {
                 Section {
                     TextField("Name", text: $name)
-                }
-
-                Section("Meal") {
-                    Picker("Meal", selection: $mealType) {
+                    Picker(L10n.meal, selection: $mealType) {
                         ForEach(mealTypes, id: \.self) { meal in
                             Text(L10n.mealName(meal)).tag(meal)
                         }
                     }
-                    .pickerStyle(.segmented)
                 }
 
                 Section(L10n.nutrition) {


### PR DESCRIPTION
## What

In the iOS quick-add and edit sheets, the meal-type selector was a segmented `Picker` (rendered as tabs) boxed in its own `Section` that wrapped nothing else.

This switches it to the default SwiftUI Form **menu/dropdown** picker and folds it into an adjacent section so it's no longer a section that just wraps a single control.

- `QuickEntrySheet`: meal picker now sits with the **Name** field; hardcoded `"Meal"` strings replaced with the localized `L10n.meal`.
- `EntryEditSheet`: meal picker now sits with **Servings** (stepper given a `Servings` label so the merged section reads cleanly without its own header).

## Why

A segmented control inside a Form, alone in its own titled section, is awkward — the idiomatic iOS Form control for picking one of a few options is the menu dropdown. Both sheets had the identical pattern, so both were updated to keep them consistent.

## Testing

- `xcodegen generate` + `xcodebuild` for the iOS Simulator → **BUILD SUCCEEDED**.
- swiftformat: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)