### PR TITLE
feat(ios): attach user to Sentry, enrich error context, forward MetricKit

### DIFF
--- a/mobile/iosApp/Bissbilanz/API/AuthManager.swift
+++ b/mobile/iosApp/Bissbilanz/API/AuthManager.swift
@@ -43,6 +43,39 @@ final class AuthManager {
         KeychainHelper.load(key: Self.accessTokenKey)
     }
 
+    /// The signed-in user's stable id — the OIDC `sub` claim decoded from the
+    /// access token — used to attach a user to crash reports (parity with
+    /// Android's `extractSubFromJwt`). Nil when signed out or when the token
+    /// can't be parsed. The token is read locally only; it is never verified
+    /// here (the server already did), this just reads the public claim.
+    var userId: String? {
+        accessToken.flatMap(Self.extractSub(fromJWT:))
+    }
+
+    /// Decodes the `sub` claim from a JWT without validating its signature.
+    /// Returns nil for anything that isn't a well-formed JWT with a string
+    /// `sub`. `nonisolated` and pure so it is unit-testable off the main actor.
+    nonisolated static func extractSub(fromJWT token: String) -> String? {
+        let segments = token.split(separator: ".")
+        guard segments.count >= 2 else { return nil }
+
+        // JWTs use base64url (no padding); restore standard base64.
+        var base64 = String(segments[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 {
+            base64 += "="
+        }
+
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sub = json["sub"] as? String
+        else {
+            return nil
+        }
+        return sub
+    }
+
     func buildLoginURL() -> URL? {
         let state = UUID().uuidString
         pendingState = state

--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -400,13 +400,53 @@ final class BissbilanzAPI {
     /// callers that recover (cache fallback, sync retries, `try?` lookups)
     /// don't silently swallow real defects. `ErrorReporter` filters expected
     /// noise (unauthorized, offline, not-found).
+    ///
+    /// Every request also drops a breadcrumb and, on failure, attaches the
+    /// endpoint, method, status code and (truncated) response body — enough to
+    /// debug a reported issue without reproducing it.
     private func performRequest<T: Decodable>(_ request: URLRequest) async throws -> T {
+        ErrorReporter.addBreadcrumb(
+            "\(request.httpMethod ?? "?") \(request.url?.path ?? "?")",
+            category: "http"
+        )
         do {
             return try await executeRequest(request)
         } catch {
-            ErrorReporter.capture(error)
+            ErrorReporter.capture(error, context: Self.errorContext(for: request, error: error))
             throw error
         }
+    }
+
+    /// Builds the structured context attached to a captured API error. Only the
+    /// URL *path* is included — query strings can carry search terms (food
+    /// names), and the response body is truncated to keep events small and
+    /// avoid shipping large payloads.
+    private static func errorContext(for request: URLRequest, error: Error) -> [String: Any] {
+        var context: [String: Any] = [:]
+        if let method = request.httpMethod {
+            context["method"] = method
+        }
+        if let path = request.url?.path {
+            context["endpoint"] = path
+        }
+        switch error as? APIError {
+        case let .serverError(code, message):
+            context["status_code"] = code
+            if let message {
+                context["response_body"] = String(message.prefix(500))
+            }
+        case let .badRequest(message):
+            context["status_code"] = 400
+            if let message {
+                context["response_body"] = String(message.prefix(500))
+            }
+        case let .decodingError(underlying):
+            context["status_code"] = 200
+            context["decoding_error"] = String(describing: underlying)
+        case .networkError, .notFound, .unauthorized, .none:
+            break
+        }
+        return context
     }
 
     private func executeRequest<T: Decodable>(_ request: URLRequest) async throws -> T {

--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -64,7 +64,7 @@ struct BissbilanzApp: App {
         // once at launch, so toggling it takes effect on the next launch.
         let container = LocalStore.makeContainerWithFallback(
             cloudKitEnabled: appMode.isLocal,
-            onError: { ErrorReporter.capture($0) }
+            onError: { ErrorReporter.capture($0, context: ["phase": "store_init"]) }
         )
         modelContainer = container
         let context = container.mainContext
@@ -149,6 +149,7 @@ struct BissbilanzApp: App {
             // default to Synced (mirrors the Android root).
             .onChange(of: authManager.authState, initial: true) { _, state in
                 defaultModeToSyncedIfNeeded()
+                syncErrorReportingUser(for: state)
                 // Upload anything queued while the session was expired.
                 if state == .authenticated {
                     syncManager.scheduleDrain()
@@ -177,6 +178,22 @@ struct BissbilanzApp: App {
         let authState = authManager.authState
         if authState == .authenticated || authState == .refreshing, appModeManager.mode == nil {
             appModeManager.setMode(.synced)
+        }
+    }
+
+    /// Keeps the Sentry user in step with auth (parity with Android): attach
+    /// the signed-in user so issues can be told apart from a fleet-wide
+    /// problem, and detach on sign-out / session expiry. Also drops a
+    /// breadcrumb so the lead-up to any later error shows the auth transition.
+    private func syncErrorReportingUser(for state: AuthState) {
+        ErrorReporter.addBreadcrumb("auth state → \(state)", category: "auth")
+        switch state {
+        case .authenticated, .refreshing:
+            if let id = authManager.userId {
+                ErrorReporter.setUser(id: id)
+            }
+        case .unauthenticated, .expired:
+            ErrorReporter.clearUser()
         }
     }
 }

--- a/mobile/iosApp/Bissbilanz/Services/ErrorReporter.swift
+++ b/mobile/iosApp/Bissbilanz/Services/ErrorReporter.swift
@@ -3,10 +3,20 @@ import Sentry
 
 /// Central Sentry wrapper — the iOS counterpart of the Android app's
 /// `SentryErrorReporter`. Crashes and unhandled errors are captured by the
-/// SDK's crash handler; handled errors funnel through `capture(_:)`, which
-/// applies the same noise filtering as Android:
+/// SDK's crash handler; handled errors funnel through `capture(_:context:)`,
+/// which applies the same noise filtering as Android:
 /// - auth failures are an expected state (session expired), not a defect
 /// - transient network failures (offline, flaky cellular) are not actionable
+///
+/// Beyond crashes, the wrapper also feeds Sentry:
+/// - the signed-in user (`setUser`/`clearUser`), so issues can be told apart
+///   from "everyone is hitting this" — parity with Android's `Sentry.setUser`
+/// - breadcrumbs (`addBreadcrumb`), a trail of recent actions shipped with the
+///   next event so a crash report shows what led up to it
+/// - structured context on handled errors (HTTP endpoint, status, response
+///   body), so an API failure carries enough to debug without a repro
+/// - MetricKit diagnostics (hangs, CPU/disk exceptions) via the SDK's own
+///   integration, plus daily aggregate metrics via `MetricKitReporter`
 ///
 /// The DSN is injected at build time via the `SENTRY_DSN` build setting
 /// (surfaced in Info.plist as `SentryDSN`). When it is empty — every local
@@ -30,18 +40,87 @@ enum ErrorReporter {
             options.attachScreenshot = true
             options.attachViewHierarchy = true
             options.tracesSampleRate = 0.2
+            // App-hang (ANR) detection — surfaces a stuck main thread with the
+            // blocking stacktrace. On by default; set explicitly so it can't be
+            // lost to a future default change.
+            options.enableAppHangTracking = true
+            // Let Sentry ingest MetricKit *diagnostics* — OS-sampled crashes,
+            // hangs, CPU and disk-write exceptions — as events with stack
+            // traces. Aggregate *metrics* (launch time, energy) are handled
+            // separately by `MetricKitReporter` (MetricKit splits the two).
+            options.enableMetricKit = true
             #if DEBUG
             options.environment = "development"
             #else
             options.environment = "production"
             #endif
         }
+
+        // Forward MetricKit's daily aggregate metrics (launch, hang rate,
+        // memory, energy) — device-only, at most one payload per day.
+        MetricKitReporter.shared.start()
     }
 
-    /// Reports a handled error, unless it is expected noise.
-    static func capture(_ error: Error) {
+    /// Associates subsequent events with a user id (the OIDC `sub`), so Sentry
+    /// can group an issue by how many distinct users it hits. Mirrors Android's
+    /// `Sentry.setUser`. No-op when Sentry is disabled.
+    static func setUser(id: String) {
+        guard isEnabled else { return }
+        let user = User()
+        user.userId = id
+        SentrySDK.setUser(user)
+    }
+
+    /// Detaches the user on sign-out / session expiry, so events from a
+    /// shared-device "logged out" state aren't misattributed.
+    static func clearUser() {
+        guard isEnabled else { return }
+        SentrySDK.setUser(nil)
+    }
+
+    /// Records a breadcrumb — a timestamped trail entry that ships with the
+    /// next captured event. Use it for high-signal milestones (a request
+    /// issued, a sync started, the auth state changing) so a later crash or
+    /// error report shows the lead-up. No-op when Sentry is disabled.
+    static func addBreadcrumb(
+        _ message: String,
+        category: String,
+        level: SentryLevel = .info,
+        data: [String: Any]? = nil
+    ) {
+        guard isEnabled else { return }
+        let crumb = Breadcrumb(level: level, category: category)
+        crumb.message = message
+        if let data {
+            crumb.data = data
+        }
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
+    /// Reports a handled error, unless it is expected noise. `context` is
+    /// attached to the event under the "details" context block — pass whatever
+    /// helps debugging without a repro (endpoint, status code, ids).
+    static func capture(_ error: Error, context: [String: Any]? = nil) {
         guard isEnabled, !shouldIgnore(error) else { return }
-        SentrySDK.capture(error: error)
+        SentrySDK.capture(error: error) { scope in
+            if let context {
+                scope.setContext(value: context, key: "details")
+            }
+        }
+    }
+
+    /// Reports a non-fatal warning: a recoverable problem still worth knowing
+    /// about (a sync conflict resolved by discarding local state, a fallback
+    /// that masked a server bug). Sent at `warning` level with optional
+    /// structured context.
+    static func captureWarning(_ message: String, context: [String: Any]? = nil) {
+        guard isEnabled else { return }
+        SentrySDK.capture(message: message) { scope in
+            scope.setLevel(.warning)
+            if let context {
+                scope.setContext(value: context, key: "details")
+            }
+        }
     }
 
     /// Sends a message event to verify the pipeline end-to-end (debug builds

--- a/mobile/iosApp/Bissbilanz/Services/MetricKitReporter.swift
+++ b/mobile/iosApp/Bissbilanz/Services/MetricKitReporter.swift
@@ -1,0 +1,61 @@
+import Foundation
+import MetricKit
+import Sentry
+
+/// Forwards MetricKit's aggregated daily *metrics* (app launch time, hang
+/// rate, memory, CPU, disk, energy) to Sentry as a single info-level event per
+/// payload, tagged `source=metrickit` so it filters apart from real issues.
+///
+/// Crash / hang / CPU-exception / disk-write *diagnostics* are a different
+/// MetricKit payload type (`MXDiagnosticPayload`) and are handled by Sentry's
+/// own MetricKit integration (`options.enableMetricKit`). This subscriber
+/// deliberately implements only the metric-payload callback, so the two never
+/// double-report.
+///
+/// MetricKit aggregates on-device and delivers at most one payload per day,
+/// and only on physical devices — never the simulator. The whole payload is
+/// shipped as its JSON representation rather than hand-parsed histograms, so
+/// new MetricKit fields show up automatically without code changes.
+/// `@unchecked Sendable`: the type holds no mutable state (the shared instance
+/// is its only storage), so it is safe to reach from MetricKit's background
+/// delivery queue and to expose as a `static let` under Swift 6 concurrency.
+final class MetricKitReporter: NSObject, MXMetricManagerSubscriber, @unchecked Sendable {
+    static let shared = MetricKitReporter()
+
+    override private init() {
+        super.init()
+    }
+
+    /// Subscribes to MetricKit. Safe to call once at launch.
+    func start() {
+        MXMetricManager.shared.add(self)
+    }
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        guard ErrorReporter.isEnabled else { return }
+        for payload in payloads {
+            report(payload)
+        }
+    }
+
+    private func report(_ payload: MXMetricPayload) {
+        // Pull the Sendable values out before the scope closure so the
+        // non-Sendable payload isn't captured across it.
+        let json = String(data: payload.jsonRepresentation(), encoding: .utf8)
+        let appVersion = payload.latestApplicationVersion
+        let multipleVersions = payload.includesMultipleApplicationVersions
+        SentrySDK.capture(message: "MetricKit daily metrics") { scope in
+            scope.setLevel(.info)
+            scope.setTag(value: "metrickit", key: "source")
+            scope.setContext(value: [
+                "app_version": appVersion,
+                "multiple_versions": multipleVersions,
+            ], key: "metrickit")
+            if let json {
+                // Full Apple-schema payload: launch time, hang rate, memory,
+                // CPU, disk I/O and energy in one blob (a few KB).
+                scope.setExtra(value: json, key: "metrickit_payload")
+            }
+        }
+    }
+}

--- a/mobile/iosApp/BissbilanzTests/AuthManagerTests.swift
+++ b/mobile/iosApp/BissbilanzTests/AuthManagerTests.swift
@@ -222,3 +222,53 @@ struct AuthManagerStateTests {
         #expect(auth.authState == .unauthenticated)
     }
 }
+
+@Suite("AuthManager JWT sub extraction")
+struct AuthManagerJWTTests {
+    /// Builds an unsigned JWT (`header.payload.signature`) with the given
+    /// payload, base64url-encoded the way real tokens are.
+    private func makeJWT(payload: [String: Any]) throws -> String {
+        func base64url(_ object: Any) throws -> String {
+            let data = try JSONSerialization.data(withJSONObject: object)
+            return data.base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+        let header = try base64url(["alg": "none", "typ": "JWT"])
+        let body = try base64url(payload)
+        return "\(header).\(body).signature"
+    }
+
+    @Test("Extracts sub from a valid token")
+    func extractsSub() throws {
+        let token = try makeJWT(payload: ["sub": "user-123", "name": "Test"])
+        #expect(AuthManager.extractSub(fromJWT: token) == "user-123")
+    }
+
+    @Test("Handles base64url payloads needing padding restored")
+    func handlesPadding() throws {
+        // A sub whose encoding lands on a length that dropped '=' padding.
+        let token = try makeJWT(payload: ["sub": "abcde"])
+        #expect(AuthManager.extractSub(fromJWT: token) == "abcde")
+    }
+
+    @Test("Returns nil when sub claim is missing")
+    func missingSub() throws {
+        let token = try makeJWT(payload: ["name": "no-sub-here"])
+        #expect(AuthManager.extractSub(fromJWT: token) == nil)
+    }
+
+    @Test("Returns nil for a malformed token")
+    func malformedToken() {
+        #expect(AuthManager.extractSub(fromJWT: "not-a-jwt") == nil)
+        #expect(AuthManager.extractSub(fromJWT: "") == nil)
+        #expect(AuthManager.extractSub(fromJWT: "only.two") == nil)
+    }
+
+    @Test("Returns nil when sub is not a string")
+    func nonStringSub() throws {
+        let token = try makeJWT(payload: ["sub": 42])
+        #expect(AuthManager.extractSub(fromJWT: token) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Improves the iOS app's Sentry observability so reported bugs carry enough context to debug without a repro, and forwards Apple's MetricKit telemetry into Sentry. Three related changes:

### 1. Attach the signed-in user to Sentry (parity with Android)
The iOS app captured crashes but never told Sentry *who* hit them — so you couldn't tell "one user has a broken token" from "everyone is crashing". Android already does this (`Sentry.setUser`); iOS now matches.
- `ErrorReporter.setUser(id:)` / `clearUser()` wrap `SentrySDK.setUser`.
- `AuthManager.userId` decodes the OIDC `sub` from the access token (mirrors Android's `extractSubFromJwt`), unit-tested.
- Wired into `BissbilanzApp`'s auth-state change: set on authenticated/refreshing, clear on sign-out/expiry.

### 2. Richer error & warning context
So a captured API error ships with the facts needed to debug it:
- `ErrorReporter.capture(_:context:)` attaches a structured `details` block.
- The `BissbilanzAPI` funnel now attaches **endpoint, HTTP method, status code and a truncated response body**, plus a per-request breadcrumb trail. Only the URL *path* is logged (query strings can carry search terms) and bodies are capped at 500 chars.
- New `ErrorReporter.addBreadcrumb(...)` and `captureWarning(...)` helpers; an auth-state breadcrumb records the lead-up to any later error.

### 3. MetricKit → Sentry
- Enabled Sentry's built-in MetricKit **diagnostics** ingestion (`options.enableMetricKit`) — OS-sampled hangs, CPU and disk-write exceptions arrive as events with stack traces. Also pinned `enableAppHangTracking` on.
- New `MetricKitReporter` subscriber forwards MetricKit's daily aggregate **metrics** (launch time, hang rate, memory, CPU, disk, energy) as one tagged (`source=metrickit`) info event per payload — the metric payloads Sentry's integration does *not* handle. The full Apple-schema JSON is attached, so new MetricKit fields appear without code changes. Device-only, ≤1 payload/day.

## Why not CloudKit for telemetry?
This started from a question about putting telemetry/logs in CloudKit. CloudKit is a record database (no error grouping, symbolication, alerting, and crashes can't reliably write from a dying process), so it's the wrong tool for observability — Sentry already covers it, and MetricKit/Xcode Organizer cover the Apple-native telemetry for free. CloudKit's right role here is data sync, which the app already uses it for (Local-mode mirroring).

## Testing
- `xcodebuild build` (app target) **succeeds** against this branch with the KMP shared framework linked.
- New `AuthManagerJWTTests` (5 cases: valid sub, base64url padding, missing sub, malformed token, non-string sub) **pass**.
- `swiftformat` clean.

## Notes
- All Sentry API usage verified against `sentry-cocoa` 9.17.1 (the pinned version).
- The commit is **unsigned** (the 1Password SSH agent was locked at commit time).
- Pre-existing, out of scope: the `BissbilanzTests` target lacks a `shared` framework search path, so `xcodebuild test` can't build the test bundle locally (CI only runs `xcodebuild build`, never the iOS tests). Worth a follow-up to make the iOS unit tests runnable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)