### PR TITLE
feat(ios): App Intents — Siri voice logging, Spotlight & Shortcuts

### DIFF
--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import SwiftData
 import SwiftUI
 
@@ -46,7 +47,7 @@ struct BissbilanzApp: App {
     @State private var supplementRepository: SupplementRepository
     @State private var goalsRepository: GoalsRepository
     @State private var preferencesRepository: PreferencesRepository
-    @State private var deepLinkRouter = DeepLinkRouter()
+    @State private var deepLinkRouter: DeepLinkRouter
     private let modelContainer: ModelContainer
 
     init() {
@@ -82,15 +83,12 @@ struct BissbilanzApp: App {
             appMode: appMode,
             syncManager: sync
         ))
-        _entryRepository = State(wrappedValue: EntryRepository(
-            context: context, api: api, appMode: appMode, syncManager: sync
-        ))
-        _foodRepository = State(wrappedValue: FoodRepository(
-            context: context, api: api, appMode: appMode, syncManager: sync
-        ))
-        _recipeRepository = State(wrappedValue: RecipeRepository(
-            context: context, api: api, appMode: appMode, syncManager: sync
-        ))
+        let entryRepo = EntryRepository(context: context, api: api, appMode: appMode, syncManager: sync)
+        let foodRepo = FoodRepository(context: context, api: api, appMode: appMode, syncManager: sync)
+        let recipeRepo = RecipeRepository(context: context, api: api, appMode: appMode, syncManager: sync)
+        _entryRepository = State(wrappedValue: entryRepo)
+        _foodRepository = State(wrappedValue: foodRepo)
+        _recipeRepository = State(wrappedValue: recipeRepo)
         _weightRepository = State(wrappedValue: WeightRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
         ))
@@ -106,6 +104,25 @@ struct BissbilanzApp: App {
         _preferencesRepository = State(wrappedValue: PreferencesRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
         ))
+
+        let router = DeepLinkRouter()
+        _deepLinkRouter = State(wrappedValue: router)
+
+        // App Intents (Siri / Spotlight / Shortcuts) run in a separate launch of
+        // the app — outside the SwiftUI environment the views use — so resolve
+        // their dependencies through AppDependencyManager. Registered here in
+        // init so they exist even when the system background-launches us purely
+        // to service an intent. EntryWriter wraps the same repositories/context
+        // the UI uses, so an intent log shares the offline-first sync path.
+        let entryWriter = EntryWriter(
+            entryRepository: entryRepo,
+            foodRepository: foodRepo,
+            recipeRepository: recipeRepo,
+            syncManager: sync
+        )
+        AppDependencyManager.shared.add(dependency: entryWriter)
+        AppDependencyManager.shared.add(dependency: router)
+        IntentDonations.isEnabled = true
     }
 
     var body: some Scene {
@@ -169,6 +186,12 @@ struct BissbilanzApp: App {
                     // Covers launch, day rollover while backgrounded and any
                     // change widgets might have missed.
                     WidgetSnapshotWriter.scheduleUpdate(context: modelContainer.mainContext)
+                    // Keep Spotlight in step with the searchable catalog so
+                    // foods/recipes are findable before the next manual log.
+                    IntentDonations.indexCatalog(
+                        foods: foodRepository.favorites() + foodRepository.localRecentFoods(),
+                        recipes: recipeRepository.favoriteRecipes()
+                    )
                 }
             }
         }

