### PR TITLE
fix(ci): sign iOS release with self-managed distribution cert

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -200,19 +200,72 @@ jobs:
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             SENTRY_DSN="$SENTRY_DSN"
 
-      - name: Export IPA
+      - name: Import distribution certificate and profiles
         env:
-          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          PROFILE_APP_BASE64: ${{ secrets.IOS_PROFILE_APP_BASE64 }}
+          PROFILE_WIDGET_BASE64: ${{ secrets.IOS_PROFILE_WIDGET_BASE64 }}
+        # Manual export signing needs our Apple Distribution identity in a
+        # keychain and the App Store profiles installed where xcodebuild looks.
+        # A throwaway keychain keeps the private key off the persistent runner.
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PWD="$(openssl rand -base64 24)"
+          security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN"
+
+          CERT="$RUNNER_TEMP/dist.p12"
+          echo "$DIST_CERT_P12_BASE64" | base64 -d > "$CERT"
+          security import "$CERT" -k "$KEYCHAIN" -P "$DIST_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$CERT"
+          # Let codesign use the imported key without an interactive prompt, and
+          # add our keychain to the search list (keeping the existing ones).
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PWD" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed 's/"//g')
+
+          install_profile() {
+            local tmp uuid
+            tmp="$(mktemp "$RUNNER_TEMP"/prof.XXXXXX)"
+            echo "$1" | base64 -d > "$tmp"
+            uuid="$(security cms -D -i "$tmp" | plutil -extract UUID raw -o - -)"
+            mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+            cp "$tmp" "$HOME/Library/MobileDevice/Provisioning Profiles/$uuid.mobileprovision"
+            echo "installed profile $uuid"
+          }
+          install_profile "$PROFILE_APP_BASE64"
+          install_profile "$PROFILE_WIDGET_BASE64"
+
+          security find-identity -v -p codesigning "$KEYCHAIN"
+
+      - name: Export IPA
+        # Manual signing: export re-signs using the Apple Distribution identity
+        # imported above and the profiles named in ExportOptions.plist. No
+        # -allowProvisioningUpdates / API key here — that path used the flaky
+        # cloud-managed distribution certificate.
         run: |
           xcodebuild -exportArchive \
             -archivePath "$RUNNER_TEMP/Bissbilanz.xcarchive" \
             -exportOptionsPlist ExportOptions.plist \
-            -exportPath "$RUNNER_TEMP/export" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_"$KEY_ID".p8 \
-            -authenticationKeyID "$KEY_ID" \
-            -authenticationKeyIssuerID "$ISSUER_ID"
+            -exportPath "$RUNNER_TEMP/export"
+
+      - name: Verify distribution signature
+        # Fail fast and clearly if export did not produce a distribution-signed
+        # app (altool would otherwise reject it ~40s later with a vaguer error).
+        run: |
+          set -euo pipefail
+          IPA=$(ls "$RUNNER_TEMP"/export/*.ipa | head -n1)
+          unzip -q -o "$IPA" -d "$RUNNER_TEMP/verify"
+          APP=$(ls -d "$RUNNER_TEMP"/verify/Payload/*.app | head -n1)
+          AUTH=$(codesign -dvv "$APP" 2>&1 | grep '^Authority=' | head -n1 || true)
+          echo "$AUTH"
+          case "$AUTH" in
+            *"Apple Distribution"*) echo "OK: distribution-signed" ;;
+            *) echo "::error::Exported app is not distribution-signed: ${AUTH:-<none>}"; exit 1 ;;
+          esac
 
       - name: Upload to TestFlight
         env:

--- a/mobile/iosApp/ExportOptions.plist
+++ b/mobile/iosApp/ExportOptions.plist
@@ -5,12 +5,25 @@
 	<!-- TestFlight and App Store distribution share this export method. -->
 	<key>method</key>
 	<string>app-store-connect</string>
-	<!-- Cloud signing: Xcode creates and manages the distribution certificate
-	     and the app + widget provisioning profiles from the App Store Connect
-	     API key passed to xcodebuild. teamID is injected from a secret in CI
-	     (kept out of the repo). -->
+	<!-- Manual signing with a self-managed distribution identity. The CI job
+	     imports our Apple Distribution certificate (.p12) into a temporary
+	     keychain and installs these two App Store provisioning profiles before
+	     export; export then re-signs the app + widget with them. This avoids
+	     Xcode's cloud-managed distribution certificate, whose private key lives
+	     in Apple's signing service and intermittently fails to be re-fetched on
+	     ephemeral CI runners (which produced dev-signed IPAs that App Store
+	     Connect rejects). teamID is injected from a secret in CI. -->
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.bissbilanz.ios</key>
+		<string>Bissbilanz iOS App Store</string>
+		<key>com.bissbilanz.ios.widgets</key>
+		<string>Bissbilanz Widgets App Store</string>
+	</dict>
 	<!-- The build number is set explicitly in CI (CURRENT_PROJECT_VERSION from
 	     the run number); don't let export rewrite it. -->
 	<key>manageAppVersionAndBuildNumber</key>


### PR DESCRIPTION
## Problem

The iOS TestFlight upload started failing (v1.19.1, v1.19.2) with `Invalid Signature … not properly signed … sign with a distribution certificate`. v1.19.0 was fine — I confirmed by downloading its artifact: `Authority=Apple Distribution: ORELL Bühler`.

Root cause: the release used Xcode **cloud-managed** distribution signing (`-allowProvisioningUpdates` + ASC API key, `signingStyle: automatic`). The managed distribution certificate's private key lives in Apple's signing service and isn't reliably re-fetched on ephemeral runners. When it can't be obtained, `xcodebuild -exportArchive` silently keeps the archive's **development** signature and still prints `EXPORT SUCCEEDED`, so App Store Connect rejects the upload. (The recently-added altool error check is what finally surfaced it; before, the bad upload exited 0 and went green.)

## Fix

Switch the release to a **self-managed Apple Distribution identity**:

- `ExportOptions.plist`: `signingStyle: manual`, `signingCertificate: Apple Distribution`, explicit `provisioningProfiles` map for `com.bissbilanz.ios` + `com.bissbilanz.ios.widgets`.
- New CI step imports the `.p12` into a throwaway keychain and installs both App Store profiles before export; the Export step drops the cloud-signing flags.
- New **Verify distribution signature** step fails fast (`codesign` → `Apple Distribution`) instead of letting altool reject it ~40s later.

The Archive step is unchanged (cloud dev-signing is reliable; export re-signs for distribution).

## New repo secrets (already set)

`IOS_DIST_CERT_P12_BASE64`, `IOS_DIST_CERT_PASSWORD`, `IOS_PROFILE_APP_BASE64`, `IOS_PROFILE_WIDGET_BASE64`.

The Apple Distribution cert (`XKH6GR99QB`) and both App Store profiles were created via the ASC API and **expire 2027-06-15** (standard 1-year validity) — will need renewal then. The old `Distribution Managed` cert is now unused and can be left as-is.

## Verification

- `.p12` imports into a macOS keychain and `security find-identity` resolves the `Apple Distribution: ORELL Bühler` identity.
- Both profiles carry the correct app-ids and embed the new cert.
- Workflow YAML is prettier-clean; `ExportOptions.plist` passes `plutil -lint`.
- End-to-end signing will be exercised by the next release / a `workflow_dispatch` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)