### PR TITLE
feat(mobile): on-device maintenance + nutrient aggregation in shared Kotlin (#321)

### DIFF
--- a/analytics-parity/fixtures/golden-vectors.json
+++ b/analytics-parity/fixtures/golden-vectors.json
@@ -1042,6 +1042,263 @@
 				"sampleSize": 5,
 				"confidence": "insufficient"
 			}
+		},
+		{
+			"fn": "calculateMaintenance",
+			"name": "loss_default_ratio",
+			"input": {
+				"weightChangeKg": -1.2,
+				"avgDailyCalories": 2100,
+				"days": 28
+			},
+			"expected": {
+				"maintenanceCalories": 2354,
+				"dailyDeficit": 254,
+				"totalEnergyBalance": 7116,
+				"fatMassKg": 0.84,
+				"muscleMassKg": 0.36,
+				"fatCalories": 6468,
+				"muscleCalories": 648,
+				"avgDailyCalories": 2100,
+				"weightChangeKg": -1.2,
+				"days": 28,
+				"muscleRatio": 0.3
+			}
+		},
+		{
+			"fn": "calculateMaintenance",
+			"name": "gain_custom_ratio",
+			"input": {
+				"weightChangeKg": 0.8,
+				"avgDailyCalories": 2850,
+				"days": 21,
+				"muscleRatio": 0.5
+			},
+			"expected": {
+				"maintenanceCalories": 2669,
+				"dailyDeficit": -181,
+				"totalEnergyBalance": -3800,
+				"fatMassKg": 0.4,
+				"muscleMassKg": 0.4,
+				"fatCalories": 3080,
+				"muscleCalories": 720,
+				"avgDailyCalories": 2850,
+				"weightChangeKg": 0.8,
+				"days": 21,
+				"muscleRatio": 0.5
+			}
+		},
+		{
+			"fn": "calculateMaintenance",
+			"name": "no_change",
+			"input": {
+				"weightChangeKg": 0,
+				"avgDailyCalories": 2000,
+				"days": 14,
+				"muscleRatio": 0.3
+			},
+			"expected": {
+				"maintenanceCalories": 2000,
+				"dailyDeficit": 0,
+				"totalEnergyBalance": 0,
+				"fatMassKg": 0,
+				"muscleMassKg": 0,
+				"fatCalories": 0,
+				"muscleCalories": 0,
+				"avgDailyCalories": 2000,
+				"weightChangeKg": 0,
+				"days": 14,
+				"muscleRatio": 0.3
+			}
+		},
+		{
+			"fn": "calculateMaintenance",
+			"name": "half_round_up",
+			"input": {
+				"weightChangeKg": -0.355,
+				"avgDailyCalories": 2000.5,
+				"days": 7,
+				"muscleRatio": 0.3
+			},
+			"expected": {
+				"maintenanceCalories": 2301,
+				"dailyDeficit": 301,
+				"totalEnergyBalance": 2105,
+				"fatMassKg": 0.25,
+				"muscleMassKg": 0.11,
+				"fatCalories": 1913,
+				"muscleCalories": 192,
+				"avgDailyCalories": 2001,
+				"weightChangeKg": -0.355,
+				"days": 7,
+				"muscleRatio": 0.3
+			}
+		},
+		{
+			"fn": "calculateMaintenance",
+			"name": "invalid_days",
+			"input": {
+				"weightChangeKg": -1,
+				"avgDailyCalories": 2000,
+				"days": 0,
+				"muscleRatio": 0.3
+			},
+			"expected": null
+		},
+		{
+			"fn": "aggregateDailyNutrientTotals",
+			"name": "mixed_food_recipe_quick",
+			"input": {
+				"entries": [
+					{
+						"date": "2025-03-01",
+						"mealType": "breakfast",
+						"servings": 2,
+						"foodId": "f_oats"
+					},
+					{
+						"date": "2025-03-01",
+						"mealType": "lunch",
+						"servings": 1.5,
+						"recipeId": "r_bowl"
+					},
+					{
+						"date": "2025-03-01",
+						"mealType": "snack",
+						"servings": 1,
+						"quickName": "Protein bar",
+						"quickCalories": 200,
+						"quickProtein": 20,
+						"quickCarbs": 22,
+						"quickFat": 7,
+						"quickFiber": 3
+					},
+					{
+						"date": "2025-03-02",
+						"mealType": "dinner",
+						"servings": 1,
+						"recipeId": "r_degenerate"
+					},
+					{
+						"date": "2025-03-02",
+						"mealType": "dinner",
+						"servings": 2,
+						"foodId": "f_salmon"
+					}
+				],
+				"foods": [
+					{
+						"id": "f_oats",
+						"servingSize": 40,
+						"calories": 150,
+						"protein": 5,
+						"carbs": 27,
+						"fat": 3,
+						"fiber": 4
+					},
+					{
+						"id": "f_salmon",
+						"servingSize": 100,
+						"calories": 208,
+						"protein": 20,
+						"carbs": 0,
+						"fat": 13,
+						"fiber": 0,
+						"novaGroup": 1,
+						"omega3": 2.3,
+						"sodium": 59,
+						"vitaminD": 11
+					},
+					{
+						"id": "f_rice",
+						"servingSize": 50,
+						"calories": 180,
+						"protein": 3.3,
+						"carbs": 39,
+						"fat": 0.4,
+						"fiber": 0.6
+					},
+					{
+						"id": "f_zero",
+						"servingSize": 0,
+						"calories": 999,
+						"protein": 9,
+						"carbs": 9,
+						"fat": 9,
+						"fiber": 9
+					}
+				],
+				"recipes": [
+					{
+						"id": "r_bowl",
+						"totalServings": 2,
+						"ingredients": [
+							{
+								"foodId": "f_salmon",
+								"quantity": 150
+							},
+							{
+								"foodId": "f_rice",
+								"quantity": 120
+							},
+							{
+								"foodId": "f_zero",
+								"quantity": 30
+							}
+						]
+					},
+					{
+						"id": "r_degenerate",
+						"totalServings": 0,
+						"ingredients": [
+							{
+								"foodId": "f_oats",
+								"quantity": 80
+							}
+						]
+					}
+				]
+			},
+			"expected": [
+				{
+					"date": "2025-03-01",
+					"calories": 1058,
+					"protein": 58.44,
+					"carbs": 146.2,
+					"fat": 28.345,
+					"fiber": 12.08,
+					"omega3": 2.5875000000000004,
+					"omega6": null,
+					"sodium": 66.375,
+					"caffeine": null,
+					"saturatedFat": null,
+					"transFat": null,
+					"vitaminC": null,
+					"vitaminD": 12.375,
+					"vitaminE": null,
+					"alcohol": null,
+					"addedSugars": null
+				},
+				{
+					"date": "2025-03-02",
+					"calories": 416,
+					"protein": 40,
+					"carbs": 0,
+					"fat": 26,
+					"fiber": 0,
+					"omega3": 4.6,
+					"omega6": null,
+					"sodium": 118,
+					"caffeine": null,
+					"saturatedFat": null,
+					"transFat": null,
+					"vitaminC": null,
+					"vitaminD": 22,
+					"vitaminE": null,
+					"alcohol": null,
+					"addedSugars": null
+				}
+			]
 		}
 	]
 }

--- a/analytics-parity/generate.ts
+++ b/analytics-parity/generate.ts
@@ -13,6 +13,13 @@ import { fileURLToPath } from 'node:url';
 import { pearsonCorrelation } from '../src/lib/analytics/correlation';
 import { movingAverage } from '../src/lib/analytics/moving-average';
 import { computeAdaptiveTDEE, detectPlateau, projectWeight } from '../src/lib/analytics/tdee';
+import {
+	aggregateDailyNutrientTotals,
+	type AggEntry,
+	type AggFood,
+	type AggRecipe
+} from '../src/lib/analytics/aggregation';
+import { calculateMaintenance, type MaintenanceInput } from '../src/lib/utils/maintenance';
 
 type Case = { fn: string; name: string; input: Record<string, unknown>; expected: unknown };
 
