### PR TITLE
feat(ios): consume shared KMP analytics on iOS (re-link framework + SKIE)

### DIFF
--- a/.github/workflows/mobile-ios.yml
+++ b/.github/workflows/mobile-ios.yml
@@ -86,9 +86,13 @@ jobs:
       - name: Build iOS app
         working-directory: mobile/iosApp
         run: |
+          # The staged shared.framework is the arm64 simulator slice and the
+          # runner is arm64, so build arm64-only — otherwise the generic
+          # Simulator destination also builds x86_64 and can't find a slice.
           xcodebuild build \
             -project Bissbilanz.xcodeproj \
             -scheme Bissbilanz \
             -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -132,6 +132,38 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
 
+      # The app links the KMP shared framework, so build and stage it for the
+      # Release/device archive (mirrors mobile-ios.yml's debug/simulator steps).
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Cache Gradle and Kotlin/Native dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.gradle/build-cache
+            ~/.konan
+          key: gradle-ios-release-${{ runner.os }}-${{ hashFiles('mobile/**/*.gradle*', 'mobile/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-ios-release-${{ runner.os }}-
+
+      - name: Build shared iOS framework (release, device)
+        working-directory: mobile
+        run: ./gradlew shared:linkReleaseFrameworkIosArm64
+
+      - name: Stage shared framework for Xcode
+        working-directory: mobile
+        run: |
+          SDK_NAME=$(xcrun --sdk iphoneos --show-sdk-version)
+          DEST="shared/build/xcode-frameworks/Release/iphoneos${SDK_NAME}"
+          mkdir -p "$DEST"
+          cp -R shared/build/bin/iosArm64/releaseFramework/shared.framework "$DEST/"
+
       - name: Determine version
         id: version
         env:

--- a/analytics-parity/README.md
+++ b/analytics-parity/README.md
@@ -1,0 +1,29 @@
+# Analytics parity (golden vectors)
+
+The maintenance / TDEE / prediction analytics live in **two** implementations that
+must stay numerically identical:
+
+- **TypeScript** — `src/lib/analytics/` (used by the SvelteKit server and web app).
+- **Kotlin** — `mobile/shared/src/commonMain/kotlin/com/bissbilanz/analytics/`
+  (the shared KMP module, consumed by the Android **and** iOS apps).
+
+`fixtures/golden-vectors.json` is a frozen, language-neutral set of
+`{ fn, input, expected }` cases. Both languages run the same inputs through their
+own implementation and assert the output matches `expected` within tolerance, so
+any drift between the server's TS and the mobile apps' Kotlin fails CI:
+
+- TypeScript: `tests/analytics/parity.test.ts` (vitest).
+- Kotlin: `mobile/shared/src/androidUnitTest/.../AnalyticsParityTest.kt` (JVM unit test).
+
+## Regenerating
+
+The fixtures are generated from the **TypeScript** implementation (the server is the
+source of truth for the wire-facing numbers) and then frozen:
+
+```bash
+bun run analytics-parity/generate.ts
+```
+
+This rewrites `fixtures/golden-vectors.json`. Only regenerate when an analytics
+formula intentionally changes — then run the Kotlin parity test to confirm the
+shared module still matches, and review the JSON diff as part of the change.

--- a/analytics-parity/fixtures/golden-vectors.json
+++ b/analytics-parity/fixtures/golden-vectors.json
@@ -1,0 +1,1047 @@
+{
+	"version": 1,
+	"description": "Frozen golden vectors locking the shared Kotlin analytics to the TypeScript analytics. Generated from the TS implementation by analytics-parity/generate.ts — do not hand-edit.",
+	"tolerances": {
+		"default": 1e-9,
+		"pValue": 1e-7
+	},
+	"cases": [
+		{
+			"fn": "pearsonCorrelation",
+			"name": "perfect_positive",
+			"input": {
+				"x": [1, 2, 3, 4, 5, 6, 7, 8],
+				"y": [2, 4, 6, 8, 10, 12, 14, 16]
+			},
+			"expected": {
+				"r": 1,
+				"pValue": 3.1249999991797647e-31,
+				"sampleSize": 8,
+				"confidence": "low",
+				"constantInput": false
+			}
+		},
+		{
+			"fn": "pearsonCorrelation",
+			"name": "perfect_negative",
+			"input": {
+				"x": [1, 2, 3, 4, 5, 6, 7, 8],
+				"y": [16, 14, 12, 10, 8, 6, 4, 2]
+			},
+			"expected": {
+				"r": -1,
+				"pValue": 3.1249999991797647e-31,
+				"sampleSize": 8,
+				"confidence": "low",
+				"constantInput": false
+			}
+		},
+		{
+			"fn": "pearsonCorrelation",
+			"name": "anscombe_like_n11",
+			"input": {
+				"x": [10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5],
+				"y": [8.04, 6.95, 7.58, 8.81, 8.33, 9.96, 7.24, 4.26, 10.84, 4.82, 5.68]
+			},
+			"expected": {
+				"r": 0.81642051634484,
+				"pValue": 0.0021696288710180995,
+				"sampleSize": 11,
+				"confidence": "low",
+				"constantInput": false
+			}
+		},
+		{
+			"fn": "pearsonCorrelation",
+			"name": "constant_input",
+			"input": {
+				"x": [3, 3, 3, 3, 3, 3, 3],
+				"y": [1, 2, 3, 4, 5, 6, 7]
+			},
+			"expected": {
+				"r": 0,
+				"pValue": 1,
+				"sampleSize": 7,
+				"confidence": "insufficient",
+				"constantInput": true
+			}
+		},
+		{
+			"fn": "pearsonCorrelation",
+			"name": "n_le_2",
+			"input": {
+				"x": [1, 2],
+				"y": [5, 9]
+			},
+			"expected": {
+				"r": 1,
+				"pValue": 1,
+				"sampleSize": 2,
+				"confidence": "insufficient",
+				"constantInput": false
+			}
+		},
+		{
+			"fn": "movingAverage",
+			"name": "window7_dense",
+			"input": {
+				"series": [70, 70.2, 69.8, 70.1, 69.9, 70, 69.7, 69.5, 69.6, 69.4],
+				"windowSize": 7
+			},
+			"expected": [
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				69.95714285714286,
+				69.88571428571429,
+				69.79999999999998,
+				69.74285714285713
+			]
+		},
+		{
+			"fn": "movingAverage",
+			"name": "window3_with_nulls",
+			"input": {
+				"series": [1, null, 3, null, 5, 6, null, 8, 9, 10],
+				"windowSize": 3
+			},
+			"expected": [null, null, 2, 3, 4, 5.5, 5.5, 7, 8.5, 9]
+		},
+		{
+			"fn": "computeAdaptiveTDEE",
+			"name": "loss_21d",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 82
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 81.95
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 81.9
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 81.85
+					},
+					{
+						"date": "2025-01-05",
+						"weightKg": 81.8
+					},
+					{
+						"date": "2025-01-06",
+						"weightKg": 81.75
+					},
+					{
+						"date": "2025-01-07",
+						"weightKg": 81.7
+					},
+					{
+						"date": "2025-01-08",
+						"weightKg": 81.65
+					},
+					{
+						"date": "2025-01-09",
+						"weightKg": 81.6
+					},
+					{
+						"date": "2025-01-10",
+						"weightKg": 81.55
+					},
+					{
+						"date": "2025-01-11",
+						"weightKg": 81.5
+					},
+					{
+						"date": "2025-01-12",
+						"weightKg": 81.45
+					},
+					{
+						"date": "2025-01-13",
+						"weightKg": 81.4
+					},
+					{
+						"date": "2025-01-14",
+						"weightKg": 81.35
+					},
+					{
+						"date": "2025-01-15",
+						"weightKg": 81.3
+					},
+					{
+						"date": "2025-01-16",
+						"weightKg": 81.25
+					},
+					{
+						"date": "2025-01-17",
+						"weightKg": 81.2
+					},
+					{
+						"date": "2025-01-18",
+						"weightKg": 81.15
+					},
+					{
+						"date": "2025-01-19",
+						"weightKg": 81.1
+					},
+					{
+						"date": "2025-01-20",
+						"weightKg": 81.05
+					},
+					{
+						"date": "2025-01-21",
+						"weightKg": 81
+					}
+				],
+				"calorieSeries": [
+					{
+						"date": "2025-01-01",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-02",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-03",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-04",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-05",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-06",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-07",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-08",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-09",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-10",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-11",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-12",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-13",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-14",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-15",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-16",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-17",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-18",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-19",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-20",
+						"calories": 2100
+					},
+					{
+						"date": "2025-01-21",
+						"calories": 2100
+					}
+				],
+				"windowDays": 14
+			},
+			"expected": {
+				"estimatedTDEE": 2485.0000000000014,
+				"trend": "loss",
+				"avgIntake": 2100,
+				"weeklyRate": -0.3500000000000011,
+				"confidence": "medium",
+				"sampleSize": 15
+			}
+		},
+		{
+			"fn": "computeAdaptiveTDEE",
+			"name": "insufficient",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 80
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 79.9
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 79.8
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 79.7
+					}
+				],
+				"calorieSeries": [
+					{
+						"date": "2025-01-01",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-02",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-03",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-04",
+						"calories": 2000
+					}
+				],
+				"windowDays": 14
+			},
+			"expected": {
+				"estimatedTDEE": null,
+				"trend": "maintenance",
+				"avgIntake": 2000,
+				"weeklyRate": 0,
+				"confidence": "insufficient",
+				"sampleSize": 4
+			}
+		},
+		{
+			"fn": "computeAdaptiveTDEE",
+			"name": "gain_variable_intake",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 75
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 75.04
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 75.08
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 75.12
+					},
+					{
+						"date": "2025-01-05",
+						"weightKg": 75.16
+					},
+					{
+						"date": "2025-01-06",
+						"weightKg": 75.2
+					},
+					{
+						"date": "2025-01-07",
+						"weightKg": 75.24
+					},
+					{
+						"date": "2025-01-08",
+						"weightKg": 75.28
+					},
+					{
+						"date": "2025-01-09",
+						"weightKg": 75.32
+					},
+					{
+						"date": "2025-01-10",
+						"weightKg": 75.36
+					},
+					{
+						"date": "2025-01-11",
+						"weightKg": 75.4
+					},
+					{
+						"date": "2025-01-12",
+						"weightKg": 75.44
+					},
+					{
+						"date": "2025-01-13",
+						"weightKg": 75.48
+					},
+					{
+						"date": "2025-01-14",
+						"weightKg": 75.52
+					},
+					{
+						"date": "2025-01-15",
+						"weightKg": 75.56
+					},
+					{
+						"date": "2025-01-16",
+						"weightKg": 75.6
+					},
+					{
+						"date": "2025-01-17",
+						"weightKg": 75.64
+					},
+					{
+						"date": "2025-01-18",
+						"weightKg": 75.68
+					}
+				],
+				"calorieSeries": [
+					{
+						"date": "2025-01-01",
+						"calories": 2600
+					},
+					{
+						"date": "2025-01-02",
+						"calories": 2720
+					},
+					{
+						"date": "2025-01-03",
+						"calories": 2840
+					},
+					{
+						"date": "2025-01-04",
+						"calories": 2600
+					},
+					{
+						"date": "2025-01-05",
+						"calories": 2720
+					},
+					{
+						"date": "2025-01-06",
+						"calories": 2840
+					},
+					{
+						"date": "2025-01-07",
+						"calories": 2600
+					},
+					{
+						"date": "2025-01-08",
+						"calories": 2720
+					},
+					{
+						"date": "2025-01-09",
+						"calories": 2840
+					},
+					{
+						"date": "2025-01-10",
+						"calories": 2600
+					},
+					{
+						"date": "2025-01-11",
+						"calories": 2720
+					},
+					{
+						"date": "2025-01-12",
+						"calories": 2840
+					},
+					{
+						"date": "2025-01-13",
+						"calories": 2600
+					},
+					{
+						"date": "2025-01-14",
+						"calories": 2720
+					},
+					{
+						"date": "2025-01-15",
+						"calories": 2840
+					},
+					{
+						"date": "2025-01-16",
+						"calories": 2600
+					},
+					{
+						"date": "2025-01-17",
+						"calories": 2720
+					},
+					{
+						"date": "2025-01-18",
+						"calories": 2840
+					}
+				],
+				"windowDays": 14
+			},
+			"expected": {
+				"estimatedTDEE": 2411.999999999999,
+				"trend": "gain",
+				"avgIntake": 2720,
+				"weeklyRate": 0.2800000000000008,
+				"confidence": "medium",
+				"sampleSize": 15
+			}
+		},
+		{
+			"fn": "detectPlateau",
+			"name": "plateau_adaptive",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-05",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-06",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-07",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-08",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-09",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-10",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-11",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-12",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-13",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-14",
+						"weightKg": 78
+					}
+				],
+				"calorieSeries": [
+					{
+						"date": "2025-01-01",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-02",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-03",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-04",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-05",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-06",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-07",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-08",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-09",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-10",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-11",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-12",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-13",
+						"calories": 2200
+					},
+					{
+						"date": "2025-01-14",
+						"calories": 2200
+					}
+				],
+				"estimatedTDEE": 2200,
+				"sodiumAvg": null
+			},
+			"expected": {
+				"isPlateaued": true,
+				"plateauDays": 14,
+				"estimatedDeficit": 0,
+				"cause": "none",
+				"confidence": "medium",
+				"sampleSize": 14
+			}
+		},
+		{
+			"fn": "detectPlateau",
+			"name": "plateau_intake_variance",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-05",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-06",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-07",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-08",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-09",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-10",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-11",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-12",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-13",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-14",
+						"weightKg": 78
+					}
+				],
+				"calorieSeries": [
+					{
+						"date": "2025-01-01",
+						"calories": 1500
+					},
+					{
+						"date": "2025-01-02",
+						"calories": 2900
+					},
+					{
+						"date": "2025-01-03",
+						"calories": 1500
+					},
+					{
+						"date": "2025-01-04",
+						"calories": 2900
+					},
+					{
+						"date": "2025-01-05",
+						"calories": 1500
+					},
+					{
+						"date": "2025-01-06",
+						"calories": 2900
+					},
+					{
+						"date": "2025-01-07",
+						"calories": 1500
+					},
+					{
+						"date": "2025-01-08",
+						"calories": 2900
+					},
+					{
+						"date": "2025-01-09",
+						"calories": 1500
+					},
+					{
+						"date": "2025-01-10",
+						"calories": 2900
+					},
+					{
+						"date": "2025-01-11",
+						"calories": 1500
+					},
+					{
+						"date": "2025-01-12",
+						"calories": 2900
+					},
+					{
+						"date": "2025-01-13",
+						"calories": 1500
+					},
+					{
+						"date": "2025-01-14",
+						"calories": 2900
+					}
+				],
+				"estimatedTDEE": 2300,
+				"sodiumAvg": null
+			},
+			"expected": {
+				"isPlateaued": true,
+				"plateauDays": 14,
+				"estimatedDeficit": 100,
+				"cause": "intake_variance",
+				"confidence": "medium",
+				"sampleSize": 14
+			}
+		},
+		{
+			"fn": "detectPlateau",
+			"name": "not_plateau",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 78
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 77.94
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 77.88
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 77.82
+					},
+					{
+						"date": "2025-01-05",
+						"weightKg": 77.76
+					},
+					{
+						"date": "2025-01-06",
+						"weightKg": 77.7
+					},
+					{
+						"date": "2025-01-07",
+						"weightKg": 77.64
+					},
+					{
+						"date": "2025-01-08",
+						"weightKg": 77.58
+					},
+					{
+						"date": "2025-01-09",
+						"weightKg": 77.52
+					},
+					{
+						"date": "2025-01-10",
+						"weightKg": 77.46
+					},
+					{
+						"date": "2025-01-11",
+						"weightKg": 77.4
+					},
+					{
+						"date": "2025-01-12",
+						"weightKg": 77.34
+					},
+					{
+						"date": "2025-01-13",
+						"weightKg": 77.28
+					},
+					{
+						"date": "2025-01-14",
+						"weightKg": 77.22
+					}
+				],
+				"calorieSeries": [
+					{
+						"date": "2025-01-01",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-02",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-03",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-04",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-05",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-06",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-07",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-08",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-09",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-10",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-11",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-12",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-13",
+						"calories": 2000
+					},
+					{
+						"date": "2025-01-14",
+						"calories": 2000
+					}
+				],
+				"estimatedTDEE": 2400,
+				"sodiumAvg": null
+			},
+			"expected": {
+				"isPlateaued": false,
+				"plateauDays": 0,
+				"estimatedDeficit": null,
+				"cause": "none",
+				"confidence": "medium",
+				"sampleSize": 14
+			}
+		},
+		{
+			"fn": "projectWeight",
+			"name": "loss_-0.49wk",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 90
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 89.93
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 89.86
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 89.79
+					},
+					{
+						"date": "2025-01-05",
+						"weightKg": 89.72
+					},
+					{
+						"date": "2025-01-06",
+						"weightKg": 89.65
+					},
+					{
+						"date": "2025-01-07",
+						"weightKg": 89.58
+					},
+					{
+						"date": "2025-01-08",
+						"weightKg": 89.51
+					},
+					{
+						"date": "2025-01-09",
+						"weightKg": 89.44
+					},
+					{
+						"date": "2025-01-10",
+						"weightKg": 89.37
+					},
+					{
+						"date": "2025-01-11",
+						"weightKg": 89.3
+					},
+					{
+						"date": "2025-01-12",
+						"weightKg": 89.23
+					},
+					{
+						"date": "2025-01-13",
+						"weightKg": 89.16
+					},
+					{
+						"date": "2025-01-14",
+						"weightKg": 89.09
+					},
+					{
+						"date": "2025-01-15",
+						"weightKg": 89.02
+					},
+					{
+						"date": "2025-01-16",
+						"weightKg": 88.95
+					},
+					{
+						"date": "2025-01-17",
+						"weightKg": 88.88
+					},
+					{
+						"date": "2025-01-18",
+						"weightKg": 88.81
+					},
+					{
+						"date": "2025-01-19",
+						"weightKg": 88.74
+					},
+					{
+						"date": "2025-01-20",
+						"weightKg": 88.67
+					}
+				],
+				"weeklyRate": -0.49
+			},
+			"expected": {
+				"currentWeight": 88.67,
+				"weeklyRate": -0.49,
+				"day30": 86.57000000000001,
+				"day60": 84.47,
+				"day90": 82.37,
+				"sampleSize": 20,
+				"confidence": "medium"
+			}
+		},
+		{
+			"fn": "projectWeight",
+			"name": "flat_low_sample",
+			"input": {
+				"weightSeries": [
+					{
+						"date": "2025-01-01",
+						"weightKg": 70
+					},
+					{
+						"date": "2025-01-02",
+						"weightKg": 70
+					},
+					{
+						"date": "2025-01-03",
+						"weightKg": 70
+					},
+					{
+						"date": "2025-01-04",
+						"weightKg": 70
+					},
+					{
+						"date": "2025-01-05",
+						"weightKg": 70
+					}
+				],
+				"weeklyRate": 0
+			},
+			"expected": {
+				"currentWeight": 70,
+				"weeklyRate": 0,
+				"day30": 70,
+				"day60": 70,
+				"day90": 70,
+				"sampleSize": 5,
+				"confidence": "insufficient"
+			}
+		}
+	]
+}

