### PR TITLE
fix: repair Dexie supplementLogs migration and dead auth-redirect guard

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -148,7 +148,11 @@ const sessionHandle: Handle = async ({ event, resolve }) => {
 		: pathname === '/de'
 			? '/'
 			: pathname;
-	const isPublicRoute = PUBLIC_PATHS.some((p) => stripped.startsWith(p));
+	// '/' must match exactly: every path starts with '/', so treating it as a
+	// startsWith prefix would mark all routes public and defeat the guard below
+	// (which is what happened after authenticated routes moved to the root).
+	const isPublicRoute =
+		stripped === '/' || PUBLIC_PATHS.some((p) => p !== '/' && stripped.startsWith(p));
 
 	if (!isPublicRoute && !event.locals.user) {
 		throw redirect(302, '/login');

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -59,17 +59,18 @@ db.version(3).stores({
 	sleepEntries: 'id, entryDate, loggedAt'
 });
 
-// v4: supplements are now nutrient-backed (kind on foods). supplementLogs keyed by
-// (supplementId, date) since per-day-per-supplement uniqueness. Existing foods
-// rows from v3 lack `kind` — backfill with 'food' so kind-filtered queries
-// don't hide them. Old logs are cleared — the server will resync on next fetch.
+// v4: supplements are now nutrient-backed (kind on foods). Existing foods rows
+// from v3 lack `kind` — backfill with 'food' so kind-filtered queries don't hide
+// them. supplementLogs is DROPPED here (recreated in v6 with a compound key):
+// Dexie cannot change a table's primary key in place, so the old `id`-keyed table
+// must be deleted and re-added across two versions. Old logs are discarded — the
+// server resyncs them on next fetch.
 db.version(4)
 	.stores({
 		foods: 'id, name, barcode, isFavorite, kind, updatedAt',
-		supplementLogs: '[supplementId+date], supplementId, date'
+		supplementLogs: null
 	})
 	.upgrade(async (tx) => {
-		await tx.table('supplementLogs').clear();
 		await tx
 			.table('foods')
 			.toCollection()
@@ -82,6 +83,15 @@ db.version(4)
 // instead of deleted, so the user can retry or discard them explicitly.
 db.version(5).stores({
 	syncQueue: '++id, createdAt, failedAt'
+});
+
+// v6: recreate supplementLogs with a compound primary key ([supplementId+date]) —
+// one log per supplement per day. Split from v4's drop because Dexie models a
+// primary-key change as delete-then-create across separate versions. Users
+// upgrading from schema v1–v3 previously crashed here with "Not yet support for
+// changing primary key" (Sentry BISSBILANZ-1T); fresh installs are unaffected.
+db.version(6).stores({
+	supplementLogs: '[supplementId+date], supplementId, date'
 });
 
 export { db };

--- a/tests/utils/dexie-migration.test.ts
+++ b/tests/utils/dexie-migration.test.ts
@@ -1,0 +1,61 @@
+import 'fake-indexeddb/auto';
+import { describe, expect, test } from 'vitest';
+import Dexie from 'dexie';
+
+// Regression test for Sentry BISSBILANZ-1T:
+//   "DatabaseClosedError: UpgradeError Not yet support for changing primary key".
+// The v4 migration originally changed supplementLogs' primary key from `id` to the
+// compound [supplementId+date] in place, which Dexie cannot do. Any user whose
+// IndexedDB was created at schema v1–v3 crashed on upgrade. The fix drops the table
+// in v4 and recreates it in v6. This seeds a legacy v1 database (the broken shape)
+// and verifies the app's schema opens without throwing.
+
+const DB_NAME = 'bissbilanz';
+
+// The exact v1 schema as originally shipped — supplementLogs keyed by `id`.
+async function seedLegacyV1Database() {
+	const legacy = new Dexie(DB_NAME);
+	legacy.version(1).stores({
+		foods: 'id, name, barcode, isFavorite, updatedAt',
+		foodEntries: 'id, date, mealType, foodId, recipeId, createdAt',
+		recipes: 'id, name, isFavorite, updatedAt',
+		recipeIngredients: 'id, recipeId, foodId',
+		userGoals: 'userId',
+		userPreferences: 'userId',
+		customMealTypes: 'id, sortOrder',
+		supplements: 'id, isActive, sortOrder',
+		supplementLogs: 'id, supplementId, date, [supplementId+date]',
+		weightEntries: 'id, entryDate, loggedAt',
+		syncQueue: '++id, createdAt',
+		syncMeta: 'tableName'
+	});
+	await legacy.open();
+	// A row keyed by the old `id` primary key — the data shape that broke the upgrade.
+	await legacy.table('supplementLogs').add({
+		id: 'log-1',
+		supplementId: 's1',
+		date: '2026-01-01',
+		count: 1
+	});
+	legacy.close();
+}
+
+describe('Dexie schema migration (BISSBILANZ-1T)', () => {
+	test('upgrades a legacy v1 database (supplementLogs keyed by id) without error', async () => {
+		await seedLegacyV1Database();
+
+		// Import after seeding so the app db opens against the legacy IndexedDB.
+		const { db } = await import('../../src/lib/db/index');
+		await expect(db.open()).resolves.toBeDefined();
+		expect(db.verno).toBe(6);
+
+		// supplementLogs was dropped (v4) and recreated (v6): old rows are gone and
+		// the table now accepts the compound primary key.
+		expect(await db.table('supplementLogs').count()).toBe(0);
+		await db.table('supplementLogs').add({ supplementId: 's1', date: '2026-01-01', count: 2 });
+		const row = await db.table('supplementLogs').get(['s1', '2026-01-01']);
+		expect(row?.count).toBe(2);
+
+		db.close();
+	});
+});


### PR DESCRIPTION
Fixes two production errors surfaced in Sentry.

## 1. Dexie `supplementLogs` migration crash — `BISSBILANZ-1T`
`DatabaseClosedError: UpgradeError Not yet support for changing primary key`

The `v4` migration changed `supplementLogs`' primary key in place (`id` → `[supplementId+date]`), which Dexie does not support. Any client whose IndexedDB was created at schema **v1–v3** crashed when upgrading, breaking offline mode. (Latent since the v4 migration landed on 2026-04-22; only surfaces when an old-schema client reloads.)

**Fix:** drop the table in `v4` and recreate it with the compound key in a new `v6` — the canonical Dexie delete-then-recreate pattern. Old logs are discarded (the server resyncs them), same as the original intent.

Adds `tests/utils/dexie-migration.test.ts`, which seeds a legacy v1 database and asserts the upgrade succeeds. Verified the test reproduces the exact `UpgradeError` against the old schema and passes against the fix.

## 2. Dead auth-redirect guard → 500 on protected routes — `BISSBILANZ-1Q`
`TypeError: undefined is not an object (evaluating 'locals.user.id')`

Since authenticated routes moved to the root (refactor on 2026-02-22), `'/'` in `PUBLIC_PATHS` matched **every** path via `startsWith`, so `isPublicRoute` was always true and the `→ /login` redirect for unauthenticated users became dead code. Unauthenticated requests to protected routes reached the page load and 500'd on `locals.user!.id` instead of redirecting. This also affected `insights`, `maintenance`, and `settings/mcp`.

**Fix:** match `'/'` exactly so the landing page stays public while protected routes redirect as intended.

## Verification
- `bun run check` → 0 errors
- Full unit suite → 1800/1800 passing