@@ -149,6 +156,101 @@ function round(v: number, dp: number): number {
 		'flat_low_sample',
 		{ weightSeries: w2, weeklyRate: 0.0 },
 		projectWeight(w2, 0)
+	);
+}
+
+// --- calculateMaintenance ---------------------------------------------------
+{
+	const maintenanceCases: { name: string; input: MaintenanceInput }[] = [
+		{
+			name: 'loss_default_ratio',
+			input: { weightChangeKg: -1.2, avgDailyCalories: 2100, days: 28 }
+		},
+		{
+			name: 'gain_custom_ratio',
+			input: { weightChangeKg: 0.8, avgDailyCalories: 2850, days: 21, muscleRatio: 0.5 }
+		},
+		{
+			name: 'no_change',
+			input: { weightChangeKg: 0, avgDailyCalories: 2000, days: 14, muscleRatio: 0.3 }
+		},
+		{
+			name: 'half_round_up',
+			input: { weightChangeKg: -0.355, avgDailyCalories: 2000.5, days: 7, muscleRatio: 0.3 }
+		},
+		{
+			name: 'invalid_days',
+			input: { weightChangeKg: -1, avgDailyCalories: 2000, days: 0, muscleRatio: 0.3 }
+		}
+	];
+	for (const { name, input } of maintenanceCases) {
+		add(
+			'calculateMaintenance',
+			name,
+			input as unknown as Record<string, unknown>,
+			calculateMaintenance(input)
+		);
+	}
+}
+
+// --- aggregateDailyNutrientTotals -------------------------------------------
+{
+	// Foods exercise: a plain food, a food with extended nutrients, an
+	// ingredient-only food, and a zero-serving-size food (NULLIF divide-by-zero).
+	const foods: AggFood[] = [
+		{ id: 'f_oats', servingSize: 40, calories: 150, protein: 5, carbs: 27, fat: 3, fiber: 4 },
+		{
+			id: 'f_salmon',
+			servingSize: 100,
+			calories: 208,
+			protein: 20,
+			carbs: 0,
+			fat: 13,
+			fiber: 0,
+			novaGroup: 1,
+			omega3: 2.3,
+			sodium: 59,
+			vitaminD: 11
+		},
+		{ id: 'f_rice', servingSize: 50, calories: 180, protein: 3.3, carbs: 39, fat: 0.4, fiber: 0.6 },
+		{ id: 'f_zero', servingSize: 0, calories: 999, protein: 9, carbs: 9, fat: 9, fiber: 9 }
+	];
+	const recipes: AggRecipe[] = [
+		{
+			id: 'r_bowl',
+			totalServings: 2,
+			ingredients: [
+				{ foodId: 'f_salmon', quantity: 150 },
+				{ foodId: 'f_rice', quantity: 120 },
+				{ foodId: 'f_zero', quantity: 30 } // contributes nothing (servingSize 0)
+			]
+		},
+		{ id: 'r_degenerate', totalServings: 0, ingredients: [{ foodId: 'f_oats', quantity: 80 }] }
+	];
+	const entries: AggEntry[] = [
+		// Day 1: a food entry, a recipe entry (1.5 servings), a quick-add entry.
+		{ date: '2025-03-01', mealType: 'breakfast', servings: 2, foodId: 'f_oats' },
+		{ date: '2025-03-01', mealType: 'lunch', servings: 1.5, recipeId: 'r_bowl' },
+		{
+			date: '2025-03-01',
+			mealType: 'snack',
+			servings: 1,
+			quickName: 'Protein bar',
+			quickCalories: 200,
+			quickProtein: 20,
+			quickCarbs: 22,
+			quickFat: 7,
+			quickFiber: 3
+		},
+		// Day 2: the degenerate recipe (totalServings 0 -> all macros null -> 0) and a salmon food.
+		{ date: '2025-03-02', mealType: 'dinner', servings: 1, recipeId: 'r_degenerate' },
+		{ date: '2025-03-02', mealType: 'dinner', servings: 2, foodId: 'f_salmon' }
+	];
+	add(
+		'aggregateDailyNutrientTotals',
+		'mixed_food_recipe_quick',
+		{ entries, foods, recipes } as unknown as Record<string, unknown>,
+		aggregateDailyNutrientTotals(entries, foods, recipes)
 	);
 }
 

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/analytics/AnalyticsParityTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/analytics/AnalyticsParityTest.kt
@@ -96,6 +96,18 @@ class AnalyticsParityTest {
                 ).toJson()
             }
 
+            "calculateMaintenance" -> {
+                calculateMaintenance(maintenanceInputFrom(input))?.toJson() ?: JsonNull
+            }
+
+            "aggregateDailyNutrientTotals" -> {
+                aggregateDailyNutrientTotals(
+                    aggEntriesFrom(input.getValue("entries")),
+                    aggFoodsFrom(input.getValue("foods")),
+                    aggRecipesFrom(input.getValue("recipes")),
+                ).let { result -> JsonArray(result.map { it.toJson() }) }
+            }
+
             else -> {
                 error("Unknown fn in fixtures: $fn")
             }
@@ -143,6 +155,42 @@ class AnalyticsParityTest {
             put("confidence", confidence.wire())
         }
 
+    private fun MaintenanceResult.toJson() =
+        buildJsonObject {
+            put("maintenanceCalories", maintenanceCalories)
+            put("dailyDeficit", dailyDeficit)
+            put("totalEnergyBalance", totalEnergyBalance)
+            put("fatMassKg", fatMassKg)
+            put("muscleMassKg", muscleMassKg)
+            put("fatCalories", fatCalories)
+            put("muscleCalories", muscleCalories)
+            put("avgDailyCalories", avgDailyCalories)
+            put("weightChangeKg", weightChangeKg)
+            put("days", days)
+            put("muscleRatio", muscleRatio)
+        }
+
+    private fun DailyNutrientTotals.toJson() =
+        buildJsonObject {
+            put("date", date)
+            put("calories", calories)
+            put("protein", protein)
+            put("carbs", carbs)
+            put("fat", fat)
+            put("fiber", fiber)
+            putNullableDouble("omega3", omega3)
+            putNullableDouble("omega6", omega6)
+            putNullableDouble("sodium", sodium)
+            putNullableDouble("caffeine", caffeine)
+            putNullableDouble("saturatedFat", saturatedFat)
+            putNullableDouble("transFat", transFat)
+            putNullableDouble("vitaminC", vitaminC)
+            putNullableDouble("vitaminD", vitaminD)
+            putNullableDouble("vitaminE", vitaminE)
+            putNullableDouble("alcohol", alcohol)
+            putNullableDouble("addedSugars", addedSugars)
+        }
+
     // TS encodes ConfidenceLevel as a lowercase string.
     private fun ConfidenceLevel.wire() = name.lowercase()
 
@@ -169,6 +217,80 @@ class AnalyticsParityTest {
         }
 
     private fun nullableDoublesFrom(el: JsonElement): List<Double?> = el.jsonArray.map { it.asNullableDouble() }