--- a/analytics-parity/generate.ts
+++ b/analytics-parity/generate.ts
@@ -1,0 +1,167 @@
+/**
+ * Generates the frozen golden-vector fixtures from the TypeScript analytics.
+ * Run with: `bun run analytics-parity/generate.ts`
+ *
+ * The fixtures lock the shared Kotlin analytics to the TS analytics — see
+ * analytics-parity/README.md. Keep this file dependency-free (pure imports of
+ * the analytics modules) so it runs without the SvelteKit runtime.
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { pearsonCorrelation } from '../src/lib/analytics/correlation';
+import { movingAverage } from '../src/lib/analytics/moving-average';
+import { computeAdaptiveTDEE, detectPlateau, projectWeight } from '../src/lib/analytics/tdee';
+
+type Case = { fn: string; name: string; input: Record<string, unknown>; expected: unknown };
+
+const cases: Case[] = [];
+const add = (fn: string, name: string, input: Record<string, unknown>, expected: unknown) =>
+	cases.push({ fn, name, input, expected });
+
+// --- helpers to build deterministic series (no Date.now / randomness) -------
+function weightSeries(days: number, startKg: number, dailyChangeKg: number) {
+	return Array.from({ length: days }, (_, i) => ({
+		date: isoDay(i),
+		weightKg: round(startKg + dailyChangeKg * i, 4)
+	}));
+}
+function calorieSeries(days: number, kcal: (i: number) => number) {
+	return Array.from({ length: days }, (_, i) => ({ date: isoDay(i), calories: kcal(i) }));
+}
+function isoDay(i: number): string {
+	// Fixed anchor; pure string math via UTC epoch days.
+	const d = new Date(Date.UTC(2025, 0, 1) + i * 86400000);
+	return d.toISOString().slice(0, 10);
+}
+function round(v: number, dp: number): number {
+	const f = 10 ** dp;
+	return Math.round(v * f) / f;
+}
+
+// --- pearsonCorrelation -----------------------------------------------------
+{
+	const x1 = [1, 2, 3, 4, 5, 6, 7, 8];
+	const y1 = [2, 4, 6, 8, 10, 12, 14, 16];
+	add('pearsonCorrelation', 'perfect_positive', { x: x1, y: y1 }, pearsonCorrelation(x1, y1));
+
+	const x2 = [1, 2, 3, 4, 5, 6, 7, 8];
+	const y2 = [16, 14, 12, 10, 8, 6, 4, 2];
+	add('pearsonCorrelation', 'perfect_negative', { x: x2, y: y2 }, pearsonCorrelation(x2, y2));
+
+	const x3 = [10, 8, 13, 9, 11, 14, 6, 4, 12, 7, 5];
+	const y3 = [8.04, 6.95, 7.58, 8.81, 8.33, 9.96, 7.24, 4.26, 10.84, 4.82, 5.68];
+	add('pearsonCorrelation', 'anscombe_like_n11', { x: x3, y: y3 }, pearsonCorrelation(x3, y3));
+
+	const x4 = [3, 3, 3, 3, 3, 3, 3];
+	const y4 = [1, 2, 3, 4, 5, 6, 7];
+	add('pearsonCorrelation', 'constant_input', { x: x4, y: y4 }, pearsonCorrelation(x4, y4));
+
+	const x5 = [1, 2];
+	const y5 = [5, 9];
+	add('pearsonCorrelation', 'n_le_2', { x: x5, y: y5 }, pearsonCorrelation(x5, y5));
+}
+
+// --- movingAverage ----------------------------------------------------------
+{
+	const s1 = [70, 70.2, 69.8, 70.1, 69.9, 70.0, 69.7, 69.5, 69.6, 69.4];
+	add('movingAverage', 'window7_dense', { series: s1, windowSize: 7 }, movingAverage(s1, 7));
+
+	const s2 = [1, null, 3, null, 5, 6, null, 8, 9, 10];
+	add('movingAverage', 'window3_with_nulls', { series: s2, windowSize: 3 }, movingAverage(s2, 3));
+}
+
+// --- computeAdaptiveTDEE ----------------------------------------------------
+{
+	const w = weightSeries(21, 82, -0.05); // ~0.35 kg/week loss
+	const c = calorieSeries(21, () => 2100);
+	add(
+		'computeAdaptiveTDEE',
+		'loss_21d',
+		{ weightSeries: w, calorieSeries: c, windowDays: 14 },
+		computeAdaptiveTDEE(w, c, 14)
+	);
+
+	const w2 = weightSeries(4, 80, -0.1); // too few weight points
+	const c2 = calorieSeries(4, () => 2000);
+	add(
+		'computeAdaptiveTDEE',
+		'insufficient',
+		{ weightSeries: w2, calorieSeries: c2, windowDays: 14 },
+		computeAdaptiveTDEE(w2, c2, 14)
+	);
+
+	const w3 = weightSeries(18, 75, 0.04); // gain
+	const c3 = calorieSeries(18, (i) => 2600 + (i % 3) * 120);
+	add(
+		'computeAdaptiveTDEE',
+		'gain_variable_intake',
+		{ weightSeries: w3, calorieSeries: c3, windowDays: 14 },
+		computeAdaptiveTDEE(w3, c3, 14)
+	);
+}
+
+// --- detectPlateau ----------------------------------------------------------
+{
+	const w = weightSeries(14, 78, 0.0); // flat → plateau
+	const c = calorieSeries(14, () => 2200);
+	const tdee = computeAdaptiveTDEE(w, c, 14).estimatedTDEE;
+	add(
+		'detectPlateau',
+		'plateau_adaptive',
+		{ weightSeries: w, calorieSeries: c, estimatedTDEE: tdee, sodiumAvg: null },
+		detectPlateau(w, c, tdee, null)
+	);
+
+	const w2 = weightSeries(14, 78, 0.0);
+	const c2 = calorieSeries(14, (i) => (i % 2 === 0 ? 1500 : 2900)); // high variance
+	add(
+		'detectPlateau',
+		'plateau_intake_variance',
+		{ weightSeries: w2, calorieSeries: c2, estimatedTDEE: 2300, sodiumAvg: null },
+		detectPlateau(w2, c2, 2300, null)
+	);
+
+	const w3 = weightSeries(14, 78, -0.06); // clearly losing → not plateau
+	const c3 = calorieSeries(14, () => 2000);
+	add(
+		'detectPlateau',
+		'not_plateau',
+		{ weightSeries: w3, calorieSeries: c3, estimatedTDEE: 2400, sodiumAvg: null },
+		detectPlateau(w3, c3, 2400, null)
+	);
+}
+
+// --- projectWeight ----------------------------------------------------------
+{
+	const w = weightSeries(20, 90, -0.07);
+	add(
+		'projectWeight',
+		'loss_-0.49wk',
+		{ weightSeries: w, weeklyRate: -0.49 },
+		projectWeight(w, -0.49)
+	);
+
+	const w2 = weightSeries(5, 70, 0.0);
+	add(
+		'projectWeight',
+		'flat_low_sample',
+		{ weightSeries: w2, weeklyRate: 0.0 },
+		projectWeight(w2, 0)
+	);
+}
+
+const out = {
+	version: 1,
+	description:
+		'Frozen golden vectors locking the shared Kotlin analytics to the TypeScript analytics. Generated from the TS implementation by analytics-parity/generate.ts — do not hand-edit.',
+	tolerances: { default: 1e-9, pValue: 1e-7 },
+	cases
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const target = resolve(here, 'fixtures/golden-vectors.json');
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, JSON.stringify(out, null, 2) + '\n');
+console.log(`Wrote ${cases.length} cases to ${target}`);

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.sqldelight) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.skie) apply false
 }
 
 subprojects {

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ koin = "4.2.2"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 datetime = "0.6.1"
-skie = "0.10.1"
+skie = "0.10.12"
 mlkit-barcode = "17.3.0"
 camerax = "1.6.1"
 ktlint = "14.2.0"
@@ -112,3 +112,4 @@ kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versio
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+skie = { id = "co.touchlab.skie", version.ref = "skie" }

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -32,7 +32,9 @@ enum WeightTrend: Equatable {
         switch WeightChartAnalyticsKt.classifyWeightTrend(deltaKg: delta, steadyBandKg: steadyBandKg) {
         case .rising: return .rising(delta)
         case .falling: return .falling(delta)
-        case .steady: return .steady(delta)
+        // SKIE exports the enum as non-frozen, so a `default` keeps the switch
+        // exhaustive across Swift toolchains (Xcode 16's 6.1 and CI's 6.2).
+        default: return .steady(delta)
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -1,5 +1,20 @@
 import Charts
+import shared
 import SwiftUI
+
+/// Bridges Swift `Double` arrays to/from the boxed-number arrays the shared
+/// Kotlin analytics expose across the Objective-C interop boundary.
+private extension [Double] {
+    var asKotlin: [KotlinDouble] {
+        map { KotlinDouble(double: $0) }
+    }
+}
+
+private extension [KotlinDouble] {
+    var asDoubles: [Double] {
+        map(\.doubleValue)
+    }
+}
 
 /// Direction of the recent weight development shown in the trend card.
 enum WeightTrend: Equatable {
@@ -12,9 +27,13 @@ enum WeightTrend: Equatable {
 
     static func from(delta: Double?) -> WeightTrend {
         guard let delta else { return .steady(nil) }
-        if delta > steadyBandKg { return .rising(delta) }
-        if delta < -steadyBandKg { return .falling(delta) }
-        return .steady(delta)
+        // Classification lives in the shared KMP analytics so iOS and Android
+        // agree on what counts as a real trend vs. daily-fluctuation noise.
+        switch WeightChartAnalyticsKt.classifyWeightTrend(deltaKg: delta, steadyBandKg: steadyBandKg) {
+        case .rising: return .rising(delta)
+        case .falling: return .falling(delta)
+        case .steady: return .steady(delta)
+        }
     }
 
     /// Local fallback for the server's `delta_7d` (Local mode / offline):
@@ -133,13 +152,17 @@ struct WeightView: View {
         let sorted = chartEntries
         guard sorted.count >= 2 else { return [] }
 
+        // 7-point trailing average (with partial leading windows) computed by the
+        // shared KMP analytics; the chart only assembles the dates around it.
+        let averages = WeightChartAnalyticsKt.weightMovingAverage(
+            values: sorted.map(\.weightKg).asKotlin,
+            window: 7
+        ).asDoubles
+
         var result: [(date: Date, average: Double)] = []
         for (index, entry) in sorted.enumerated() {
             guard let date = DateFormatting.date(from: entry.entryDate) else { continue }
-            let windowStart = max(0, index - 6)
-            let window = sorted[windowStart ... index]
-            let avg = window.map(\.weightKg).reduce(0, +) / Double(window.count)
-            result.append((date: date, average: avg))
+            result.append((date: date, average: averages[index]))
         }
         return result
     }
@@ -151,22 +174,19 @@ struct WeightView: View {
             return (date, entry.weightKg)
         }
 
-        // Simple linear regression
-        let n = Double(sorted.count)
-        let xVals = sorted.enumerated().map { Double($0.offset) }
-        let yVals = sorted.map(\.1)
-        let xMean = xVals.reduce(0, +) / n
-        let yMean = yVals.reduce(0, +) / n
-        let numerator = zip(xVals, yVals).map { ($0 - xMean) * ($1 - yMean) }.reduce(0, +)
-        let denominator = xVals.map { ($0 - xMean) * ($0 - xMean) }.reduce(0, +)
-        guard denominator > 0 else { return [] }
-        let slope = numerator / denominator
-        let intercept = yMean - slope * xMean
+        // Least-squares fit (entry index → weight) computed by the shared KMP
+        // analytics; iOS keeps its index-based x-axis by passing entry indices.
+        let fit = WeightChartAnalyticsKt.linearRegression(
+            xs: sorted.indices.map(Double.init).asKotlin,
+            ys: sorted.map(\.1).asKotlin
+        )
+        guard let fit, let lastDate = sorted.last?.0 else { return [] }
+        let slope = fit.slope
+        let intercept = fit.intercept
 
-        guard let lastDate = sorted.last?.0 else { return [] }
         var result: [(Date, Double)] = []
         // Start from last actual data point
-        let lastX = n - 1
+        let lastX = Double(sorted.count - 1)
         result.append((lastDate, slope * lastX + intercept))
         for day in 1 ... projectionDays {
             let futureDate = lastDate.adding(days: day)

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -41,6 +41,17 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.bissbilanz.ios
+        # Link the KMP shared framework. Gradle builds it and stages it under
+        # shared/build/xcode-frameworks/<configuration>/<sdk>/ (see the shared
+        # iOS framework steps in mobile-ios.yml / mobile-release.yml).
+        FRAMEWORK_SEARCH_PATHS:
+          - '$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)'
+        OTHER_LDFLAGS:
+          - '-framework'
+          - 'shared'
+          # SQLDelight's native SQLite driver (SQLiter) inside the static shared
+          # framework references libsqlite3 symbols the host app must resolve.
+          - '-lsqlite3'
     info:
       path: Bissbilanz/Info.plist
       properties:
@@ -76,6 +87,8 @@ targets:
         com.apple.developer.icloud-services:
           - CloudKit
     dependencies:
+      - framework: '../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/shared.framework'
+        embed: false
       - sdk: HealthKit.framework
       - package: Sentry
       - target: BissbilanzWidgets

--- a/mobile/shared/build.gradle.kts
+++ b/mobile/shared/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.sqldelight)
+    alias(libs.plugins.skie)
 }
 
 kotlin {
@@ -70,6 +71,15 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+skie {
+    // SKIE uploads anonymized build analytics by default; disable both the
+    // capture and upload phases so CI/dev framework builds make no network
+    // calls and leak no project metadata.
+    analytics {
+        enabled.set(false)
     }
 }
 

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/analytics/AnalyticsParityTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/analytics/AnalyticsParityTest.kt
@@ -1,0 +1,240 @@
+package com.bissbilanz.analytics
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.io.File
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Cross-language golden-vector parity for the analytics shared with the
+ * TypeScript server. Both this test and tests/analytics/parity.test.ts assert
+ * the same frozen fixtures, so the server's TS analytics and the mobile apps'
+ * Kotlin analytics fail CI the moment they diverge. See analytics-parity/README.md.
+ */
+class AnalyticsParityTest {
+    @Test
+    fun matchesGoldenVectors() {
+        val root = Json.parseToJsonElement(loadFixtureText()).jsonObject
+        val cases = root.getValue("cases").jsonArray
+        check(cases.isNotEmpty()) { "no golden-vector cases found" }
+
+        val failures = mutableListOf<String>()
+        for (case in cases) {
+            val obj = case.jsonObject
+            val fn = obj.getValue("fn").jsonPrimitive.content
+            val name = obj.getValue("name").jsonPrimitive.content
+            val input = obj.getValue("input").jsonObject
+            val expected = obj.getValue("expected")
+            val actual = runCase(fn, input)
+            try {
+                assertClose(actual, expected, "$fn/$name")
+            } catch (e: AssertionError) {
+                failures += e.message ?: "$fn/$name mismatch"
+            }
+        }
+        if (failures.isNotEmpty()) {
+            fail("Kotlin analytics diverged from the golden vectors:\n" + failures.joinToString("\n"))
+        }
+    }
+
+    private fun runCase(
+        fn: String,
+        input: JsonObject,
+    ): JsonElement =
+        when (fn) {
+            "pearsonCorrelation" -> {
+                pearsonCorrelation(
+                    doubleArrayFrom(input.getValue("x")),
+                    doubleArrayFrom(input.getValue("y")),
+                ).toJson()
+            }
+
+            "movingAverage" -> {
+                movingAverage(
+                    nullableDoublesFrom(input.getValue("series")),
+                    input.getValue("windowSize").jsonPrimitive.int,
+                ).let { result -> JsonArray(result.map { it?.let(::JsonPrimitive) ?: JsonNull }) }
+            }
+
+            "computeAdaptiveTDEE" -> {
+                computeAdaptiveTDEE(
+                    weightSeriesFrom(input.getValue("weightSeries")),
+                    calorieSeriesFrom(input.getValue("calorieSeries")),
+                    input.getValue("windowDays").jsonPrimitive.int,
+                ).toJson()
+            }
+
+            "detectPlateau" -> {
+                detectPlateau(
+                    weightSeriesFrom(input.getValue("weightSeries")),
+                    calorieSeriesFrom(input.getValue("calorieSeries")),
+                    input["estimatedTDEE"].nullableDouble(),
+                    input["sodiumAvg"].nullableDouble(),
+                ).toJson()
+            }
+
+            "projectWeight" -> {
+                projectWeight(
+                    weightSeriesFrom(input.getValue("weightSeries")),
+                    input.getValue("weeklyRate").jsonPrimitive.double,
+                ).toJson()
+            }
+
+            else -> {
+                error("Unknown fn in fixtures: $fn")
+            }
+        }
+
+    // --- result -> JSON (shape mirrors the TS return objects) ----------------
+
+    private fun CorrelationResult.toJson() =
+        buildJsonObject {
+            put("r", r)
+            put("pValue", pValue)
+            put("sampleSize", sampleSize)
+            put("confidence", confidence.wire())
+            put("constantInput", constantInput)
+        }
+
+    private fun TDEEResult.toJson() =
+        buildJsonObject {
+            putNullableDouble("estimatedTDEE", estimatedTDEE)
+            put("trend", trend)
+            put("avgIntake", avgIntake)
+            put("weeklyRate", weeklyRate)
+            put("confidence", confidence.wire())
+            put("sampleSize", sampleSize)
+        }
+
+    private fun PlateauResult.toJson() =
+        buildJsonObject {
+            put("isPlateaued", isPlateaued)
+            put("plateauDays", plateauDays)
+            putNullableDouble("estimatedDeficit", estimatedDeficit)
+            put("cause", cause)
+            put("confidence", confidence.wire())
+            put("sampleSize", sampleSize)
+        }
+
+    private fun WeightForecast.toJson() =
+        buildJsonObject {
+            putNullableDouble("currentWeight", currentWeight)
+            put("weeklyRate", weeklyRate)
+            putNullableDouble("day30", day30)
+            putNullableDouble("day60", day60)
+            putNullableDouble("day90", day90)
+            put("sampleSize", sampleSize)
+            put("confidence", confidence.wire())
+        }
+
+    // TS encodes ConfidenceLevel as a lowercase string.
+    private fun ConfidenceLevel.wire() = name.lowercase()
+
+    private fun JsonObjectBuilder.putNullableDouble(
+        key: String,
+        value: Double?,
+    ) {
+        put(key, value?.let(::JsonPrimitive) ?: JsonNull)
+    }
+
+    // --- input parsing -------------------------------------------------------
+
+    private fun weightSeriesFrom(el: JsonElement): List<Pair<String, Double?>> = seriesFrom(el, "weightKg")
+
+    private fun calorieSeriesFrom(el: JsonElement): List<Pair<String, Double?>> = seriesFrom(el, "calories")
+
+    private fun seriesFrom(
+        el: JsonElement,
+        valueKey: String,
+    ): List<Pair<String, Double?>> =
+        el.jsonArray.map {
+            val o = it.jsonObject
+            o.getValue("date").jsonPrimitive.content to o.getValue(valueKey).asNullableDouble()
+        }
+
+    private fun nullableDoublesFrom(el: JsonElement): List<Double?> = el.jsonArray.map { it.asNullableDouble() }
+
+    private fun doubleArrayFrom(el: JsonElement): DoubleArray = el.jsonArray.map { it.jsonPrimitive.double }.toDoubleArray()
+
+    private fun JsonElement.asNullableDouble(): Double? = if (this is JsonNull) null else jsonPrimitive.double
+
+    private fun JsonElement?.nullableDouble(): Double? = if (this == null || this is JsonNull) null else jsonPrimitive.double
+
+    // --- comparison with the same tolerances as the TS harness ---------------
+
+    private fun assertClose(
+        actual: JsonElement,
+        expected: JsonElement,
+        path: String,
+    ) {
+        when (expected) {
+            is JsonNull -> {
+                if (actual !is JsonNull) fail("$path: expected null, got $actual")
+            }
+
+            is JsonArray -> {
+                if (actual !is JsonArray) fail("$path: expected array, got $actual")
+                if (actual.size != expected.size) fail("$path: size ${actual.size} != ${expected.size}")
+                expected.forEachIndexed { i, e -> assertClose(actual[i], e, "$path[$i]") }
+            }
+
+            is JsonObject -> {
+                if (actual !is JsonObject) fail("$path: expected object, got $actual")
+                for ((k, e) in expected) assertClose(actual[k] ?: JsonNull, e, "$path.$k")
+            }
+
+            is JsonPrimitive -> {
+                assertPrimitiveClose(actual, expected, path)
+            }
+        }
+    }
+
+    private fun assertPrimitiveClose(
+        actual: JsonElement,
+        expected: JsonPrimitive,
+        path: String,
+    ) {
+        if (actual !is JsonPrimitive) fail("$path: expected primitive, got $actual")
+        val expectedBool = if (!expected.isString) expected.booleanOrNull else null
+        if (expectedBool != null) {
+            if (actual.booleanOrNull != expectedBool) fail("$path: expected $expectedBool, got $actual")
+            return
+        }
+        val expectedNum = if (!expected.isString) expected.doubleOrNull else null
+        if (expectedNum != null) {
+            val actualNum = actual.doubleOrNull ?: fail("$path: expected number, got $actual")
+            val tol = if (path.endsWith("pValue")) 1e-7 else 1e-9 * maxOf(1.0, abs(expectedNum))
+            if (abs(actualNum - expectedNum) > tol) {
+                fail("$path: expected $expectedNum, got $actualNum (tolerance $tol)")
+            }
+            return
+        }
+        if (actual.content != expected.content) fail("$path: expected '${expected.content}', got '${actual.content}'")
+    }
+
+    private fun loadFixtureText(): String {
+        var dir: File? = File(System.getProperty("user.dir"))
+        repeat(8) {
+            val candidate = File(dir, "analytics-parity/fixtures/golden-vectors.json")
+            if (candidate.exists()) return candidate.readText()
+            dir = dir?.parentFile
+        }
+        error("golden-vectors.json not found walking up from ${System.getProperty("user.dir")}")
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/analytics/WeightChartAnalytics.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/analytics/WeightChartAnalytics.kt
@@ -1,0 +1,79 @@
+package com.bissbilanz.analytics
+
+/**
+ * Direction of a recent weight change, for the on-device trend indicator.
+ * Lives in the shared module so the iOS and Android trend cards classify
+ * identically instead of each re-deriving the thresholds.
+ */
+enum class WeightTrendDirection { RISING, FALLING, STEADY }
+
+/**
+ * Classifies a weight change (in kg) over a period into a trend direction.
+ * Changes within [steadyBandKg] of zero are treated as daily-fluctuation noise
+ * rather than a real trend.
+ */
+fun classifyWeightTrend(
+    deltaKg: Double,
+    steadyBandKg: Double = 0.3,
+): WeightTrendDirection =
+    when {
+        deltaKg > steadyBandKg -> WeightTrendDirection.RISING
+        deltaKg < -steadyBandKg -> WeightTrendDirection.FALLING
+        else -> WeightTrendDirection.STEADY
+    }
+
+/**
+ * Trailing moving average with partial leading windows: position `i` is the
+ * average of the up-to-[window] values ending at `i`, so the first `window - 1`
+ * positions average fewer points instead of being undefined. This keeps a value
+ * at every point, which is what the weight chart's smoothing line draws.
+ *
+ * Note this differs from [movingAverage], which leaves the leading positions
+ * null — that variant is for series where a partial window would be misleading.
+ */
+fun weightMovingAverage(
+    values: List<Double>,
+    window: Int,
+): List<Double> {
+    require(window >= 1) { "window must be >= 1, was $window" }
+    return values.indices.map { i ->
+        val start = maxOf(0, i - window + 1)
+        val slice = values.subList(start, i + 1)
+        slice.sum() / slice.size
+    }
+}
+
+/** Slope and intercept of an ordinary least-squares line `y = slope * x + intercept`. */
+data class LinearFit(
+    val slope: Double,
+    val intercept: Double,
+)
+
+/**
+ * Ordinary least-squares fit of [ys] on [xs]. Returns null when the inputs are
+ * mismatched in length, have fewer than two points, or have zero variance in x
+ * (a vertical line has no defined slope).
+ *
+ * Callers pick their own x scale — entry index for evenly-spaced points, or day
+ * offsets when real gaps between entries should matter — so the same fit backs
+ * both the iOS and Android weight-projection charts.
+ */
+fun linearRegression(
+    xs: List<Double>,
+    ys: List<Double>,
+): LinearFit? {
+    val n = xs.size
+    if (n < 2 || ys.size != n) return null
+    val xMean = xs.sum() / n
+    val yMean = ys.sum() / n
+    var num = 0.0
+    var den = 0.0
+    for (i in 0 until n) {
+        val dx = xs[i] - xMean
+        num += dx * (ys[i] - yMean)
+        den += dx * dx
+    }
+    if (den == 0.0) return null
+    val slope = num / den
+    return LinearFit(slope = slope, intercept = yMean - slope * xMean)
+}

--- a/tests/analytics/parity.test.ts
+++ b/tests/analytics/parity.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { pearsonCorrelation } from '../../src/lib/analytics/correlation';
+import { movingAverage } from '../../src/lib/analytics/moving-average';
+import { computeAdaptiveTDEE, detectPlateau, projectWeight } from '../../src/lib/analytics/tdee';
+
+/**
+ * Cross-language golden-vector parity. The same frozen fixtures are asserted by
+ * the Kotlin shared module (mobile/shared/.../AnalyticsParityTest.kt), so this
+ * file and that one together fail CI if the server's TS analytics and the mobile
+ * apps' Kotlin analytics ever diverge. See analytics-parity/README.md.
+ */
+
+type GoldenCase = { fn: string; name: string; input: Record<string, unknown>; expected: unknown };
+type GoldenFile = { cases: GoldenCase[] };
+
+const golden: GoldenFile = JSON.parse(
+	readFileSync(resolve(__dirname, '../../analytics-parity/fixtures/golden-vectors.json'), 'utf-8')
+);
+
+function runFn(fn: string, input: any): unknown {
+	switch (fn) {
+		case 'pearsonCorrelation':
+			return pearsonCorrelation(input.x, input.y);
+		case 'movingAverage':
+			return movingAverage(input.series, input.windowSize);
+		case 'computeAdaptiveTDEE':
+			return computeAdaptiveTDEE(input.weightSeries, input.calorieSeries, input.windowDays);
+		case 'detectPlateau':
+			return detectPlateau(
+				input.weightSeries,
+				input.calorieSeries,
+				input.estimatedTDEE,
+				input.sodiumAvg
+			);
+		case 'projectWeight':
+			return projectWeight(input.weightSeries, input.weeklyRate);
+		default:
+			throw new Error(`Unknown fn in fixtures: ${fn}`);
+	}
+}
+
+// Tolerance rule shared verbatim with the Kotlin harness: pValue is an absolute
+// 1e-7 (it flows through an iterative beta approximation); every other number is
+// a relative 1e-9 scaled by magnitude. Non-numbers must match exactly.
+function numbersClose(actual: number, expected: number, key: string): boolean {
+	if (Number.isNaN(actual) && Number.isNaN(expected)) return true;
+	const tol = key === 'pValue' ? 1e-7 : 1e-9 * Math.max(1, Math.abs(expected));
+	return Math.abs(actual - expected) <= tol;
+}
+
+function assertMatches(actual: any, expected: any, path: string, key = ''): void {
+	if (expected === null || expected === undefined) {
+		expect(actual ?? null, `${path} should be null`).toBe(null);
+		return;
+	}
+	if (typeof expected === 'number') {
+		expect(typeof actual, `${path} type`).toBe('number');
+		expect(
+			numbersClose(actual, expected, key),
+			`${path}: expected ${expected}, got ${actual}`
+		).toBe(true);
+		return;
+	}
+	if (Array.isArray(expected)) {
+		expect(Array.isArray(actual), `${path} should be array`).toBe(true);
+		expect(actual.length, `${path} length`).toBe(expected.length);
+		expected.forEach((v, i) => assertMatches(actual[i], v, `${path}[${i}]`, key));
+		return;
+	}
+	if (typeof expected === 'object') {
+		for (const k of Object.keys(expected)) {
+			assertMatches(actual?.[k], expected[k], `${path}.${k}`, k);
+		}
+		return;
+	}
+	expect(actual, `${path}`).toBe(expected); // string / boolean
+}
+
+describe('analytics golden-vector parity (TypeScript)', () => {
+	it('has cases to check', () => {
+		expect(golden.cases.length).toBeGreaterThan(0);
+	});
+
+	for (const c of golden.cases) {
+		it(`${c.fn}/${c.name}`, () => {
+			const actual = runFn(c.fn, c.input);
+			assertMatches(actual, c.expected, `${c.fn}/${c.name}`);
+		});
+	}
+});


### PR DESCRIPTION
Implements the **decided** scope of #322 — iOS consumes the shared Kotlin analytics instead of a parallel Swift re-implementation — and adds the golden-vector guardrail that keeps the server (TS) and mobile (Kotlin) analytics in lockstep.

## What changed

**Re-link the KMP `shared` framework into iOS**
- Restored the `shared.framework` linkage in `project.yml` (removed as "unused" in `2b903d55`) and added `-lsqlite3` — SQLDelight's native driver needs it from the static framework once its symbols are actually referenced.
- The framework is already built+staged by `mobile-ios.yml` / `codeql-mobile.yml`; added the same build+stage steps to `mobile-release.yml` for the Release/device archive.

**SKIE for clean Swift interop**
- Wired the SKIE Gradle plugin into the shared module. Bumped the pinned version `0.10.1 -> 0.10.12`: **0.10.1 does not support Kotlin 2.3.21** (it caps at 2.1.10); 0.10.12 does. Kotlin enums now bridge to native, exhaustive Swift enums.
- Disabled SKIE's build-analytics upload so CI/dev framework builds make no network calls.

**Collapse the duplicated Swift weight-chart math**
- New pure shared analytics: `classifyWeightTrend`/`WeightTrendDirection`, `weightMovingAverage`, `linearRegression`/`LinearFit`.
- `WeightView` now calls into `shared` for trend classification, the 7-point moving average, and the projection's least-squares fit — behaviour preserved (iOS keeps its index-based x-axis).

**Golden-vector parity suite (the #322 guardrail)**
- `analytics-parity/fixtures/golden-vectors.json` — frozen inputs+outputs generated from the TS analytics.
- Asserted by **both** `tests/analytics/parity.test.ts` (vitest) and `AnalyticsParityTest.kt` (shared JVM unit test), so any TS↔Kotlin drift fails CI.

## Verification (local)
- iOS app builds & links (`xcodebuild`, simulator) ✅
- Release device framework builds (`linkReleaseFrameworkIosArm64`) ✅
- `:shared:testDebugUnitTest :shared:ktlintCheck :androidApp:assembleDebug :androidApp:ktlintCheck` ✅
- `bun run check`, `bun run api:check`, `bun run test` (1815 tests) ✅

## Notes / follow-ups
- The server-side Kotlin question from #322 (Ktor sidecar / in-process JVM — never the dual-writer pattern) is intentionally **not** here; tracked in a follow-up issue.
- Android's weight chart still has its own `linearRegression` (day-offset based, `Float`); unifying it onto the shared fit is a deliberate, behaviour-affecting follow-up.

Refs #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)