--- a/mobile/iosApp/Bissbilanz/Intents/BissbilanzShortcuts.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/BissbilanzShortcuts.swift
@@ -1,0 +1,31 @@
+import AppIntents
+
+/// Registers the app's shortcuts so they appear automatically in the Shortcuts
+/// app, Spotlight and Siri at install — no donation needed for these to exist.
+///
+/// Constraints enforced by the framework: every phrase must contain
+/// `\(.applicationName)`, a phrase may reference at most one parameter, and a
+/// provider may expose at most 10 shortcuts.
+struct BissbilanzShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: LogFoodIntent(),
+            phrases: [
+                "Log \(\.$food) with \(.applicationName)",
+                "Log a food with \(.applicationName)",
+                "Add food to \(.applicationName)",
+            ],
+            shortTitle: "Log Food",
+            systemImageName: "fork.knife"
+        )
+        AppShortcut(
+            intent: LogRecipeIntent(),
+            phrases: [
+                "Log \(\.$recipe) with \(.applicationName)",
+                "Log a recipe with \(.applicationName)",
+            ],
+            shortTitle: "Log Recipe",
+            systemImageName: "list.bullet.rectangle"
+        )
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/EntryWriter.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/EntryWriter.swift
@@ -1,0 +1,123 @@
+import Foundation
+import SwiftData
+
+/// Single, UI- and AppIntents-agnostic entry point for reading the food/recipe
+/// catalog and writing a log entry. App Intents (`LogFoodIntent`,
+/// `FoodEntityQuery`, …) run in a *separate* invocation of the app — the system
+/// background-launches the process to service Siri / Spotlight / Shortcuts — so
+/// they can't reach the SwiftUI environment the views use. They resolve this
+/// type through `AppDependencyManager` instead.
+///
+/// It deliberately wraps the existing repositories rather than re-implementing
+/// the optimistic-write + sync-enqueue flow: an intent log is the exact same
+/// `EntryRepository.createEntry` path the in-app quick-log uses, so it inherits
+/// offline-first behaviour, HealthKit write-back and `temp_` reconciliation for
+/// free. Kept free of `FoodEntity`/`RecipeEntity` so the Widgets and Watch
+/// issues can reuse it from their own extensions.
+@MainActor
+final class EntryWriter {
+    private let entryRepository: EntryRepository
+    private let foodRepository: FoodRepository
+    private let recipeRepository: RecipeRepository
+    private let syncManager: SyncManager
+
+    init(
+        entryRepository: EntryRepository,
+        foodRepository: FoodRepository,
+        recipeRepository: RecipeRepository,
+        syncManager: SyncManager
+    ) {
+        self.entryRepository = entryRepository
+        self.foodRepository = foodRepository
+        self.recipeRepository = recipeRepository
+        self.syncManager = syncManager
+    }
+
+    // MARK: - Food reads
+
+    /// API-first search (caches into the local store), local fallback offline
+    /// and in Local mode — the same path the in-app search uses.
+    func searchFoods(_ query: String) async -> [Food] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return suggestedFoods() }
+        return await foodRepository.searchFoods(query: trimmed)
+    }
+
+    func food(id: String) -> Food? {
+        foodRepository.food(id: id)
+    }
+
+    func foods(ids: [String]) -> [Food] {
+        ids.compactMap { foodRepository.food(id: $0) }
+    }
+
+    /// Favorites first, then recently logged foods — what Siri / Shortcuts show
+    /// before the user types. Local store only, so it stays instant.
+    func suggestedFoods(limit: Int = 12) -> [Food] {
+        var seen = Set<String>()
+        var result: [Food] = []
+        for food in foodRepository.favorites() + foodRepository.localRecentFoods(limit: limit) {
+            if seen.insert(food.id).inserted {
+                result.append(food)
+            }
+            if result.count >= limit { break }
+        }
+        return result
+    }
+
+    // MARK: - Recipe reads
+
+    /// Recipes are a local-first, modest set (no server search endpoint), so a
+    /// name/substring filter over the cached list matches the in-app behaviour.
+    func searchRecipes(_ query: String) -> [Recipe] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return suggestedRecipes() }
+        return recipeRepository.recipes().filter { $0.name.localizedCaseInsensitiveContains(trimmed) }
+    }
+
+    func recipe(id: String) -> Recipe? {
+        recipeRepository.recipe(id: id)
+    }
+
+    func recipes(ids: [String]) -> [Recipe] {
+        ids.compactMap { recipeRepository.recipe(id: $0) }
+    }
+
+    func suggestedRecipes(limit: Int = 12) -> [Recipe] {
+        let favorites = recipeRepository.favoriteRecipes()
+        return Array((favorites.isEmpty ? recipeRepository.recipes() : favorites).prefix(limit))
+    }
+
+    // MARK: - Writes
+
+    /// Logs a food for `date` (today by default) and, when online and signed
+    /// in, waits for the upload so the entry has synced by the time the intent
+    /// returns. Offline / Local mode falls through to the normal queued path.
+    @discardableResult
+    func logFood(
+        id: String,
+        meal: MealTypeAppEnum,
+        servings: Double,
+        date: String = DateFormatting.today
+    ) async throws -> Entry {
+        let food = foodRepository.food(id: id)
+        let create = EntryCreate(foodId: id, mealType: meal.serverValue, servings: max(servings, 0.0001), date: date)
+        let entry = try await entryRepository.createEntry(create, food: food)
+        await syncManager.drainPendingQueue()
+        return entry
+    }
+
+    @discardableResult
+    func logRecipe(
+        id: String,
+        meal: MealTypeAppEnum,
+        servings: Double,
+        date: String = DateFormatting.today
+    ) async throws -> Entry {
+        let recipe = recipeRepository.recipe(id: id)
+        let create = EntryCreate(recipeId: id, mealType: meal.serverValue, servings: max(servings, 0.0001), date: date)
+        let entry = try await entryRepository.createEntry(create, recipe: recipe)
+        await syncManager.drainPendingQueue()
+        return entry
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/EntryWriter.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/EntryWriter.swift
@@ -90,9 +90,11 @@ final class EntryWriter {
 
     // MARK: - Writes
 
-    /// Logs a food for `date` (today by default) and, when online and signed
-    /// in, waits for the upload so the entry has synced by the time the intent
-    /// returns. Offline / Local mode falls through to the normal queued path.
+    /// Logs a food for `date` (today by default). When online and signed in it
+    /// then awaits a queue drain so the upload is attempted before the intent
+    /// returns (a concurrent in-flight drain may already own it, in which case
+    /// this returns early and the op uploads on the next trigger). Offline /
+    /// Local mode falls through to the normal queued path.
     @discardableResult
     func logFood(
         id: String,

--- a/mobile/iosApp/Bissbilanz/Intents/FoodEntity.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/FoodEntity.swift
@@ -1,0 +1,66 @@
+import AppIntents
+import CoreSpotlight
+import Foundation
+
+/// A food from the user's database, exposed to Siri, Spotlight and Shortcuts.
+///
+/// Conforms to `IndexedEntity` so the same value can be pushed into the
+/// Spotlight index (iOS 18) — selecting a result then runs `OpenFoodIntent`.
+/// Only the fields the system actually shows are carried; the full `Food`
+/// (macros, etc.) is looked up from the store at log time via `EntryWriter`.
+struct FoodEntity: AppEntity, IndexedEntity {
+    let id: String
+    let name: String
+    let brand: String?
+    let calories: Double
+
+    init(food: Food) {
+        id = food.id
+        name = food.name
+        brand = food.brand
+        calories = food.calories
+    }
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Food")
+    }
+
+    static let defaultQuery = FoodEntityQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        let kcal = "\(Int(calories.rounded())) kcal"
+        let subtitle = [brand, kcal].compactMap { $0 }.joined(separator: " · ")
+        return DisplayRepresentation(title: "\(name)", subtitle: "\(subtitle)")
+    }
+
+    /// Spotlight metadata, layered on top of the framework default so the title
+    /// and a macro hint show in search results.
+    var attributeSet: CSSearchableItemAttributeSet {
+        let set = defaultAttributeSet
+        set.title = name
+        set.contentDescription = [brand, "\(Int(calories.rounded())) kcal"]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+        set.keywords = [name, brand].compactMap { $0 }
+        return set
+    }
+}
+
+/// Resolves `FoodEntity` values for the framework: stored ids back to entities,
+/// a spoken/typed string to candidates (multiple → automatic disambiguation),
+/// and a suggestion list shown before the user types.
+struct FoodEntityQuery: EntityStringQuery {
+    @Dependency private var entryWriter: EntryWriter
+
+    func entities(for identifiers: [String]) async throws -> [FoodEntity] {
+        await entryWriter.foods(ids: identifiers).map(FoodEntity.init)
+    }
+
+    func entities(matching string: String) async throws -> [FoodEntity] {
+        await entryWriter.searchFoods(string).map(FoodEntity.init)
+    }
+
+    func suggestedEntities() async throws -> [FoodEntity] {
+        await entryWriter.suggestedFoods().map(FoodEntity.init)
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/IntentDonations.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/IntentDonations.swift
@@ -1,0 +1,65 @@
+import AppIntents
+import CoreSpotlight
+import Foundation
+
+/// Feeds Siri suggestions and Spotlight from the app side: donate the matching
+/// "log" intent after a manual log so Siri learns the user's habits, and push
+/// foods/recipes into the Spotlight index so they're searchable system-wide.
+///
+/// Disabled by default and switched on once at app launch
+/// (`BissbilanzApp.init`), so contexts that exercise `EntryRepository`
+/// without a full app launch (SwiftUI previews, headless tooling) stay inert.
+/// Every donation/indexing call is best-effort and swallows its errors, so it
+/// never affects the log itself even when enabled.
+enum IntentDonations {
+    /// Set once on the main actor at launch; read on the main actor from the
+    /// repository. Single-writer, so `nonisolated(unsafe)` is sound here.
+    nonisolated(unsafe) static var isEnabled = false
+
+    /// Donate + incrementally index after a single manual log. `mealType` is
+    /// the wire value from the created entry; an unknown value simply donates
+    /// without a meal.
+    static func donateLog(food: Food?, recipe: Recipe?, mealType: String) {
+        guard isEnabled else { return }
+        let meal = MealTypeAppEnum(rawValue: mealType)
+        if let food {
+            let entity = FoodEntity(food: food)
+            Task {
+                let intent = LogFoodIntent()
+                intent.food = entity
+                intent.meal = meal
+                intent.servings = 1
+                try? await IntentDonationManager.shared.donate(intent: intent)
+                try? await CSSearchableIndex.default().indexAppEntities([entity])
+            }
+        }
+        if let recipe {
+            let entity = RecipeEntity(recipe: recipe)
+            Task {
+                let intent = LogRecipeIntent()
+                intent.recipe = entity
+                intent.meal = meal
+                intent.servings = 1
+                try? await IntentDonationManager.shared.donate(intent: intent)
+                try? await CSSearchableIndex.default().indexAppEntities([entity])
+            }
+        }
+    }
+
+    /// Reindex the searchable catalog (favorites + recents) into Spotlight.
+    /// Called at launch / foreground so results exist before any manual log.
+    static func indexCatalog(foods: [Food], recipes: [Recipe]) {
+        guard isEnabled else { return }
+        let foodEntities = foods.map(FoodEntity.init)
+        let recipeEntities = recipes.map(RecipeEntity.init)
+        guard !foodEntities.isEmpty || !recipeEntities.isEmpty else { return }
+        Task {
+            if !foodEntities.isEmpty {
+                try? await CSSearchableIndex.default().indexAppEntities(foodEntities)
+            }
+            if !recipeEntities.isEmpty {
+                try? await CSSearchableIndex.default().indexAppEntities(recipeEntities)
+            }
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/LogFoodIntent.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/LogFoodIntent.swift
@@ -1,0 +1,49 @@
+import AppIntents
+import Foundation
+
+/// "Hey Siri, log a banana with Bissbilanz." Creates a food entry without
+/// opening the app (`openAppWhenRun = false`); the write goes through the same
+/// offline-first path as the in-app quick-log, so it persists in Local mode and
+/// uploads when online.
+struct LogFoodIntent: AppIntent {
+    static var title: LocalizedStringResource {
+        "Log Food"
+    }
+
+    static var description: IntentDescription {
+        IntentDescription("Log a food from your Bissbilanz database to today's diary.")
+    }
+
+    /// Log silently — the result dialog is the only feedback.
+    static var openAppWhenRun: Bool {
+        false
+    }
+
+    @Parameter(title: "Food")
+    var food: FoodEntity
+
+    @Parameter(title: "Meal")
+    var meal: MealTypeAppEnum?
+
+    @Parameter(title: "Servings", default: 1.0)
+    var servings: Double
+
+    @Dependency
+    private var entryWriter: EntryWriter
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Log \(\.$food)") {
+            \.$meal
+            \.$servings
+        }
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let resolvedMeal = meal ?? .forCurrentTime()
+        let entry = try await entryWriter.logFood(id: food.id, meal: resolvedMeal, servings: servings)
+        let calories = entry.totalCalories > 0 ? entry.totalCalories : food.calories * servings
+        let dialog = L10n.intentLoggedFood(food.name, meal: resolvedMeal.serverValue, calories: Int(calories.rounded()))
+        return .result(dialog: "\(dialog)")
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/LogRecipeIntent.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/LogRecipeIntent.swift
@@ -1,0 +1,51 @@
+import AppIntents
+import Foundation
+
+/// Recipe counterpart of `LogFoodIntent` — logs one serving (by default) of a
+/// recipe to today's diary without opening the app.
+struct LogRecipeIntent: AppIntent {
+    static var title: LocalizedStringResource {
+        "Log Recipe"
+    }
+
+    static var description: IntentDescription {
+        IntentDescription("Log a recipe from your Bissbilanz database to today's diary.")
+    }
+
+    static var openAppWhenRun: Bool {
+        false
+    }
+
+    @Parameter(title: "Recipe")
+    var recipe: RecipeEntity
+
+    @Parameter(title: "Meal")
+    var meal: MealTypeAppEnum?
+
+    @Parameter(title: "Servings", default: 1.0)
+    var servings: Double
+
+    @Dependency
+    private var entryWriter: EntryWriter
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Log \(\.$recipe)") {
+            \.$meal
+            \.$servings
+        }
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let resolvedMeal = meal ?? .forCurrentTime()
+        let entry = try await entryWriter.logRecipe(id: recipe.id, meal: resolvedMeal, servings: servings)
+        let perServing = recipe.caloriesPerServing ?? 0
+        let calories = entry.totalCalories > 0 ? entry.totalCalories : perServing * servings
+        let dialog = L10n.intentLoggedFood(
+            recipe.name,
+            meal: resolvedMeal.serverValue,
+            calories: Int(calories.rounded())
+        )
+        return .result(dialog: "\(dialog)")
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/MealTypeAppEnum.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/MealTypeAppEnum.swift
@@ -1,0 +1,45 @@
+import AppIntents
+import Foundation
+
+/// The server's four meal types, surfaced to App Intents / Siri / Shortcuts as
+/// a selectable enum. The raw value is the wire value (`mealType` on
+/// `EntryCreate`), so `serverValue` is just `rawValue` — kept as a named
+/// accessor so call sites read intentionally and a future server-driven set of
+/// custom meal types has one place to diverge.
+enum MealTypeAppEnum: String, AppEnum, CaseIterable {
+    case breakfast
+    case lunch
+    case dinner
+    case snacks
+
+    /// Wire value for `EntryCreate.mealType`.
+    var serverValue: String {
+        rawValue
+    }
+
+    /// Meal a log defaults to when the user doesn't say one — mirrors the
+    /// time-of-day mapping the in-app quick-log uses (`FoodSearchView`).
+    static func forCurrentTime(_ date: Date = Date()) -> MealTypeAppEnum {
+        switch Calendar.current.component(.hour, from: date) {
+        case 5 ..< 11: .breakfast
+        case 11 ..< 14: .lunch
+        case 14 ..< 17: .snacks
+        default: .dinner
+        }
+    }
+
+    /// App Intents metadata is extracted statically, so these stay English
+    /// literals; the runtime confirmation dialog is localized via `L10n`.
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Meal")
+    }
+
+    static var caseDisplayRepresentations: [MealTypeAppEnum: DisplayRepresentation] {
+        [
+            .breakfast: DisplayRepresentation(title: "Breakfast", image: .init(systemName: "sunrise")),
+            .lunch: DisplayRepresentation(title: "Lunch", image: .init(systemName: "sun.max")),
+            .dinner: DisplayRepresentation(title: "Dinner", image: .init(systemName: "moon.stars")),
+            .snacks: DisplayRepresentation(title: "Snacks", image: .init(systemName: "carrot")),
+        ]
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/OpenFoodIntent.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/OpenFoodIntent.swift
@@ -1,0 +1,24 @@
+import AppIntents
+import Foundation
+
+/// Opens a food's detail screen. The system runs this when the user taps the
+/// food's Spotlight result (an `OpenIntent` whose `target` matches the indexed
+/// entity), and it also shows up in Shortcuts as "Open Food". Routing reuses
+/// the existing deep-link plumbing the widgets already drive.
+struct OpenFoodIntent: OpenIntent {
+    static var title: LocalizedStringResource {
+        "Open Food"
+    }
+
+    @Parameter(title: "Food")
+    var target: FoodEntity
+
+    @Dependency
+    private var deepLinkRouter: DeepLinkRouter
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        deepLinkRouter.pending = .food(target.id)
+        return .result()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/OpenRecipeIntent.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/OpenRecipeIntent.swift
@@ -1,0 +1,22 @@
+import AppIntents
+import Foundation
+
+/// Opens a recipe's detail screen — recipe counterpart of `OpenFoodIntent`,
+/// driven by a Spotlight tap on a recipe result.
+struct OpenRecipeIntent: OpenIntent {
+    static var title: LocalizedStringResource {
+        "Open Recipe"
+    }
+
+    @Parameter(title: "Recipe")
+    var target: RecipeEntity
+
+    @Dependency
+    private var deepLinkRouter: DeepLinkRouter
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        deepLinkRouter.pending = .recipe(target.id)
+        return .result()
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Intents/RecipeEntity.swift
+++ b/mobile/iosApp/Bissbilanz/Intents/RecipeEntity.swift
@@ -1,0 +1,58 @@
+import AppIntents
+import CoreSpotlight
+import Foundation
+
+/// A recipe from the user's database, exposed to Siri, Spotlight and
+/// Shortcuts. Mirrors `FoodEntity`; logging a recipe maps to `EntryCreate`'s
+/// `recipeId`, the per-serving counterpart of logging a food.
+struct RecipeEntity: AppEntity, IndexedEntity {
+    let id: String
+    let name: String
+    let caloriesPerServing: Double?
+
+    init(recipe: Recipe) {
+        id = recipe.id
+        name = recipe.name
+        let servings = max(recipe.totalServings, 1)
+        caloriesPerServing = recipe.calories.map { $0 / servings }
+    }
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Recipe")
+    }
+
+    static let defaultQuery = RecipeEntityQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        guard let caloriesPerServing else {
+            return DisplayRepresentation(title: "\(name)")
+        }
+        return DisplayRepresentation(title: "\(name)", subtitle: "\(Int(caloriesPerServing.rounded())) kcal / serving")
+    }
+
+    var attributeSet: CSSearchableItemAttributeSet {
+        let set = defaultAttributeSet
+        set.title = name
+        if let caloriesPerServing {
+            set.contentDescription = "\(Int(caloriesPerServing.rounded())) kcal / serving"
+        }
+        set.keywords = [name]
+        return set
+    }
+}
+
+struct RecipeEntityQuery: EntityStringQuery {
+    @Dependency private var entryWriter: EntryWriter
+
+    func entities(for identifiers: [String]) async throws -> [RecipeEntity] {
+        await entryWriter.recipes(ids: identifiers).map(RecipeEntity.init)
+    }
+
+    func entities(matching string: String) async throws -> [RecipeEntity] {
+        await entryWriter.searchRecipes(string).map(RecipeEntity.init)
+    }
+
+    func suggestedEntities() async throws -> [RecipeEntity] {
+        await entryWriter.suggestedRecipes().map(RecipeEntity.init)
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
@@ -88,6 +88,11 @@ final class EntryRepository {
         save()
         syncManager.enqueue(.createEntry(body: create, localId: temp.id))
         syncDayToHealth(create.date, knownFood: food)
+        // Feed Siri suggestions / Spotlight when a known food or recipe was
+        // logged. No-op outside the app (e.g. in tests) — see IntentDonations.
+        if food != nil || recipe != nil {
+            IntentDonations.donateLog(food: food, recipe: recipe, mealType: create.mealType)
+        }
         return temp
     }
 

--- a/mobile/iosApp/Bissbilanz/Utilities/DeepLink.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/DeepLink.swift
@@ -9,6 +9,7 @@ enum DeepLink: Equatable, Identifiable {
     case scanner
     case weight
     case food(String)
+    case recipe(String)
 
     var id: String {
         switch self {
@@ -16,6 +17,7 @@ enum DeepLink: Equatable, Identifiable {
         case .scanner: "scan"
         case .weight: "weight"
         case let .food(foodId): "food-\(foodId)"
+        case let .recipe(recipeId): "recipe-\(recipeId)"
         }
     }
 
@@ -36,6 +38,12 @@ enum DeepLink: Equatable, Identifiable {
                 .removingPercentEncoding
             guard let foodId, !foodId.isEmpty else { return nil }
             return .food(foodId)
+        case "recipe":
+            let recipeId = url.pathComponents
+                .first { $0 != "/" }?
+                .removingPercentEncoding
+            guard let recipeId, !recipeId.isEmpty else { return nil }
+            return .recipe(recipeId)
         default:
             return nil
         }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -271,6 +271,15 @@ enum L10n {
         localized("failed_to_log", en: "Failed to log", de: "Eintragung fehlgeschlagen")
     }
 
+    /// Spoken/shown confirmation after a Siri / Shortcuts log.
+    static func intentLoggedFood(_ name: String, meal: String, calories: Int) -> String {
+        localized(
+            "intent_logged_food",
+            en: "Logged \(name) — \(mealName(meal)), \(calories) kcal",
+            de: "\(name) eingetragen — \(mealName(meal)), \(calories) kcal"
+        )
+    }
+
     // MARK: - Entries
 
     static var logFood: String {

--- a/mobile/iosApp/Bissbilanz/Views/ContentView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/ContentView.swift
@@ -89,6 +89,8 @@ struct ContentView: View {
                     WeightView()
                 case let .food(foodId):
                     FoodDetailView(foodId: foodId)
+                case let .recipe(recipeId):
+                    RecipeDetailView(recipeId: recipeId)
                 }
             }
         }

--- a/mobile/iosApp/BissbilanzTests/IntentsTests.swift
+++ b/mobile/iosApp/BissbilanzTests/IntentsTests.swift
@@ -1,0 +1,147 @@
+@testable import Bissbilanz
+import Foundation
+import SwiftData
+import Testing
+
+@Suite("App Intents")
+@MainActor
+struct IntentsTests {
+    private func makeWriter(_ harness: RepositoryHarness) -> EntryWriter {
+        EntryWriter(
+            entryRepository: harness.entryRepository,
+            foodRepository: harness.foodRepository,
+            recipeRepository: harness.recipeRepository,
+            syncManager: harness.syncManager
+        )
+    }
+
+    private func seedFood(_ harness: RepositoryHarness, _ food: Food) throws {
+        harness.context.insert(LocalFood(food: food))
+        try harness.context.save()
+    }
+
+    private func date(hour: Int) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 6
+        components.day = 16
+        components.hour = hour
+        return Calendar.current.date(from: components)!
+    }
+
+    // MARK: - Meal defaulting
+
+    @Test("forCurrentTime maps the hour of day to a meal")
+    func mealForCurrentTime() {
+        #expect(MealTypeAppEnum.forCurrentTime(date(hour: 8)) == .breakfast)
+        #expect(MealTypeAppEnum.forCurrentTime(date(hour: 12)) == .lunch)
+        #expect(MealTypeAppEnum.forCurrentTime(date(hour: 15)) == .snacks)
+        #expect(MealTypeAppEnum.forCurrentTime(date(hour: 20)) == .dinner)
+        #expect(MealTypeAppEnum.forCurrentTime(date(hour: 3)) == .dinner)
+        #expect(MealTypeAppEnum.breakfast.serverValue == "breakfast")
+    }
+
+    // MARK: - Logging
+
+    @Test("logFood writes the entry locally and queues the upload in Synced mode")
+    func logFoodQueuesUpload() async throws {
+        // online: false so the immediate drain is a no-op and the queued op
+        // stays observable without stubbing the network.
+        let harness = try RepositoryHarness(mode: .synced, online: false)
+        try seedFood(harness, harness.food(id: "f1", name: "Banana"))
+        let writer = makeWriter(harness)
+
+        let entry = try await writer.logFood(id: "f1", meal: .breakfast, servings: 2, date: "2026-06-16")
+
+        #expect(entry.foodId == "f1")
+        #expect(entry.mealType == "breakfast")
+        #expect(entry.servings == 2)
+        #expect(harness.entryRepository.entries(date: "2026-06-16").map(\.id) == [entry.id])
+        let queued = harness.syncManager.queuedRows()
+        #expect(queued.count == 1)
+        #expect(queued.first?.type == "create_entry")
+        #expect(queued.first?.affectedId == entry.id)
+    }
+
+    @Test("logFood persists locally without queueing in Local mode")
+    func logFoodLocalMode() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try seedFood(harness, harness.food(id: "f1", name: "Banana"))
+        let writer = makeWriter(harness)
+
+        let entry = try await writer.logFood(id: "f1", meal: .lunch, servings: 1, date: "2026-06-16")
+
+        #expect(harness.entryRepository.entries(date: "2026-06-16").map(\.id) == [entry.id])
+        #expect(harness.syncManager.queuedRows().isEmpty)
+    }
+
+    @Test("logRecipe logs by recipeId")
+    func logRecipe() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try harness.context.insert(LocalRecipe(recipe: harness.recipe(id: "r1", name: "Bowl")))
+        try harness.context.save()
+        let writer = makeWriter(harness)
+
+        let entry = try await writer.logRecipe(id: "r1", meal: .dinner, servings: 1, date: "2026-06-16")
+
+        #expect(entry.recipeId == "r1")
+        #expect(entry.mealType == "dinner")
+        #expect(harness.entryRepository.entries(date: "2026-06-16").map(\.id) == [entry.id])
+    }
+
+    // MARK: - Resolution
+
+    @Test("searchFoods falls back to favorites and recents for an empty query")
+    func searchFoodsEmptyReturnsSuggestions() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try seedFood(harness, harness.food(id: "f1", name: "Apple", isFavorite: true))
+        try seedFood(harness, harness.food(id: "f2", name: "Almonds", isFavorite: true))
+        let writer = makeWriter(harness)
+
+        let suggestions = await writer.searchFoods("   ")
+
+        #expect(Set(suggestions.map(\.id)) == ["f1", "f2"])
+    }
+
+    @Test("searchFoods matches by name in Local mode")
+    func searchFoodsMatchesByName() async throws {
+        let harness = try RepositoryHarness(mode: .local)
+        try seedFood(harness, harness.food(id: "f1", name: "Brown Rice"))
+        try seedFood(harness, harness.food(id: "f2", name: "Black Beans"))
+        let writer = makeWriter(harness)
+
+        let results = await writer.searchFoods("rice")
+
+        #expect(results.map(\.id) == ["f1"])
+    }
+
+    @Test("FoodEntity carries the fields the system displays and indexes")
+    func foodEntityMapping() {
+        let food = harness_food(id: "f1", name: "Banana", calories: 105, brand: "Dole")
+        let entity = FoodEntity(food: food)
+        #expect(entity.id == "f1")
+        #expect(entity.name == "Banana")
+        #expect(entity.brand == "Dole")
+        #expect(entity.calories == 105)
+        #expect(entity.attributeSet.title == "Banana")
+    }
+
+    /// Standalone `Food` factory (no harness/store needed).
+    private func harness_food(id: String, name: String, calories: Double, brand: String?) -> Food {
+        var dict: [String: Any] = [
+            "id": id,
+            "userId": "u1",
+            "name": name,
+            "servingSize": 100,
+            "servingUnit": "g",
+            "calories": calories,
+            "protein": 1,
+            "carbs": 27,
+            "fat": 0,
+            "fiber": 3,
+            "isFavorite": false,
+        ]
+        if let brand { dict["brand"] = brand }
+        return try! JSONPatch.decode(Food.self, from: dict)
+    }
+}

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -90,6 +90,10 @@ targets:
       - framework: '../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/shared.framework'
         embed: false
       - sdk: HealthKit.framework
+      # App Intents (Siri / Shortcuts / Spotlight voice logging) + Spotlight
+      # indexing of FoodEntity/RecipeEntity.
+      - sdk: AppIntents.framework
+      - sdk: CoreSpotlight.framework
       - package: Sentry
       - target: BissbilanzWidgets
         embed: true


### PR DESCRIPTION
Implements #317.

## What

Adopts the **App Intents** framework so users can log foods and recipes by voice ("Hey Siri, log a banana with Bissbilanz"), from **Spotlight**, and in **Shortcuts** automations.

### New (`Bissbilanz/Intents/`)
- **`LogFoodIntent` / `LogRecipeIntent`** — log silently (`openAppWhenRun = false`), returning a localized confirmation dialog. Meal and servings are optional (meal defaults to the time-of-day meal).
- **`FoodEntity` / `RecipeEntity`** (`AppEntity` + `IndexedEntity`) with **`EntityStringQuery`** queries that resolve a spoken/typed string to candidates (multiple → the framework's automatic disambiguation), ids back to entities, and favorites/recents as suggestions.
- **`MealTypeAppEnum`** — the server's `breakfast/lunch/dinner/snacks`, with the same time-of-day default the in-app quick-log uses.
- **`BissbilanzShortcuts`** (`AppShortcutsProvider`) — exposes the two log shortcuts (≤10 phrases, one parameter per phrase, each includes the app name).
- **`OpenFoodIntent` / `OpenRecipeIntent`** (`OpenIntent`) — tapping a Spotlight result routes to the food/recipe detail via the existing deep-link router.
- **`IntentDonations`** — Spotlight indexing (`CSSearchableIndex.indexAppEntities`) + Siri donation after each manual log.
- **`EntryWriter`** — single, UI/AppIntents-agnostic entry point wrapping the repositories (search + optimistic-write + enqueue + drain). Registered via `AppDependencyManager` so intents resolve it.

### Wiring
- `BissbilanzApp` builds + registers `EntryWriter` and the deep-link router, enables donations, and reindexes Spotlight on foreground.
- `EntryRepository.createEntry` donates/indexes after a known-food/recipe log.
- `DeepLink` gains a `.recipe` case (+ `ContentView` handling) for `OpenRecipeIntent`.
- `project.yml`: link `AppIntents.framework` + `CoreSpotlight.framework`.

## Key decision: intents run in the app process (no App Intents extension)

The issue's recommendation (a) assumed the SwiftData store lives in the App Group. It doesn't — only the **widget JSON snapshot** is in `group.com.bissbilanz`; the store is in the app container. Rather than migrate the store (risky, and the cross-process need is really the **Widgets quick-add**/**Watch** issues), intents run in the app's process — the system background-launches the app to service Siri/Spotlight/Shortcuts. `perform()` then reuses the existing offline-first `EntryRepository.createEntry` path as-is (Local-mode persist, queued upload + immediate drain when online, HealthKit write-back, `temp_` reconciliation). `EntryWriter` is the reusable seam those follow-up issues can later point at an App-Group store.

## Acceptance criteria
- [x] "Log a banana with Bissbilanz" resolves a food and creates an entry without opening the app
- [x] Disambiguation appears when multiple foods match (framework-driven, via `EntityStringQuery`)
- [x] Foods appear in Spotlight; tapping opens the detail (`OpenFoodIntent`)
- [x] The log intent appears in Shortcuts and can run in automations
- [x] Intent-created entries appear in the app and sync (online) / persist (Local mode)

## Testing
- `bun`-side unchanged. iOS:
  - **App builds** for the simulator under **Swift 6 strict concurrency** (`xcodebuild build`, `** BUILD SUCCEEDED **`).
  - **Full `BissbilanzTests` suite green** — 287 tests pass, including 7 new `IntentsTests` (meal defaulting, `logFood`/`logRecipe` write+enqueue in Synced/Local modes, search/suggestions, `FoodEntity` mapping). The donation hook in `createEntry` is regression-free.
  - `swiftformat --lint` clean.

## Notes
- Intent metadata (titles/phrases) is English (no string catalog yet); the runtime confirmation dialog is localized via `L10n` (en/de). German Siri phrases are a follow-up.
- Baseline is the iOS 16/18 App Intents API (deployment target is iOS 18); iOS 26 `supportedModes` successors are forward-migration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)