+
+    private fun maintenanceInputFrom(input: JsonObject): MaintenanceInput =
+        MaintenanceInput(
+            weightChangeKg = input.getValue("weightChangeKg").jsonPrimitive.double,
+            avgDailyCalories = input.getValue("avgDailyCalories").jsonPrimitive.double,
+            days = input.getValue("days").jsonPrimitive.int,
+            muscleRatio = input.optDouble("muscleRatio") ?: DEFAULT_MUSCLE_RATIO,
+        )
+
+    private fun aggFoodsFrom(el: JsonElement): List<AggFood> =
+        el.jsonArray.map { it.jsonObject }.map { o ->
+            AggFood(
+                id = o.str("id"),
+                servingSize = o.dbl("servingSize"),
+                calories = o.dbl("calories"),
+                protein = o.dbl("protein"),
+                carbs = o.dbl("carbs"),
+                fat = o.dbl("fat"),
+                fiber = o.dbl("fiber"),
+                novaGroup = o.optInt("novaGroup"),
+                omega3 = o.optDouble("omega3"),
+                omega6 = o.optDouble("omega6"),
+                sodium = o.optDouble("sodium"),
+                caffeine = o.optDouble("caffeine"),
+                saturatedFat = o.optDouble("saturatedFat"),
+                transFat = o.optDouble("transFat"),
+                vitaminC = o.optDouble("vitaminC"),
+                vitaminD = o.optDouble("vitaminD"),
+                vitaminE = o.optDouble("vitaminE"),
+                alcohol = o.optDouble("alcohol"),
+                addedSugars = o.optDouble("addedSugars"),
+            )
+        }
+
+    private fun aggRecipesFrom(el: JsonElement): List<AggRecipe> =
+        el.jsonArray.map { it.jsonObject }.map { o ->
+            AggRecipe(
+                id = o.str("id"),
+                totalServings = o.dbl("totalServings"),
+                ingredients =
+                    o.getValue("ingredients").jsonArray.map { it.jsonObject }.map { ing ->
+                        AggRecipeIngredient(foodId = ing.str("foodId"), quantity = ing.dbl("quantity"))
+                    },
+            )
+        }
+
+    private fun aggEntriesFrom(el: JsonElement): List<AggEntry> =
+        el.jsonArray.map { it.jsonObject }.map { o ->
+            AggEntry(
+                date = o.str("date"),
+                mealType = o.str("mealType"),
+                servings = o.dbl("servings"),
+                foodId = o.optStr("foodId"),
+                recipeId = o.optStr("recipeId"),
+                eatenAt = o.optStr("eatenAt"),
+                foodName = o.optStr("foodName"),
+                quickName = o.optStr("quickName"),
+                quickCalories = o.optDouble("quickCalories"),
+                quickProtein = o.optDouble("quickProtein"),
+                quickCarbs = o.optDouble("quickCarbs"),
+                quickFat = o.optDouble("quickFat"),
+                quickFiber = o.optDouble("quickFiber"),
+            )
+        }
+
+    private fun JsonObject.str(key: String): String = getValue(key).jsonPrimitive.content
+
+    private fun JsonObject.dbl(key: String): Double = getValue(key).jsonPrimitive.double
+
+    private fun JsonObject.optStr(key: String): String? = this[key]?.let { if (it is JsonNull) null else it.jsonPrimitive.content }
+
+    private fun JsonObject.optDouble(key: String): Double? = this[key]?.let { if (it is JsonNull) null else it.jsonPrimitive.double }
+
+    private fun JsonObject.optInt(key: String): Int? = this[key]?.let { if (it is JsonNull) null else it.jsonPrimitive.int }
 
     private fun doubleArrayFrom(el: JsonElement): DoubleArray = el.jsonArray.map { it.jsonPrimitive.double }.toDoubleArray()
 

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/analytics/Aggregation.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/analytics/Aggregation.kt
@@ -1,0 +1,524 @@
+package com.bissbilanz.analytics
+
+import kotlinx.datetime.LocalDate
+
+/*
+ * On-device equivalent of the server's recipe-macro aggregation
+ * (src/lib/server/analytics.ts). The server resolves per-entry and per-day
+ * nutrient totals with SQL CTEs over Postgres; this reproduces the exact same
+ * math in pure Kotlin over local rows so the mobile apps can build the inputs
+ * the analytics functions expect without an API round-trip.
+ *
+ * Faithfulness to the SQL matters down to the NULL handling, because that is
+ * what the golden-vector parity suite (analytics-parity/) locks against the TS
+ * reference (src/lib/analytics/aggregation.ts). The rules being mirrored:
+ *  - a / NULLIF(b, 0) -> null when b == 0 (see nullDiv);
+ *  - SUM(...) ignores NULL terms and is NULL only when every term is NULL
+ *    (see nullSum);
+ *  - core macros COALESCE to 0 (always numeric); extended nutrients do not, so
+ *    a day with no measured value for a nutrient stays null rather than 0.
+ *
+ * Each platform's data-loader maps its SQLDelight / SwiftData rows into these
+ * plain AggEntry / AggFood / AggRecipe shapes — that mapping is the only
+ * platform-specific part; everything below is shared.
+ */
+
+/** A food with its base (per-serving-size) nutrients; extended nutrients are nullable. */
+data class AggFood(
+    val id: String,
+    val servingSize: Double,
+    val calories: Double,
+    val protein: Double,
+    val carbs: Double,
+    val fat: Double,
+    val fiber: Double,
+    val novaGroup: Int? = null,
+    val omega3: Double? = null,
+    val omega6: Double? = null,
+    val sodium: Double? = null,
+    val caffeine: Double? = null,
+    val saturatedFat: Double? = null,
+    val transFat: Double? = null,
+    val vitaminC: Double? = null,
+    val vitaminD: Double? = null,
+    val vitaminE: Double? = null,
+    val alcohol: Double? = null,
+    val addedSugars: Double? = null,
+)
+
+/** One ingredient line of a recipe: a [foodId] taken in [quantity] of the food's serving unit. */
+data class AggRecipeIngredient(
+    val foodId: String,
+    val quantity: Double,
+)
+
+/** A recipe and its ingredient lines; [totalServings] divides the summed ingredient nutrients. */
+data class AggRecipe(
+    val id: String,
+    val totalServings: Double,
+    val ingredients: List<AggRecipeIngredient>,
+)
+
+/**
+ * A logged entry. Exactly one of [foodId] / [recipeId] is normally set; a
+ * quick-add entry sets neither and carries its own `quick*` macros. [servings]
+ * scales whichever source resolves.
+ */
+data class AggEntry(
+    val date: String,
+    val mealType: String,
+    val servings: Double,
+    val foodId: String? = null,
+    val recipeId: String? = null,
+    val eatenAt: String? = null,
+    val foodName: String? = null,
+    val quickName: String? = null,
+    val quickCalories: Double? = null,
+    val quickProtein: Double? = null,
+    val quickCarbs: Double? = null,
+    val quickFat: Double? = null,
+    val quickFiber: Double? = null,
+)
+
+/** Per-day nutrient totals; core macros are always numeric, extended nutrients are null when unmeasured. */
+data class DailyNutrientTotals(
+    val date: String,
+    val calories: Double,
+    val protein: Double,
+    val carbs: Double,
+    val fat: Double,
+    val fiber: Double,
+    val omega3: Double?,
+    val omega6: Double?,
+    val sodium: Double?,
+    val caffeine: Double?,
+    val saturatedFat: Double?,
+    val transFat: Double?,
+    val vitaminC: Double?,
+    val vitaminD: Double?,
+    val vitaminE: Double?,
+    val alcohol: Double?,
+    val addedSugars: Double?,
+)
+
+/** Per-entry resolved nutrients (the on-device equivalent of `getExtendedNutrientEntries`). */
+data class ExtendedNutrientEntry(
+    val date: String,
+    val mealType: String,
+    val eatenAt: String?,
+    val foodId: String?,
+    val recipeId: String?,
+    val foodName: String,
+    val calories: Double,
+    val protein: Double,
+    val carbs: Double,
+    val fat: Double,
+    val fiber: Double,
+    val novaGroup: Int?,
+    val omega3: Double?,
+    val omega6: Double?,
+    val sodium: Double?,
+    val caffeine: Double?,
+    val saturatedFat: Double?,
+    val transFat: Double?,
+    val vitaminC: Double?,
+    val vitaminD: Double?,
+    val vitaminE: Double?,
+    val alcohol: Double?,
+    val addedSugars: Double?,
+)
+
+/** Per-entry meal-timing row (the on-device equivalent of `getMealTimingData`). */
+data class MealTimingRow(
+    val date: String,
+    val mealType: String,
+    val eatenAt: String?,
+    val foodId: String?,
+    val recipeId: String?,
+    val calories: Double,
+    val foodName: String,
+)
+
+/** Per-entry food-diversity row (the on-device equivalent of `getFoodDiversityData`). */
+data class FoodDiversityRow(
+    val date: String,
+    val foodId: String?,
+    val recipeId: String?,
+    val foodName: String,
+    val novaGroup: Int?,
+)
+
+/** One day of the weight/food correlation series (the on-device equivalent of `getWeightFoodSeries`). */
+data class WeightFoodPoint(
+    val date: String,
+    val calories: Double?,
+    val weightKg: Double?,
+    val movingAvg: Double?,
+)
+
+/** Sleep night paired with the previous day's evening calories (`getSleepFoodCorrelationData`). */
+data class SleepFoodPoint(
+    val date: String,
+    val eveningCalories: Double?,
+    val sleepDurationMinutes: Int,
+    val sleepQuality: Int,
+)
+
+/** A weight measurement on a date. */
+data class WeightRow(
+    val entryDate: String,
+    val weightKg: Double,
+)
+
+/** A sleep measurement on a date. */
+data class SleepRow(
+    val entryDate: String,
+    val durationMinutes: Int,
+    val quality: Int,
+)
+
+// --- SQL-semantics primitives ----------------------------------------------
+
+/** `a / NULLIF(b, 0)`: null when the divisor is zero, otherwise the quotient. */
+internal fun nullDiv(
+    a: Double,
+    b: Double,
+): Double? = if (b == 0.0) null else a / b
+
+/** `SUM(values)`: ignores nulls; null only when every value is null. */
+internal fun nullSum(values: List<Double?>): Double? {
+    var acc = 0.0
+    var any = false
+    for (v in values) {
+        if (v != null) {
+            acc += v
+            any = true
+        }
+    }
+    return if (any) acc else null
+}
+
+// --- recipe macro resolution (the recipe_macros / recipe_extended CTEs) ------
+
+private class ResolvedRecipe(
+    val calories: Double?,
+    val protein: Double?,
+    val carbs: Double?,
+    val fat: Double?,
+    val fiber: Double?,
+    val omega3: Double?,
+    val omega6: Double?,
+    val sodium: Double?,
+    val caffeine: Double?,
+    val saturatedFat: Double?,
+    val transFat: Double?,
+    val vitaminC: Double?,
+    val vitaminD: Double?,
+    val vitaminE: Double?,
+    val alcohol: Double?,
+    val addedSugars: Double?,
+)
+
+/**
+ * Per-serving recipe nutrient:
+ * `SUM(food.nutrient * qty / NULLIF(food.servingSize, 0)) / NULLIF(recipe.totalServings, 0)`.
+ * Ingredients whose food is missing or whose nutrient is null contribute nothing
+ * (matching the INNER JOIN + NULL-skipping SUM); an all-null result is null.
+ */
+private fun recipePerServing(
+    recipe: AggRecipe,
+    foodsById: Map<String, AggFood>,
+    nutrient: (AggFood) -> Double?,
+): Double? {
+    val terms =
+        recipe.ingredients.mapNotNull { ing ->
+            val food = foodsById[ing.foodId] ?: return@mapNotNull null
+            val value = nutrient(food) ?: return@mapNotNull null
+            nullDiv(value * ing.quantity, food.servingSize)
+        }
+    if (terms.isEmpty()) return null
+    return nullDiv(terms.sum(), recipe.totalServings)
+}
+
+private fun resolveRecipes(
+    recipes: List<AggRecipe>,
+    foodsById: Map<String, AggFood>,
+): Map<String, ResolvedRecipe> =
+    recipes.associate { r ->
+        r.id to
+            ResolvedRecipe(
+                calories = recipePerServing(r, foodsById) { it.calories },
+                protein = recipePerServing(r, foodsById) { it.protein },
+                carbs = recipePerServing(r, foodsById) { it.carbs },
+                fat = recipePerServing(r, foodsById) { it.fat },
+                fiber = recipePerServing(r, foodsById) { it.fiber },
+                omega3 = recipePerServing(r, foodsById) { it.omega3 },
+                omega6 = recipePerServing(r, foodsById) { it.omega6 },
+                sodium = recipePerServing(r, foodsById) { it.sodium },
+                caffeine = recipePerServing(r, foodsById) { it.caffeine },
+                saturatedFat = recipePerServing(r, foodsById) { it.saturatedFat },
+                transFat = recipePerServing(r, foodsById) { it.transFat },
+                vitaminC = recipePerServing(r, foodsById) { it.vitaminC },
+                vitaminD = recipePerServing(r, foodsById) { it.vitaminD },
+                vitaminE = recipePerServing(r, foodsById) { it.vitaminE },
+                alcohol = recipePerServing(r, foodsById) { it.alcohol },
+                addedSugars = recipePerServing(r, foodsById) { it.addedSugars },
+            )
+    }
+
+// --- per-entry resolution (the COALESCE expressions) ------------------------
+
+/** `COALESCE(food.macro, recipe.macro, quick.macro, 0) * servings` — always numeric. */
+private fun entryCore(
+    entry: AggEntry,
+    food: AggFood?,
+    recipe: ResolvedRecipe?,
+    foodMacro: (AggFood) -> Double,
+    recipeMacro: (ResolvedRecipe) -> Double?,
+    quick: Double?,
+): Double {
+    val base = food?.let(foodMacro) ?: recipe?.let(recipeMacro) ?: quick ?: 0.0
+    return base * entry.servings
+}
+
+/** `COALESCE(food.nutrient, recipe.nutrient) * servings` — null (no quick fallback) when both absent. */
+private fun entryExtended(
+    entry: AggEntry,
+    food: AggFood?,
+    recipe: ResolvedRecipe?,
+    foodNutrient: (AggFood) -> Double?,
+    recipeNutrient: (ResolvedRecipe) -> Double?,
+): Double? {
+    val base = food?.let(foodNutrient) ?: recipe?.let(recipeNutrient) ?: return null
+    return base * entry.servings
+}
+
+private fun foodNameOf(
+    entry: AggEntry,
+    food: AggFood?,
+): String = entry.foodName ?: entry.quickName ?: "Unknown"
+
+// --- public aggregations ----------------------------------------------------
+
+/**
+ * Per-day nutrient totals across [entries], resolving foods and recipes the same
+ * way the server does. Returned sorted by date ascending; only dates with at
+ * least one entry appear. Mirrors `getDailyNutrientTotals`.
+ */
+fun aggregateDailyNutrientTotals(
+    entries: List<AggEntry>,
+    foods: List<AggFood>,
+    recipes: List<AggRecipe>,
+): List<DailyNutrientTotals> {
+    val foodsById = foods.associateBy { it.id }
+    val resolved = resolveRecipes(recipes, foodsById)
+
+    val byDate = entries.groupBy { it.date }
+    return byDate.keys
+        .sorted()
+        .map { date ->
+            val dayEntries = byDate.getValue(date)
+            val rows =
+                dayEntries.map { e ->
+                    val food = e.foodId?.let { foodsById[it] }
+                    val recipe = e.recipeId?.let { resolved[it] }
+                    EntryNutrients(e, food, recipe)
+                }
+            DailyNutrientTotals(
+                date = date,
+                calories = rows.sumOf { it.core({ f -> f.calories }, { r -> r.calories }, it.entry.quickCalories) },
+                protein = rows.sumOf { it.core({ f -> f.protein }, { r -> r.protein }, it.entry.quickProtein) },
+                carbs = rows.sumOf { it.core({ f -> f.carbs }, { r -> r.carbs }, it.entry.quickCarbs) },
+                fat = rows.sumOf { it.core({ f -> f.fat }, { r -> r.fat }, it.entry.quickFat) },
+                fiber = rows.sumOf { it.core({ f -> f.fiber }, { r -> r.fiber }, it.entry.quickFiber) },
+                omega3 = nullSum(rows.map { it.ext({ f -> f.omega3 }, { r -> r.omega3 }) }),
+                omega6 = nullSum(rows.map { it.ext({ f -> f.omega6 }, { r -> r.omega6 }) }),
+                sodium = nullSum(rows.map { it.ext({ f -> f.sodium }, { r -> r.sodium }) }),
+                caffeine = nullSum(rows.map { it.ext({ f -> f.caffeine }, { r -> r.caffeine }) }),
+                saturatedFat = nullSum(rows.map { it.ext({ f -> f.saturatedFat }, { r -> r.saturatedFat }) }),
+                transFat = nullSum(rows.map { it.ext({ f -> f.transFat }, { r -> r.transFat }) }),
+                vitaminC = nullSum(rows.map { it.ext({ f -> f.vitaminC }, { r -> r.vitaminC }) }),
+                vitaminD = nullSum(rows.map { it.ext({ f -> f.vitaminD }, { r -> r.vitaminD }) }),
+                vitaminE = nullSum(rows.map { it.ext({ f -> f.vitaminE }, { r -> r.vitaminE }) }),
+                alcohol = nullSum(rows.map { it.ext({ f -> f.alcohol }, { r -> r.alcohol }) }),
+                addedSugars = nullSum(rows.map { it.ext({ f -> f.addedSugars }, { r -> r.addedSugars }) }),
+            )
+        }
+}
+
+/**
+ * Per-entry resolved nutrients across [entries]. Mirrors `getExtendedNutrientEntries`;
+ * sorted by (date, eatenAt) so downstream timing logic sees the same order as the server.
+ */
+fun extendedNutrientEntries(
+    entries: List<AggEntry>,
+    foods: List<AggFood>,
+    recipes: List<AggRecipe>,
+): List<ExtendedNutrientEntry> {
+    val foodsById = foods.associateBy { it.id }
+    val resolved = resolveRecipes(recipes, foodsById)
+
+    return entries.sortedByEntryOrder().map { e ->
+        val food = e.foodId?.let { foodsById[it] }
+        val recipe = e.recipeId?.let { resolved[it] }
+        val n = EntryNutrients(e, food, recipe)
+        ExtendedNutrientEntry(
+            date = e.date,
+            mealType = e.mealType,
+            eatenAt = e.eatenAt,
+            foodId = e.foodId,
+            recipeId = e.recipeId,
+            foodName = foodNameOf(e, food),
+            calories = n.core({ f -> f.calories }, { r -> r.calories }, e.quickCalories),
+            protein = n.core({ f -> f.protein }, { r -> r.protein }, e.quickProtein),
+            carbs = n.core({ f -> f.carbs }, { r -> r.carbs }, e.quickCarbs),
+            fat = n.core({ f -> f.fat }, { r -> r.fat }, e.quickFat),
+            fiber = n.core({ f -> f.fiber }, { r -> r.fiber }, e.quickFiber),
+            novaGroup = food?.novaGroup,
+            omega3 = n.ext({ f -> f.omega3 }, { r -> r.omega3 }),
+            omega6 = n.ext({ f -> f.omega6 }, { r -> r.omega6 }),
+            sodium = n.ext({ f -> f.sodium }, { r -> r.sodium }),
+            caffeine = n.ext({ f -> f.caffeine }, { r -> r.caffeine }),
+            saturatedFat = n.ext({ f -> f.saturatedFat }, { r -> r.saturatedFat }),
+            transFat = n.ext({ f -> f.transFat }, { r -> r.transFat }),
+            vitaminC = n.ext({ f -> f.vitaminC }, { r -> r.vitaminC }),
+            vitaminD = n.ext({ f -> f.vitaminD }, { r -> r.vitaminD }),
+            vitaminE = n.ext({ f -> f.vitaminE }, { r -> r.vitaminE }),
+            alcohol = n.ext({ f -> f.alcohol }, { r -> r.alcohol }),
+            addedSugars = n.ext({ f -> f.addedSugars }, { r -> r.addedSugars }),
+        )
+    }
+}
+
+/** Per-entry calories + name, sorted by (date, eatenAt). Mirrors `getMealTimingData`. */
+fun mealTimingRows(
+    entries: List<AggEntry>,
+    foods: List<AggFood>,
+    recipes: List<AggRecipe>,
+): List<MealTimingRow> {
+    val foodsById = foods.associateBy { it.id }
+    val resolved = resolveRecipes(recipes, foodsById)
+
+    return entries.sortedByEntryOrder().map { e ->
+        val food = e.foodId?.let { foodsById[it] }
+        val recipe = e.recipeId?.let { resolved[it] }
+        val n = EntryNutrients(e, food, recipe)
+        MealTimingRow(
+            date = e.date,
+            mealType = e.mealType,
+            eatenAt = e.eatenAt,
+            foodId = e.foodId,
+            recipeId = e.recipeId,
+            calories = n.core({ f -> f.calories }, { r -> r.calories }, e.quickCalories),
+            foodName = foodNameOf(e, food),
+        )
+    }
+}
+
+/** Per-entry food identity + NOVA group, sorted by date. Mirrors `getFoodDiversityData`. */
+fun foodDiversityRows(
+    entries: List<AggEntry>,
+    foods: List<AggFood>,
+): List<FoodDiversityRow> {
+    val foodsById = foods.associateBy { it.id }
+    return entries.sortedBy { it.date }.map { e ->
+        val food = e.foodId?.let { foodsById[it] }
+        FoodDiversityRow(
+            date = e.date,
+            foodId = e.foodId,
+            recipeId = e.recipeId,
+            foodName = foodNameOf(e, food),
+            novaGroup = food?.novaGroup,
+        )
+    }
+}
+
+/**
+ * Daily calories joined with weight measurements, plus a trailing 7-calendar-day
+ * moving average of weight. Mirrors `getWeightFoodSeries`: the window is the
+ * current day and the six prior calendar days (not the prior six samples), and
+ * a day with no weight contributes nothing.
+ */
+fun weightFoodSeries(
+    entries: List<AggEntry>,
+    foods: List<AggFood>,
+    recipes: List<AggRecipe>,
+    weights: List<WeightRow>,
+): List<WeightFoodPoint> {
+    val caloriesByDate =
+        aggregateDailyNutrientTotals(entries, foods, recipes).associate { it.date to it.calories }
+    val weightByDate = weights.associate { it.entryDate to it.weightKg }
+
+    val dates = (caloriesByDate.keys + weightByDate.keys).distinct().sorted()
+    val epochDays = dates.map { LocalDate.parse(it).toEpochDays() }
+
+    return dates.indices.map { i ->
+        val windowStart = epochDays[i] - 6
+        var sum = 0.0
+        var count = 0
+        var j = i
+        while (j >= 0 && epochDays[j] >= windowStart) {
+            weightByDate[dates[j]]?.let {
+                sum += it
+                count++
+            }
+            j--
+        }
+        WeightFoodPoint(
+            date = dates[i],
+            calories = caloriesByDate[dates[i]],
+            weightKg = weightByDate[dates[i]],
+            movingAvg = if (count > 0) sum / count else null,
+        )
+    }
+}
+
+/**
+ * Pairs each sleep night with the prior day's evening calories. Mirrors
+ * `getSleepFoodCorrelationData`, but the caller pre-filters [eveningEntries] to
+ * entries eaten at/after the local evening cutoff (the server does this in SQL
+ * with a timezone-aware `EXTRACT(HOUR ...)`).
+ */
+fun sleepFoodCorrelation(
+    eveningEntries: List<AggEntry>,
+    foods: List<AggFood>,
+    recipes: List<AggRecipe>,
+    sleep: List<SleepRow>,
+): List<SleepFoodPoint> {
+    val eveningCaloriesByDate =
+        aggregateDailyNutrientTotals(eveningEntries, foods, recipes).associate { it.date to it.calories }
+
+    return sleep.map { night ->
+        val prevDate = LocalDate.parse(night.entryDate).toEpochDays() - 1
+        val prevDateStr = LocalDate.fromEpochDays(prevDate).toString()
+        SleepFoodPoint(
+            date = night.entryDate,
+            eveningCalories = eveningCaloriesByDate[prevDateStr],
+            sleepDurationMinutes = night.durationMinutes,
+            sleepQuality = night.quality,
+        )
+    }
+}
+
+// --- shared per-entry helper ------------------------------------------------
+
+/** Bundles an entry with its resolved food/recipe so the macro accessors read cleanly. */
+private class EntryNutrients(
+    val entry: AggEntry,
+    val food: AggFood?,
+    val recipe: ResolvedRecipe?,
+) {
+    fun core(
+        foodMacro: (AggFood) -> Double,
+        recipeMacro: (ResolvedRecipe) -> Double?,
+        quick: Double?,
+    ): Double = entryCore(entry, food, recipe, foodMacro, recipeMacro, quick)
+
+    fun ext(
+        foodNutrient: (AggFood) -> Double?,
+        recipeNutrient: (ResolvedRecipe) -> Double?,
+    ): Double? = entryExtended(entry, food, recipe, foodNutrient, recipeNutrient)
+}
+
+/** Stable (date, eatenAt) ordering matching the server's `ORDER BY date, eatenAt`. */
+private fun List<AggEntry>.sortedByEntryOrder(): List<AggEntry> = sortedWith(compareBy({ it.date }, { it.eatenAt ?: "" }))

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/analytics/Maintenance.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/analytics/Maintenance.kt
@@ -1,0 +1,103 @@
+package com.bissbilanz.analytics
+
+import kotlin.math.abs
+import kotlin.math.floor
+
+/**
+ * Energy-balance maintenance-calorie estimator. Pure port of the server's
+ * `src/lib/utils/maintenance.ts` so the mobile apps can compute maintenance
+ * on-device (local/anonymous users) and online users can compute it from the
+ * synced local DB without an API round-trip. The golden-vector parity suite
+ * (analytics-parity/) keeps this in lockstep with the TS source.
+ *
+ * The model splits an observed weight change into fat and muscle mass using a
+ * fixed muscle ratio, prices each at its energy density, and converts the total
+ * energy imbalance over the window into a daily deficit/surplus relative to the
+ * average intake.
+ */
+const val KCAL_PER_KG_FAT = 7700.0
+const val KCAL_PER_KG_MUSCLE = 1800.0
+const val DEFAULT_MUSCLE_RATIO = 0.3
+
+/** Inputs to [calculateMaintenance]; mirrors the TS `MaintenanceInput`. */
+data class MaintenanceInput(
+    val weightChangeKg: Double,
+    val avgDailyCalories: Double,
+    val days: Int,
+    val muscleRatio: Double = DEFAULT_MUSCLE_RATIO,
+)
+
+/** Result of [calculateMaintenance]; mirrors the TS `MaintenanceResult` field-for-field. */
+data class MaintenanceResult(
+    val maintenanceCalories: Double,
+    val dailyDeficit: Double,
+    val totalEnergyBalance: Double,
+    val fatMassKg: Double,
+    val muscleMassKg: Double,
+    val fatCalories: Double,
+    val muscleCalories: Double,
+    val avgDailyCalories: Double,
+    val weightChangeKg: Double,
+    val days: Int,
+    val muscleRatio: Double,
+)
+
+/**
+ * Estimates maintenance calories from a window's weight change and average
+ * intake. Returns null for a non-positive window or negative average intake,
+ * matching the server contract exactly.
+ *
+ * A loss (negative [MaintenanceInput.weightChangeKg]) implies intake was below
+ * maintenance, so the daily deficit is added back to the average to recover
+ * maintenance; a gain subtracts. All public numbers are rounded the same way
+ * the TS does (JS `Math.round`, i.e. round-half-up — see [jsRound]).
+ */
+fun calculateMaintenance(input: MaintenanceInput): MaintenanceResult? {
+    val weightChangeKg = input.weightChangeKg
+    val avgDailyCalories = input.avgDailyCalories
+    val days = input.days
+    val muscleRatio = input.muscleRatio
+
+    if (days <= 0 || avgDailyCalories < 0) return null
+
+    val fatRatio = 1 - muscleRatio
+    val fatMassKg = abs(weightChangeKg) * fatRatio
+    val muscleMassKg = abs(weightChangeKg) * muscleRatio
+
+    val fatCalories = fatMassKg * KCAL_PER_KG_FAT
+    val muscleCalories = muscleMassKg * KCAL_PER_KG_MUSCLE
+    val totalEnergy = fatCalories + muscleCalories
+
+    val sign =
+        when {
+            weightChangeKg < 0 -> 1
+            weightChangeKg > 0 -> -1
+            else -> 0
+        }
+    val totalEnergyBalance = totalEnergy * sign
+    val dailyDeficit = if (days > 0) totalEnergyBalance / days else 0.0
+
+    val maintenanceCalories = jsRound(avgDailyCalories + dailyDeficit)
+
+    return MaintenanceResult(
+        maintenanceCalories = maintenanceCalories,
+        dailyDeficit = jsRound(dailyDeficit),
+        totalEnergyBalance = jsRound(totalEnergyBalance),
+        fatMassKg = jsRound(fatMassKg * 100) / 100,
+        muscleMassKg = jsRound(muscleMassKg * 100) / 100,
+        fatCalories = jsRound(fatCalories),
+        muscleCalories = jsRound(muscleCalories),
+        avgDailyCalories = jsRound(avgDailyCalories),
+        weightChangeKg = weightChangeKg,
+        days = days,
+        muscleRatio = muscleRatio,
+    )
+}
+
+/**
+ * JavaScript `Math.round` semantics: round half toward +infinity (`Math.round(2.5)
+ * == 3`, `Math.round(-2.5) == -2`). Kotlin's `kotlin.math.round` rounds half to
+ * even, so it cannot be used here without breaking byte-for-byte parity with the
+ * TS server.
+ */
+internal fun jsRound(value: Double): Double = floor(value + 0.5)

--- a/mobile/shared/src/commonTest/kotlin/com/bissbilanz/analytics/AggregationTest.kt
+++ b/mobile/shared/src/commonTest/kotlin/com/bissbilanz/analytics/AggregationTest.kt
@@ -1,0 +1,146 @@
+package com.bissbilanz.analytics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for the on-device aggregation transforms. The two cross-language
+ * pieces ([calculateMaintenance] and [aggregateDailyNutrientTotals]) are also
+ * locked to the TS reference by the golden-vector parity suite; this file covers
+ * the per-entry / series transforms that the platform data-loaders consume.
+ */
+class AggregationTest {
+    private val oats =
+        AggFood(id = "oats", servingSize = 40.0, calories = 150.0, protein = 5.0, carbs = 27.0, fat = 3.0, fiber = 4.0)
+    private val salmon =
+        AggFood(
+            id = "salmon",
+            servingSize = 100.0,
+            calories = 208.0,
+            protein = 20.0,
+            carbs = 0.0,
+            fat = 13.0,
+            fiber = 0.0,
+            novaGroup = 1,
+            omega3 = 2.3,
+            sodium = 59.0,
+        )
+    private val rice =
+        AggFood(id = "rice", servingSize = 50.0, calories = 180.0, protein = 3.3, carbs = 39.0, fat = 0.4, fiber = 0.6)
+
+    private val bowl =
+        AggRecipe(
+            id = "bowl",
+            totalServings = 2.0,
+            ingredients = listOf(AggRecipeIngredient("salmon", 150.0), AggRecipeIngredient("rice", 120.0)),
+        )
+
+    @Test
+    fun dailyTotalsResolveFoodRecipeAndQuick() {
+        val entries =
+            listOf(
+                AggEntry(date = "2025-03-01", mealType = "breakfast", servings = 2.0, foodId = "oats"),
+                AggEntry(date = "2025-03-01", mealType = "lunch", servings = 1.5, recipeId = "bowl"),
+                AggEntry(
+                    date = "2025-03-01",
+                    mealType = "snack",
+                    servings = 1.0,
+                    quickName = "Bar",
+                    quickCalories = 200.0,
+                    quickProtein = 20.0,
+                ),
+            )
+        val totals = aggregateDailyNutrientTotals(entries, listOf(oats, salmon, rice), listOf(bowl))
+        assertEquals(1, totals.size)
+        // oats 300 + recipe (744/2)*1.5=558 + quick 200 = 1058
+        assertEquals(1058.0, totals[0].calories, 1e-9)
+        // omega3 only from the recipe's salmon: (2.3*150/100)/2*1.5 = 2.5875
+        assertEquals(2.5875, totals[0].omega3!!, 1e-9)
+        // no carbs nutrient carries omega6 anywhere -> null
+        assertNull(totals[0].omega6)
+    }
+
+    @Test
+    fun zeroServingSizeAndZeroTotalServingsContributeNothing() {
+        val zeroFood = AggFood(id = "z", servingSize = 0.0, calories = 999.0, protein = 9.0, carbs = 9.0, fat = 9.0, fiber = 9.0)
+        val degenerate = AggRecipe(id = "deg", totalServings = 0.0, ingredients = listOf(AggRecipeIngredient("oats", 80.0)))
+        val entries =
+            listOf(
+                AggEntry(date = "2025-03-02", mealType = "a", servings = 1.0, foodId = "z"),
+                AggEntry(date = "2025-03-02", mealType = "b", servings = 1.0, recipeId = "deg"),
+            )
+        val totals = aggregateDailyNutrientTotals(entries, listOf(oats, zeroFood), listOf(degenerate))
+        // zero-serving food -> NULLIF divide-by-zero is only inside recipes; a direct
+        // food entry still uses its stored calories, so only the recipe collapses to 0.
+        assertEquals(999.0, totals[0].calories, 1e-9)
+        assertNull(totals[0].omega3)
+    }
+
+    @Test
+    fun extendedEntriesSortByDateThenEatenAtAndCarryNova() {
+        val entries =
+            listOf(
+                AggEntry(date = "2025-03-01", mealType = "dinner", servings = 1.0, foodId = "salmon", eatenAt = "2025-03-01T20:00:00Z"),
+                AggEntry(date = "2025-03-01", mealType = "breakfast", servings = 2.0, foodId = "oats", eatenAt = "2025-03-01T08:00:00Z"),
+            )
+        val rows = extendedNutrientEntries(entries, listOf(oats, salmon), emptyList())
+        assertEquals(listOf("oats", "salmon"), rows.map { it.foodId })
+        assertEquals(1, rows[1].novaGroup)
+        assertNull(rows[0].novaGroup)
+        assertEquals(59.0, rows[1].sodium!!, 1e-9)
+    }
+
+    @Test
+    fun foodNameFallsBackToQuickNameThenUnknown() {
+        val entries =
+            listOf(
+                AggEntry(date = "2025-03-01", mealType = "snack", servings = 1.0, quickName = "Homemade"),
+                AggEntry(date = "2025-03-01", mealType = "snack", servings = 1.0),
+            )
+        val rows = foodDiversityRows(entries, emptyList())
+        assertEquals(listOf("Homemade", "Unknown"), rows.map { it.foodName })
+    }
+
+    @Test
+    fun weightFoodSeriesTrailing7DayWindowSkipsGaps() {
+        val weights =
+            listOf(
+                WeightRow("2025-03-01", 80.0),
+                WeightRow("2025-03-05", 79.6),
+                WeightRow("2025-03-12", 79.2),
+            )
+        val series = weightFoodSeries(emptyList(), emptyList(), emptyList(), weights)
+        assertEquals(listOf("2025-03-01", "2025-03-05", "2025-03-12"), series.map { it.date })
+        // day 5 window covers Feb 27..Mar 5 -> avg(80.0, 79.6)
+        assertEquals(79.8, series[1].movingAvg!!, 1e-9)
+        // day 12 window is Mar 6..12 -> Mar 1 and Mar 5 both fall outside, only Mar 12
+        assertEquals(79.2, series[2].movingAvg!!, 1e-9)
+    }
+
+    @Test
+    fun sleepFoodPairsPreviousDayEveningCalories() {
+        val eveningEntries =
+            listOf(AggEntry(date = "2025-03-01", mealType = "dinner", servings = 1.0, foodId = "salmon"))
+        val sleep = listOf(SleepRow("2025-03-02", 420, 4), SleepRow("2025-03-01", 400, 3))
+        val rows = sleepFoodCorrelation(eveningEntries, listOf(salmon), emptyList(), sleep)
+        val byDate = rows.associateBy { it.date }
+        assertEquals(208.0, byDate.getValue("2025-03-02").eveningCalories!!, 1e-9)
+        assertNull(byDate.getValue("2025-03-01").eveningCalories)
+    }
+
+    @Test
+    fun maintenanceReturnsNullForInvalidWindow() {
+        assertNull(calculateMaintenance(MaintenanceInput(weightChangeKg = -1.0, avgDailyCalories = 2000.0, days = 0)))
+        assertNull(calculateMaintenance(MaintenanceInput(weightChangeKg = -1.0, avgDailyCalories = -1.0, days = 7)))
+    }
+
+    @Test
+    fun maintenanceLossAddsDeficitBack() {
+        val result = calculateMaintenance(MaintenanceInput(weightChangeKg = -1.2, avgDailyCalories = 2100.0, days = 28))
+        assertTrue(result != null)
+        assertEquals(2354.0, result.maintenanceCalories, 1e-9)
+        assertEquals(0.3, result.muscleRatio, 1e-9)
+    }
+}

--- a/src/lib/analytics/aggregation.ts
+++ b/src/lib/analytics/aggregation.ts
@@ -1,0 +1,260 @@
+/**
+ * Pure, dependency-free reference for the per-day nutrient aggregation that the
+ * server runs as SQL CTEs in `src/lib/server/analytics.ts`. This is the canonical
+ * on-device aggregation: the shared Kotlin port
+ * (`mobile/shared/.../analytics/Aggregation.kt`) is locked to it by the
+ * golden-vector parity suite (analytics-parity/), and the mobile apps compute
+ * daily totals from their local DB through that Kotlin port.
+ *
+ * The math mirrors the SQL down to its NULL handling:
+ *  - `a / NULLIF(b, 0)` -> null when `b === 0` (see {@link nullDiv});
+ *  - `SUM(...)` ignores NULL terms and is NULL only when every term is NULL
+ *    (see {@link nullSum});
+ *  - core macros COALESCE to 0 (always numeric); extended nutrients do not, so a
+ *    day with no measured value for a nutrient stays null rather than 0.
+ *
+ * Keep this file free of SvelteKit/Drizzle imports so the generator and the
+ * parity test can import it without the server runtime.
+ */
+
+export type AggFood = {
+	id: string;
+	servingSize: number;
+	calories: number;
+	protein: number;
+	carbs: number;
+	fat: number;
+	fiber: number;
+	novaGroup?: number | null;
+	omega3?: number | null;
+	omega6?: number | null;
+	sodium?: number | null;
+	caffeine?: number | null;
+	saturatedFat?: number | null;
+	transFat?: number | null;
+	vitaminC?: number | null;
+	vitaminD?: number | null;
+	vitaminE?: number | null;
+	alcohol?: number | null;
+	addedSugars?: number | null;
+};
+
+export type AggRecipeIngredient = {
+	foodId: string;
+	quantity: number;
+};
+
+export type AggRecipe = {
+	id: string;
+	totalServings: number;
+	ingredients: AggRecipeIngredient[];
+};
+
+export type AggEntry = {
+	date: string;
+	mealType: string;
+	servings: number;
+	foodId?: string | null;
+	recipeId?: string | null;
+	eatenAt?: string | null;
+	foodName?: string | null;
+	quickName?: string | null;
+	quickCalories?: number | null;
+	quickProtein?: number | null;
+	quickCarbs?: number | null;
+	quickFat?: number | null;
+	quickFiber?: number | null;
+};
+
+export type DailyNutrientTotals = {
+	date: string;
+	calories: number;
+	protein: number;
+	carbs: number;
+	fat: number;
+	fiber: number;
+	omega3: number | null;
+	omega6: number | null;
+	sodium: number | null;
+	caffeine: number | null;
+	saturatedFat: number | null;
+	transFat: number | null;
+	vitaminC: number | null;
+	vitaminD: number | null;
+	vitaminE: number | null;
+	alcohol: number | null;
+	addedSugars: number | null;
+};
+
+// --- SQL-semantics primitives ----------------------------------------------
+
+/** `a / NULLIF(b, 0)`: null when the divisor is zero, otherwise the quotient. */
+export function nullDiv(a: number, b: number): number | null {
+	return b === 0 ? null : a / b;
+}
+
+/** `SUM(values)`: ignores nulls; null only when every value is null. */
+export function nullSum(values: (number | null)[]): number | null {
+	let acc = 0;
+	let any = false;
+	for (const v of values) {
+		if (v !== null && v !== undefined) {
+			acc += v;
+			any = true;
+		}
+	}
+	return any ? acc : null;
+}
+
+// --- recipe macro resolution (recipe_macros / recipe_extended CTEs) ---------
+
+const CORE_KEYS = ['calories', 'protein', 'carbs', 'fat', 'fiber'] as const;
+const EXTENDED_KEYS = [
+	'omega3',
+	'omega6',
+	'sodium',
+	'caffeine',
+	'saturatedFat',
+	'transFat',
+	'vitaminC',
+	'vitaminD',
+	'vitaminE',
+	'alcohol',
+	'addedSugars'
+] as const;
+
+type CoreKey = (typeof CORE_KEYS)[number];
+type ExtendedKey = (typeof EXTENDED_KEYS)[number];
+type ResolvedRecipe = Record<CoreKey | ExtendedKey, number | null>;
+
+/**
+ * Per-serving recipe nutrient:
+ * `SUM(food.nutrient * qty / NULLIF(food.servingSize, 0)) / NULLIF(recipe.totalServings, 0)`.
+ * Ingredients whose food is missing or whose nutrient is null contribute nothing.
+ */
+function recipePerServing(
+	recipe: AggRecipe,
+	foodsById: Map<string, AggFood>,
+	nutrient: (f: AggFood) => number | null | undefined
+): number | null {
+	const terms: number[] = [];
+	for (const ing of recipe.ingredients) {
+		const food = foodsById.get(ing.foodId);
+		if (!food) continue;
+		const value = nutrient(food);
+		if (value === null || value === undefined) continue;
+		const term = nullDiv(value * ing.quantity, food.servingSize);
+		if (term !== null) terms.push(term);
+	}
+	if (terms.length === 0) return null;
+	return nullDiv(
+		terms.reduce((a, b) => a + b, 0),
+		recipe.totalServings
+	);
+}
+
+function resolveRecipes(
+	recipes: AggRecipe[],
+	foodsById: Map<string, AggFood>
+): Map<string, ResolvedRecipe> {
+	const out = new Map<string, ResolvedRecipe>();
+	for (const recipe of recipes) {
+		const resolved = {} as ResolvedRecipe;
+		for (const key of [...CORE_KEYS, ...EXTENDED_KEYS]) {
+			resolved[key] = recipePerServing(recipe, foodsById, (f) => f[key]);
+		}
+		out.set(recipe.id, resolved);
+	}
+	return out;
+}
+
+// --- per-entry resolution (COALESCE expressions) ----------------------------
+
+const QUICK_KEY: Record<CoreKey, keyof AggEntry> = {
+	calories: 'quickCalories',
+	protein: 'quickProtein',
+	carbs: 'quickCarbs',
+	fat: 'quickFat',
+	fiber: 'quickFiber'
+};
+
+/** `COALESCE(food.macro, recipe.macro, quick.macro, 0) * servings` — always numeric. */
+function entryCore(
+	entry: AggEntry,
+	food: AggFood | undefined,
+	recipe: ResolvedRecipe | undefined,
+	key: CoreKey
+): number {
+	const fromFood = food ? food[key] : null;
+	const fromRecipe = recipe ? recipe[key] : null;
+	const fromQuick = entry[QUICK_KEY[key]] as number | null | undefined;
+	const base = fromFood ?? fromRecipe ?? fromQuick ?? 0;
+	return base * entry.servings;
+}
+
+/** `COALESCE(food.nutrient, recipe.nutrient) * servings` — null (no quick fallback) when both absent. */
+function entryExtended(
+	entry: AggEntry,
+	food: AggFood | undefined,
+	recipe: ResolvedRecipe | undefined,
+	key: ExtendedKey
+): number | null {
+	const fromFood = food ? food[key] : null;
+	const fromRecipe = recipe ? recipe[key] : null;
+	const base = fromFood ?? fromRecipe;
+	if (base === null || base === undefined) return null;
+	return base * entry.servings;
+}
+
+/**
+ * Per-day nutrient totals across `entries`, resolving foods and recipes the same
+ * way the server's CTEs do. Sorted by date ascending; only dates with at least
+ * one entry appear. The on-device equivalent of `getDailyNutrientTotals`.
+ */
+export function aggregateDailyNutrientTotals(
+	entries: AggEntry[],
+	foods: AggFood[],
+	recipes: AggRecipe[]
+): DailyNutrientTotals[] {
+	const foodsById = new Map(foods.map((f) => [f.id, f]));
+	const resolved = resolveRecipes(recipes, foodsById);
+
+	const byDate = new Map<string, AggEntry[]>();
+	for (const e of entries) {
+		const list = byDate.get(e.date) ?? [];
+		list.push(e);
+		byDate.set(e.date, list);
+	}
+
+	const dates = [...byDate.keys()].sort();
+	return dates.map((date) => {
+		const rows = byDate.get(date)!.map((e) => ({
+			entry: e,
+			food: e.foodId ? foodsById.get(e.foodId) : undefined,
+			recipe: e.recipeId ? resolved.get(e.recipeId) : undefined
+		}));
+		const core = (key: CoreKey) =>
+			rows.reduce((sum, r) => sum + entryCore(r.entry, r.food, r.recipe, key), 0);
+		const ext = (key: ExtendedKey) =>
+			nullSum(rows.map((r) => entryExtended(r.entry, r.food, r.recipe, key)));
+		return {
+			date,
+			calories: core('calories'),
+			protein: core('protein'),
+			carbs: core('carbs'),
+			fat: core('fat'),
+			fiber: core('fiber'),
+			omega3: ext('omega3'),
+			omega6: ext('omega6'),
+			sodium: ext('sodium'),
+			caffeine: ext('caffeine'),
+			saturatedFat: ext('saturatedFat'),
+			transFat: ext('transFat'),
+			vitaminC: ext('vitaminC'),
+			vitaminD: ext('vitaminD'),
+			vitaminE: ext('vitaminE'),
+			alcohol: ext('alcohol'),
+			addedSugars: ext('addedSugars')
+		};
+	});
+}

--- a/tests/analytics/parity.test.ts
+++ b/tests/analytics/parity.test.ts
@@ -5,6 +5,8 @@ import { resolve } from 'node:path';
 import { pearsonCorrelation } from '../../src/lib/analytics/correlation';
 import { movingAverage } from '../../src/lib/analytics/moving-average';
 import { computeAdaptiveTDEE, detectPlateau, projectWeight } from '../../src/lib/analytics/tdee';
+import { aggregateDailyNutrientTotals } from '../../src/lib/analytics/aggregation';
+import { calculateMaintenance } from '../../src/lib/utils/maintenance';
 
 /**
  * Cross-language golden-vector parity. The same frozen fixtures are asserted by
@@ -37,6 +39,10 @@ function runFn(fn: string, input: any): unknown {
 			);
 		case 'projectWeight':
 			return projectWeight(input.weightSeries, input.weeklyRate);
+		case 'calculateMaintenance':
+			return calculateMaintenance(input);
+		case 'aggregateDailyNutrientTotals':
+			return aggregateDailyNutrientTotals(input.entries, input.foods, input.recipes);
 		default:
 			throw new Error(`Unknown fn in fixtures: ${fn}`);
 	}


### PR DESCRIPTION
Implements the **shared-Kotlin engine** for #321 — computing maintenance calories and per-day nutrient totals on-device — and extends the #322 golden-vector guardrail so the server (TS) and mobile (Kotlin) analytics can't silently drift.

This is the cross-cutting, cross-language core the issue calls out as the "meatiest new piece." The per-platform view wiring is intentionally **not** in this PR (see *Remaining work*); landing the shared engine first keeps that wiring to mechanical, golden-locked changes.

## What's here

**`commonMain` — pure shared analytics**
- `analytics/Maintenance.kt` — `calculateMaintenance()`, a faithful port of `src/lib/utils/maintenance.ts` (energy-balance TDEE; fat = 7700 / muscle = 1800 kcal·kg⁻¹; default muscle ratio 0.3). Uses **JS round-half-up**, not Kotlin's banker's rounding, to stay byte-for-byte with the server.
- `analytics/Aggregation.kt` — the on-device equivalent of the server's recipe-macro CTEs (`src/lib/server/analytics.ts`). Resolves food / recipe / quick-add entries into per-day totals, mirroring the SQL semantics exactly:
  - `a / NULLIF(b, 0)` → null on zero divisor,
  - `SUM(...)` skips nulls and is null only when every term is null,
  - core macros `COALESCE` to 0 (always numeric); extended nutrients do **not** (a day with no measured value stays null, not 0).

  It also exposes the per-entry / weight-food / meal-timing / diversity / sleep-food transforms. These plain `Agg*` shapes are the **platform data-loader contract**: each platform maps its SQLDelight / SwiftData rows into them, and everything downstream is shared.

**TS reference**
- `src/lib/analytics/aggregation.ts` — a dependency-free TS mirror of the SQL aggregation, used by the generator and the parity test (the server keeps its SQL; this is the canonical on-device/golden reference).

**Parity guardrail (the #322 net)**
- Golden vectors + both parity harnesses (`tests/analytics/parity.test.ts`, `AnalyticsParityTest.kt`) now also cover `calculateMaintenance` and `aggregateDailyNutrientTotals`, including the tricky paths: recipe-from-ingredients resolution, zero serving size, zero total servings, quick-add fallback, null extended nutrients, and round-half-up ties.
- `AggregationTest.kt` adds Kotlin unit coverage for the per-entry / series transforms.

## Acceptance criteria covered
- [x] Maintenance calculator exists in `commonMain` and matches server output on golden vectors.
- [x] On-device daily totals (including recipes) match the server within tolerance on golden vectors.
- [x] Golden-vector parity tests pass for TS + Kotlin in CI.

(The remaining criteria — local/anonymous users seeing insights with no network, online users computing from the local DB, iOS dropping its Swift math, Android dropping its analytics API calls — are the per-platform wiring below.)

## Verification (local)
- `bun run check` ✅ · `bun run test` (TS parity, 22 cases) ✅
- `:shared:testDebugUnitTest` (Kotlin parity + `AggregationTest`) ✅ · `:shared:ktlintCheck` ✅

## Remaining work (follow-up, on top of this engine)
Each is a sizable migration of a working app's UI and is best reviewed on its own:
- **Android (B):** SQLDelight data-loader → `Agg*` shapes; switch `MaintenanceScreen` + `InsightsViewModel` to compute via the shared functions instead of the analytics API.
- **iOS (C):** SwiftData data-loader → `Agg*` shapes (via SKIE); replace the Swift maintenance/Stats math + `/api/maintenance` call with the shared Kotlin. Needs a full Xcode archive to verify, so it's deliberately separate.
- **Sync (D):** fasting-day flags and the supplement schedule already sync into the local stores (verified), so this is mostly graceful-absence handling.

Refs #321, #322