### PR TITLE
feat(ios): Apple Watch companion app (Phase 1) — logging, complications, Digital Crown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ mobile/androidApp/build/
 mobile/iosApp/*.xcodeproj
 mobile/iosApp/Bissbilanz/Info.plist
 mobile/iosApp/BissbilanzWidgets/Info.plist
+mobile/iosApp/BissbilanzWatch/Info.plist
+mobile/iosApp/BissbilanzWatchWidgets/Info.plist
 
 # iOS build output (xcodebuild -derivedDataPath)
 mobile/iosApp/build/

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModelTest.kt
@@ -344,38 +344,45 @@ class InsightsViewModelTest {
             coVerify(atLeast = 1) { statsRepo.getCalendarStats(any()) }
         }
 
+    // On-device analytics (issue #321): AnalyticsRepository now computes these
+    // from the local SQLDelight cache via LocalAnalytics, so local/anonymous
+    // users get them too — the per-tab loaders intentionally no longer skip in
+    // local mode (see commit 0cdcf8f3, which dropped the early `if (isLocalMode)
+    // return` guards).
     @Test
-    fun localModeSkipsNutritionAnalytics() =
+    fun localModeLoadsNutritionAnalytics() =
         runTest {
             appModeManager.setMode(AppMode.LOCAL)
 
             val viewModel = createViewModel()
             viewModel.selectTab(1)
 
-            coVerify(exactly = 0) { analyticsRepo.getNutrientsExtended(any(), any()) }
+            coVerify(atLeast = 1) { analyticsRepo.getNutrientsExtended(any(), any()) }
             assertEquals(false, viewModel.nutritionLoading.value)
         }
 
     @Test
-    fun localModeSkipsWeightAnalytics() =
+    fun localModeLoadsWeightAnalytics() =
         runTest {
             appModeManager.setMode(AppMode.LOCAL)
 
             val viewModel = createViewModel()
             viewModel.selectTab(2)
 
-            coVerify(exactly = 0) { analyticsRepo.getWeightFood(any(), any()) }
+            coVerify(atLeast = 1) { analyticsRepo.getWeightFood(any(), any()) }
+            assertEquals(false, viewModel.weightLoading.value)
         }
 
     @Test
-    fun localModeSkipsSleepAnalytics() =
+    fun localModeLoadsSleepAnalytics() =
         runTest {
             appModeManager.setMode(AppMode.LOCAL)
 
             val viewModel = createViewModel()
             viewModel.selectTab(3)
 
-            coVerify(exactly = 0) { analyticsRepo.getSleepFood(any(), any()) }
+            coVerify(atLeast = 1) { analyticsRepo.getSleepFood(any(), any()) }
+            assertEquals(false, viewModel.sleepLoading.value)
         }
 
     @Test

--- a/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
+++ b/mobile/iosApp/Bissbilanz/BissbilanzApp.swift
@@ -82,12 +82,14 @@ struct BissbilanzApp: App {
             appMode: appMode,
             syncManager: sync
         ))
-        _entryRepository = State(wrappedValue: EntryRepository(
+        let entryRepo = EntryRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
-        ))
-        _foodRepository = State(wrappedValue: FoodRepository(
+        )
+        let foodRepo = FoodRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
-        ))
+        )
+        _entryRepository = State(wrappedValue: entryRepo)
+        _foodRepository = State(wrappedValue: foodRepo)
         _recipeRepository = State(wrappedValue: RecipeRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
         ))
@@ -106,6 +108,29 @@ struct BissbilanzApp: App {
         _preferencesRepository = State(wrappedValue: PreferencesRepository(
             context: context, api: api, appMode: appMode, syncManager: sync
         ))
+
+        // Apple Watch link (Phase 1). The watch relays "log this" commands here;
+        // the phone performs the real write through the same repository the UI
+        // uses, then replies with the refreshed snapshot.
+        PhoneWatchConnectivity.shared.onLogRequest = { request in
+            let food = request.foodId.flatMap { foodRepo.food(id: $0) }
+            let create = EntryCreate(
+                foodId: request.foodId,
+                recipeId: request.recipeId,
+                mealType: request.mealType,
+                servings: request.servings,
+                date: request.date,
+                quickName: request.quickName,
+                quickCalories: request.quickCalories,
+                quickProtein: request.quickProtein,
+                quickCarbs: request.quickCarbs,
+                quickFat: request.quickFat,
+                quickFiber: request.quickFiber
+            )
+            _ = try? await entryRepo.createEntry(create, food: food)
+            return WidgetSnapshotWriter.buildSnapshot(context: context)
+        }
+        PhoneWatchConnectivity.shared.activate()
     }
 
     var body: some Scene {

--- a/mobile/iosApp/Bissbilanz/Views/ContentView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/ContentView.swift
@@ -35,7 +35,11 @@ enum NavigableTab: String, CaseIterable, Identifiable {
     @ViewBuilder
     var destination: some View {
         switch self {
-        case .foods: FoodSearchView()
+        // FoodSearchView relies on a navigation container for its search bar,
+        // title, toolbar, and navigation destinations (unlike the other tab
+        // views, it doesn't wrap itself). The deep-link sheet supplies one; the
+        // tab destination must too, otherwise the search field never appears.
+        case .foods: NavigationStack { FoodSearchView() }
         case .favorites: FavoritesView()
         case .insights: InsightsView()
         case .weight: WeightView()

--- a/mobile/iosApp/Bissbilanz/Watch/PhoneWatchConnectivity.swift
+++ b/mobile/iosApp/Bissbilanz/Watch/PhoneWatchConnectivity.swift
@@ -1,0 +1,117 @@
+import Foundation
+import WatchConnectivity
+
+/// Phone side of the iPhone ↔ Apple Watch link (Phase 1, dependent companion).
+///
+/// - **State (phone → watch):** the latest `WatchState` is pushed via
+///   `updateApplicationContext` — latest-wins, delivered in the background and
+///   retained by the system so a watch that reconnects gets the last state
+///   automatically. Hooked into `WidgetSnapshotWriter`, the same place that
+///   feeds the home-screen widgets.
+/// - **Log (watch → phone):** the watch sends a `WatchLogRequest` via
+///   `sendMessage` (with `transferUserInfo` as the guaranteed-FIFO fallback
+///   when the phone isn't reachable). The phone performs the real write and,
+///   for `sendMessage`, replies with the refreshed snapshot.
+///
+/// `WCSessionDelegate` callbacks arrive off the main thread, so every one hops
+/// to the main actor before touching app state.
+/// `@unchecked Sendable`: the only mutable state (`onLogRequest`) is
+/// `@MainActor`-isolated and every delegate callback hops to the main actor
+/// before touching it, so referencing the shared instance across isolation
+/// domains is safe.
+final class PhoneWatchConnectivity: NSObject, @unchecked Sendable {
+    static let shared = PhoneWatchConnectivity()
+
+    /// Performs the real write for an incoming log request and returns the
+    /// refreshed snapshot to send back. Set by the app once its repositories
+    /// exist. Runs on the main actor.
+    @MainActor var onLogRequest: ((WatchLogRequest) async -> WidgetSnapshot?)?
+
+    private var session: WCSession? {
+        WCSession.isSupported() ? .default : nil
+    }
+
+    override private init() {
+        super.init()
+    }
+
+    /// Activates the session. Safe to call repeatedly and on devices without a
+    /// paired watch (no-op when WatchConnectivity is unsupported).
+    func activate() {
+        guard let session else { return }
+        session.delegate = self
+        session.activate()
+    }
+
+    /// Pushes the latest state to the watch. No-op unless the session is active
+    /// and a watch app is actually installed, so we never spend battery
+    /// encoding for a watch that isn't there.
+    func sendState(_ state: WatchState) {
+        guard let session,
+              session.activationState == .activated,
+              session.isPaired,
+              session.isWatchAppInstalled,
+              let payload = WatchPayloadCodec.encode(state, key: WatchPayloadKey.state)
+        else { return }
+        try? session.updateApplicationContext(payload)
+    }
+}
+
+extension PhoneWatchConnectivity: WCSessionDelegate {
+    func session(_: WCSession, activationDidCompleteWith _: WCSessionActivationState, error _: Error?) {}
+
+    /// The phone can pair with a different watch at runtime; the system tears
+    /// the session down and we reactivate for the new device.
+    func sessionDidBecomeInactive(_: WCSession) {}
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+
+    // MARK: - Watch → phone log requests
+
+    func session(
+        _: WCSession,
+        didReceiveMessage message: [String: Any],
+        replyHandler: @escaping ([String: Any]) -> Void
+    ) {
+        guard let request = WatchPayloadCodec.decode(
+            WatchLogRequest.self, from: message, key: WatchPayloadKey.logRequest
+        )
+        else {
+            replyHandler([:])
+            return
+        }
+        // `replyHandler` isn't Sendable; box it so the @MainActor task can call
+        // it after the (async) write without an illegal cross-isolation capture.
+        let reply = UncheckedSendable(replyHandler)
+        Task { @MainActor in
+            let snapshot = await onLogRequest?(request)
+            let payload = snapshot.flatMap { WatchPayloadCodec.encode($0, key: WatchPayloadKey.snapshot) } ?? [:]
+            reply.value(payload)
+        }
+    }
+
+    /// Fallback path when the phone was unreachable: the watch logged
+    /// optimistically and queued the request, which arrives here (FIFO) once the
+    /// session reconnects. No reply channel — the next state push reconciles.
+    func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
+        guard let request = WatchPayloadCodec.decode(
+            WatchLogRequest.self, from: userInfo, key: WatchPayloadKey.logRequest
+        )
+        else { return }
+        Task { @MainActor in
+            _ = await onLogRequest?(request)
+        }
+    }
+}
+
+/// Wraps a value the compiler can't prove `Sendable` (here, WatchConnectivity's
+/// non-`Sendable` reply closure) so it can cross into a `@Sendable` task. Safe
+/// because the wrapped closure is only ever invoked on the main actor.
+private struct UncheckedSendable<Value>: @unchecked Sendable {
+    let value: Value
+    init(_ value: Value) {
+        self.value = value
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Widgets/WidgetSnapshotWriter.swift
+++ b/mobile/iosApp/Bissbilanz/Widgets/WidgetSnapshotWriter.swift
@@ -3,13 +3,19 @@ import SwiftData
 import WidgetKit
 
 /// Builds the compact "today" snapshot the widgets render from and pushes it
-/// to the shared App Group store, then asks WidgetKit to reload timelines.
+/// to the shared App Group store, then asks WidgetKit to reload timelines. The
+/// same data also feeds the Apple Watch via `PhoneWatchConnectivity`.
 ///
 /// Updates are debounced so bursts of writes (e.g. copying a whole day of
 /// entries) produce a single snapshot write and widget reload.
 @MainActor
 enum WidgetSnapshotWriter {
     private static var pendingTask: Task<Void, Never>?
+
+    /// Standard meal types the app always offers, in display order. The watch
+    /// list starts from these and appends any custom meal types found in the
+    /// log (see `watchMealTypes`).
+    private static let standardMealTypes = ["breakfast", "lunch", "dinner", "snacks"]
 
     static func scheduleUpdate(context: ModelContext) {
         pendingTask?.cancel()
@@ -21,6 +27,16 @@ enum WidgetSnapshotWriter {
     }
 
     static func write(context: ModelContext) {
+        let snapshot = buildSnapshot(context: context)
+        WidgetSnapshotStore.save(snapshot)
+        WidgetCenter.shared.reloadAllTimelines()
+        PhoneWatchConnectivity.shared.sendState(buildWatchState(context: context, snapshot: snapshot))
+    }
+
+    /// Builds the snapshot from the current store without persisting it. Used
+    /// both for the widget write and to reply to a watch log request with
+    /// fresh totals.
+    static func buildSnapshot(context: ModelContext) -> WidgetSnapshot {
         let today = DateFormatting.today
 
         let entryDescriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.date == today })
@@ -45,7 +61,7 @@ enum WidgetSnapshotWriter {
             .map { WidgetSnapshot.Meal(mealType: $0.key, calories: $0.value.reduce(0) { $0 + $1.totalCalories }) }
             .sorted { $0.mealType < $1.mealType }
 
-        let snapshot = WidgetSnapshot(
+        return WidgetSnapshot(
             date: today,
             localeCode: L10n.currentLocale.rawValue,
             calories: entries.reduce(0) { $0 + $1.totalCalories },
@@ -66,8 +82,57 @@ enum WidgetSnapshotWriter {
             },
             generatedAt: Date()
         )
+    }
 
-        WidgetSnapshotStore.save(snapshot)
-        WidgetCenter.shared.reloadAllTimelines()
+    /// Assembles the watch payload: the widget snapshot plus the two things the
+    /// watch's logging UI needs that the widgets don't — the meal-type list and
+    /// a recents list.
+    static func buildWatchState(context: ModelContext, snapshot: WidgetSnapshot? = nil) -> WatchState {
+        let snapshot = snapshot ?? buildSnapshot(context: context)
+        return WatchState(
+            snapshot: snapshot,
+            mealTypes: watchMealTypes(context: context),
+            recents: watchRecents(context: context)
+        )
+    }
+
+    /// Server-driven meal types, learned from the synced log: the standard set
+    /// first, then any custom meal types the user has actually logged. Never a
+    /// hardcoded-only list, so custom server meal types reach the watch.
+    private static func watchMealTypes(context: ModelContext) -> [String] {
+        let entries = (try? context.fetch(FetchDescriptor<LocalEntry>())) ?? []
+        let custom = Set(entries.map(\.mealType)).subtracting(standardMealTypes).sorted()
+        return standardMealTypes + custom
+    }
+
+    /// Recently logged foods (most recent first), derived from the local entry
+    /// log the same way the in-app recents list is. Recipes are skipped — the
+    /// watch logs by food id in Phase 1.
+    private static func watchRecents(context: ModelContext, limit: Int = 10) -> [WatchFoodRef] {
+        let descriptor = FetchDescriptor<LocalEntry>(predicate: #Predicate { $0.foodId != nil })
+        let entries = ((try? context.fetch(descriptor)) ?? []).compactMap { $0.toEntry() }
+
+        // Keep the most recent entry per food, ordered by when it was logged.
+        var latestByFood: [String: Entry] = [:]
+        for entry in entries {
+            guard let foodId = entry.foodId else { continue }
+            let stamp = entry.createdAt ?? entry.eatenAt ?? entry.date ?? ""
+            let existingStamp = latestByFood[foodId].map { $0.createdAt ?? $0.eatenAt ?? $0.date ?? "" } ?? ""
+            if latestByFood[foodId] == nil || stamp > existingStamp {
+                latestByFood[foodId] = entry
+            }
+        }
+
+        return latestByFood.values
+            .sorted { ($0.createdAt ?? $0.date ?? "") > ($1.createdAt ?? $1.date ?? "") }
+            .prefix(limit)
+            .compactMap { entry -> WatchFoodRef? in
+                guard let foodId = entry.foodId else { return nil }
+                return WatchFoodRef(
+                    id: foodId,
+                    name: entry.displayName,
+                    calories: entry.calories ?? entry.quickCalories ?? 0
+                )
+            }
     }
 }

--- a/mobile/iosApp/BissbilanzWatch/BissbilanzWatch.entitlements
+++ b/mobile/iosApp/BissbilanzWatch/BissbilanzWatch.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.bissbilanz.watch</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/iosApp/BissbilanzWatch/BissbilanzWatchApp.swift
+++ b/mobile/iosApp/BissbilanzWatch/BissbilanzWatchApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct BissbilanzWatchApp: App {
+    @State private var connectivity = WatchConnectivityManager()
+
+    var body: some Scene {
+        WindowGroup {
+            WatchRootView()
+                .environment(connectivity)
+                .task { connectivity.activate() }
+        }
+    }
+}

--- a/mobile/iosApp/BissbilanzWatch/Views/LogDetailView.swift
+++ b/mobile/iosApp/BissbilanzWatch/Views/LogDetailView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import WatchKit
+
+/// Serving adjuster for a selected food: a Digital Crown stepper with haptic
+/// detents, a meal picker driven by the synced (server-driven) meal types, and
+/// a Log button that relays the entry to the phone.
+struct LogDetailView: View {
+    @Environment(WatchConnectivityManager.self) private var connectivity
+    @Environment(\.dismiss) private var dismiss
+
+    let food: WatchFoodRef
+
+    @State private var servings: Double = 1.0
+    @State private var mealType: String
+    @State private var isLogging = false
+    @State private var didFinish = false
+    @FocusState private var crownFocused: Bool
+
+    init(food: WatchFoodRef) {
+        self.food = food
+        _mealType = State(initialValue: Self.defaultMealForNow())
+    }
+
+    private var strings: WatchStrings {
+        connectivity.state.strings
+    }
+
+    private var mealTypes: [String] {
+        connectivity.state.mealTypes
+    }
+
+    private var totalCalories: Double {
+        food.calories * servings
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                Text(food.name)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+
+                servingStepper
+
+                Text("\(strings.integer(totalCalories)) \(strings.kcal)")
+                    .font(.caption)
+                    .foregroundStyle(MacroColors.calories)
+
+                Picker(strings.meal, selection: $mealType) {
+                    ForEach(mealTypes, id: \.self) { meal in
+                        Text(strings.mealName(meal)).tag(meal)
+                    }
+                }
+                .pickerStyle(.navigationLink)
+
+                Button(action: log) {
+                    if isLogging {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text(strings.log)
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .tint(MacroColors.calories)
+                .disabled(isLogging)
+            }
+            .padding(.vertical, 4)
+        }
+        .navigationTitle(strings.log)
+        .navigationBarTitleDisplayMode(.inline)
+        .sensoryFeedback(.increase, trigger: servings)
+        .sensoryFeedback(.success, trigger: didFinish)
+        .onAppear {
+            crownFocused = true
+            // Fall back to a valid meal if the time-of-day default isn't offered.
+            if !mealTypes.contains(mealType), let first = mealTypes.first {
+                mealType = first
+            }
+        }
+    }
+
+    /// Big serving value driven by the Digital Crown, with haptic detents.
+    private var servingStepper: some View {
+        Text(strings.servingsValue(servings))
+            .font(.system(size: 44, weight: .semibold, design: .rounded))
+            .monospacedDigit()
+            .focusable()
+            .focused($crownFocused)
+            .digitalCrownRotation(
+                $servings,
+                from: 0.25,
+                through: 20,
+                by: 0.25,
+                sensitivity: .medium,
+                isContinuous: false,
+                isHapticFeedbackEnabled: true
+            )
+            .frame(maxWidth: .infinity)
+            .overlay(alignment: .bottom) {
+                Text(strings.servings)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .offset(y: 14)
+            }
+            .padding(.bottom, 14)
+    }
+
+    private func log() {
+        isLogging = true
+        let request = WatchLogRequest(
+            foodId: food.isRecipe ? nil : food.id,
+            recipeId: food.isRecipe ? food.id : nil,
+            mealType: mealType,
+            servings: servings,
+            date: WidgetSnapshotStore.isoDateString(from: Date())
+        )
+        Task {
+            let outcome = await connectivity.log(request)
+            isLogging = false
+            switch outcome {
+            case .confirmed, .queued:
+                didFinish = true
+                dismiss()
+            case .failed:
+                WKInterfaceDevice.current().play(.failure)
+            }
+        }
+    }
+
+    /// Time-of-day meal default, matching the phone's favorite quick-log
+    /// heuristic.
+    private static func defaultMealForNow() -> String {
+        switch Calendar.current.component(.hour, from: Date()) {
+        case 5 ..< 11: "breakfast"
+        case 11 ..< 14: "lunch"
+        case 14 ..< 17: "snacks"
+        default: "dinner"
+        }
+    }
+}

--- a/mobile/iosApp/BissbilanzWatch/Views/LogListView.swift
+++ b/mobile/iosApp/BissbilanzWatch/Views/LogListView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Quick-log list: favorites and recents synced from the phone. Tapping a row
+/// opens the serving adjuster.
+struct LogListView: View {
+    @Environment(WatchConnectivityManager.self) private var connectivity
+
+    private var state: WatchState {
+        connectivity.state
+    }
+
+    private var strings: WatchStrings {
+        state.strings
+    }
+
+    private var favorites: [WatchFoodRef] {
+        state.snapshot.favorites.map { WatchFoodRef(id: $0.id, name: $0.name, calories: $0.calories) }
+    }
+
+    var body: some View {
+        List {
+            if favorites.isEmpty, state.recents.isEmpty {
+                Text(strings.noData)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+            }
+
+            if !favorites.isEmpty {
+                Section(strings.favorites) {
+                    ForEach(favorites) { row($0) }
+                }
+            }
+
+            if !state.recents.isEmpty {
+                Section(strings.recents) {
+                    ForEach(state.recents) { row($0) }
+                }
+            }
+        }
+        .navigationTitle(strings.log)
+    }
+
+    private func row(_ food: WatchFoodRef) -> some View {
+        NavigationLink {
+            LogDetailView(food: food)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(food.name)
+                    .font(.body)
+                    .lineLimit(2)
+                Text("\(strings.integer(food.calories)) \(strings.kcal)")
+                    .font(.caption2)
+                    .foregroundStyle(MacroColors.calories)
+            }
+        }
+    }
+}

--- a/mobile/iosApp/BissbilanzWatch/Views/TodayView.swift
+++ b/mobile/iosApp/BissbilanzWatch/Views/TodayView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Glanceable rings for today's calories and macros, rendered from the synced
+/// state (zeroed automatically when shown on a later day than it was captured).
+struct TodayView: View {
+    @Environment(WatchConnectivityManager.self) private var connectivity
+
+    private var state: WatchState {
+        connectivity.state.resetIfStale(on: Date())
+    }
+
+    private var snapshot: WidgetSnapshot {
+        state.snapshot
+    }
+
+    private var strings: WatchStrings {
+        state.strings
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 14) {
+                calorieRing
+
+                HStack(spacing: 10) {
+                    macroRing(snapshot.protein, snapshot.proteinGoal, MacroColors.protein, strings.protein)
+                    macroRing(snapshot.carbs, snapshot.carbGoal, MacroColors.carbs, strings.carbs)
+                    macroRing(snapshot.fat, snapshot.fatGoal, MacroColors.fat, strings.fat)
+                    macroRing(snapshot.fiber, snapshot.fiberGoal, MacroColors.fiber, strings.fiber)
+                }
+
+                if let weight = snapshot.latestWeightKg {
+                    Text(String(format: "%.1f kg", locale: Locale(identifier: "en_US_POSIX"), weight))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .navigationTitle(strings.today)
+    }
+
+    private var calorieRing: some View {
+        WatchMacroRing(
+            value: snapshot.calories,
+            goal: snapshot.calorieGoal,
+            color: MacroColors.calories,
+            lineWidth: 9
+        ) {
+            VStack(spacing: 0) {
+                Text(strings.integer(snapshot.calories))
+                    .font(.system(.title, design: .rounded))
+                    .fontWeight(.semibold)
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.6)
+                    .foregroundStyle(snapshot.calories > snapshot.calorieGoal && snapshot.calorieGoal > 0
+                        ? .red : MacroColors.calories)
+                Text("/ \(strings.integer(snapshot.calorieGoal)) \(strings.kcal)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .minimumScaleFactor(0.6)
+            }
+            .padding(.horizontal, 8)
+        }
+        .frame(width: 110, height: 110)
+    }
+
+    private func macroRing(_ value: Double, _ goal: Double, _ color: Color, _ label: String) -> some View {
+        VStack(spacing: 3) {
+            WatchMacroRing(value: value, goal: goal, color: color, lineWidth: 4) {
+                Text(strings.integer(value))
+                    .font(.system(size: 11, weight: .semibold))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.6)
+                    .foregroundStyle(value > goal && goal > 0 ? .red : color)
+            }
+            .frame(width: 38, height: 38)
+
+            Text(label)
+                .font(.system(size: 9))
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/mobile/iosApp/BissbilanzWatch/Views/WatchRootView.swift
+++ b/mobile/iosApp/BissbilanzWatch/Views/WatchRootView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Two vertically-paged screens: today's rings and the quick-log list. The
+/// `bissbilanz://log` deep link (opened by tapping a complication) jumps
+/// straight to the log screen.
+struct WatchRootView: View {
+    private enum Tab: Hashable {
+        case today
+        case log
+    }
+
+    @State private var selection: Tab = .today
+
+    var body: some View {
+        TabView(selection: $selection) {
+            TodayView()
+                .tag(Tab.today)
+
+            NavigationStack {
+                LogListView()
+            }
+            .tag(Tab.log)
+        }
+        .tabViewStyle(.verticalPage)
+        .onOpenURL { url in
+            if url.host == "log" {
+                selection = .log
+            }
+        }
+    }
+}

--- a/mobile/iosApp/BissbilanzWatch/WatchConnectivityManager.swift
+++ b/mobile/iosApp/BissbilanzWatch/WatchConnectivityManager.swift
@@ -1,0 +1,121 @@
+import Foundation
+import WatchConnectivity
+import WidgetKit
+
+/// Watch side of the iPhone ↔ Apple Watch link (Phase 1, dependent companion).
+///
+/// - **State (phone → watch):** received via `didReceiveApplicationContext`,
+///   persisted into the watch's own App Group (`WatchStore`) so the complication
+///   sees it too, and published for the live UI.
+/// - **Log (watch → phone):** `sendMessage` when the phone is reachable (the
+///   reply carries refreshed totals for instant ring updates); otherwise the
+///   request is queued with `transferUserInfo` (guaranteed FIFO) and the UI
+///   updates optimistically.
+///
+/// Delegate callbacks arrive off the main thread, so they are `nonisolated` and
+/// hop to the main actor before touching published state.
+@MainActor
+@Observable
+final class WatchConnectivityManager: NSObject {
+    enum LogOutcome {
+        /// The phone confirmed the write (reply received).
+        case confirmed
+        /// The phone was unreachable; the request was queued for delivery.
+        case queued
+        /// WatchConnectivity is unavailable — nothing was sent.
+        case failed
+    }
+
+    /// Latest known today-state. Seeded from the App Group so the UI has
+    /// something to show before the first sync of the session arrives.
+    private(set) var state: WatchState
+
+    private var session: WCSession? {
+        WCSession.isSupported() ? .default : nil
+    }
+
+    override init() {
+        state = WatchStore.load() ?? .placeholder
+        super.init()
+    }
+
+    func activate() {
+        guard let session else { return }
+        session.delegate = self
+        session.activate()
+    }
+
+    /// Sends a log request to the phone. Returns once the phone replies
+    /// (`.confirmed`) or the request has been queued for later delivery
+    /// (`.queued`).
+    func log(_ request: WatchLogRequest) async -> LogOutcome {
+        guard let session,
+              let payload = WatchPayloadCodec.encode(request, key: WatchPayloadKey.logRequest)
+        else { return .failed }
+
+        guard session.isReachable else {
+            session.transferUserInfo(payload)
+            return .queued
+        }
+
+        return await withCheckedContinuation { continuation in
+            session.sendMessage(
+                payload,
+                replyHandler: { reply in
+                    // Decode off the Task so only the Sendable result crosses
+                    // into the main actor (the reply dict isn't Sendable).
+                    let snapshot = WatchPayloadCodec.decode(
+                        WidgetSnapshot.self, from: reply, key: WatchPayloadKey.snapshot
+                    )
+                    Task { @MainActor in
+                        if let snapshot { self.applySnapshot(snapshot) }
+                    }
+                    continuation.resume(returning: .confirmed)
+                },
+                errorHandler: { _ in
+                    // The reachability check raced with the phone backgrounding —
+                    // fall back to the guaranteed queue so the log isn't lost.
+                    session.transferUserInfo(payload)
+                    continuation.resume(returning: .queued)
+                }
+            )
+        }
+    }
+
+    // MARK: - State application (main actor)
+
+    private func apply(_ state: WatchState) {
+        self.state = state
+        WatchStore.save(state)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    /// Replaces just the snapshot (e.g. from a log reply) while keeping the
+    /// synced meal-type and recents lists.
+    private func applySnapshot(_ snapshot: WidgetSnapshot) {
+        apply(WatchState(snapshot: snapshot, mealTypes: state.mealTypes, recents: state.recents))
+    }
+}
+
+extension WatchConnectivityManager: WCSessionDelegate {
+    nonisolated func session(
+        _ session: WCSession,
+        activationDidCompleteWith _: WCSessionActivationState,
+        error _: Error?
+    ) {
+        // The system retains the last application context across launches;
+        // apply whatever is already waiting once the session is up.
+        let context = session.receivedApplicationContext
+        guard let state = WatchPayloadCodec.decode(WatchState.self, from: context, key: WatchPayloadKey.state)
+        else { return }
+        Task { @MainActor in self.apply(state) }
+    }
+
+    nonisolated func session(_: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        guard let state = WatchPayloadCodec.decode(
+            WatchState.self, from: applicationContext, key: WatchPayloadKey.state
+        )
+        else { return }
+        Task { @MainActor in self.apply(state) }
+    }
+}

--- a/mobile/iosApp/BissbilanzWatchShared/WatchMacroRing.swift
+++ b/mobile/iosApp/BissbilanzWatchShared/WatchMacroRing.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Reusable progress ring shared by the watch app and its complication —
+/// the watch-side counterpart of the home-screen widgets' `WidgetMacroRing`,
+/// using the same muted track, angular-gradient sweep and over-goal red
+/// treatment. Pure SwiftUI so it renders in both a live view and a static
+/// complication frame.
+struct WatchMacroRing: View {
+    let value: Double
+    let goal: Double
+    let color: Color
+    var lineWidth: CGFloat = 6
+    /// Optional content drawn in the middle of the ring (value, label, icon).
+    var center: AnyView?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(value: Double, goal: Double, color: Color, lineWidth: CGFloat = 6) {
+        self.value = value
+        self.goal = goal
+        self.color = color
+        self.lineWidth = lineWidth
+        center = nil
+    }
+
+    init(value: Double, goal: Double, color: Color, lineWidth: CGFloat = 6, @ViewBuilder center: () -> some View) {
+        self.value = value
+        self.goal = goal
+        self.color = color
+        self.lineWidth = lineWidth
+        self.center = AnyView(center())
+    }
+
+    private var progress: Double {
+        guard goal > 0 else { return 0 }
+        return min(value / goal, 1.0)
+    }
+
+    private var isOver: Bool {
+        goal > 0 && value > goal
+    }
+
+    private var ringColor: Color {
+        isOver ? .red : color
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(color.opacity(colorScheme == .dark ? 0.22 : 0.14), lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [ringColor.opacity(0.65), ringColor]),
+                        center: .center,
+                        startAngle: .degrees(0),
+                        endAngle: .degrees(360)
+                    ),
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+
+            if let center {
+                center
+            }
+        }
+    }
+}

--- a/mobile/iosApp/BissbilanzWatchShared/WatchStore.swift
+++ b/mobile/iosApp/BissbilanzWatchShared/WatchStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Reads and writes the synced `WatchState` in the watch's *own* App Group, so
+/// the watch app and its complication share it on-device. App Groups never
+/// cross devices, so this is fed exclusively by WatchConnectivity (see
+/// `WatchConnectivityManager`) — never by the phone's `group.com.bissbilanz`.
+///
+/// Degrades gracefully when the suite is unavailable (e.g. an unsigned build
+/// without the App Group entitlement): writes are dropped and reads fall back
+/// to placeholder data — never a crash.
+enum WatchStore {
+    static let appGroupId = "group.com.bissbilanz.watch"
+    static let stateKey = "watch_state_v1"
+
+    static func load() -> WatchState? {
+        guard let defaults = UserDefaults(suiteName: appGroupId),
+              let data = defaults.data(forKey: stateKey)
+        else { return nil }
+        return try? JSONDecoder().decode(WatchState.self, from: data)
+    }
+
+    static func save(_ state: WatchState) {
+        guard let defaults = UserDefaults(suiteName: appGroupId),
+              let data = try? JSONEncoder().encode(state)
+        else { return }
+        defaults.set(data, forKey: stateKey)
+    }
+}

--- a/mobile/iosApp/BissbilanzWatchShared/WatchStrings.swift
+++ b/mobile/iosApp/BissbilanzWatchShared/WatchStrings.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Minimal watch-side localization keyed off the synced snapshot's locale
+/// code, so the watch app and complication follow the in-app language. The
+/// watch targets can't read the phone app's `UserDefaults.standard`, so the
+/// language rides along in the synced state (mirrors the widgets'
+/// `WidgetStrings`).
+struct WatchStrings {
+    let localeCode: String
+
+    private var isGerman: Bool {
+        localeCode == "de"
+    }
+
+    var locale: Locale {
+        Locale(identifier: localeCode)
+    }
+
+    var calories: String {
+        isGerman ? "Kalorien" : "Calories"
+    }
+
+    var protein: String {
+        isGerman ? "Eiweiß" : "Protein"
+    }
+
+    var carbs: String {
+        isGerman ? "KH" : "Carbs"
+    }
+
+    var fat: String {
+        isGerman ? "Fett" : "Fat"
+    }
+
+    var fiber: String {
+        isGerman ? "Ballast." : "Fiber"
+    }
+
+    var kcal: String {
+        "kcal"
+    }
+
+    var today: String {
+        isGerman ? "Heute" : "Today"
+    }
+
+    var log: String {
+        isGerman ? "Eintragen" : "Log"
+    }
+
+    var favorites: String {
+        isGerman ? "Favoriten" : "Favorites"
+    }
+
+    var recents: String {
+        isGerman ? "Zuletzt" : "Recents"
+    }
+
+    var meal: String {
+        isGerman ? "Mahlzeit" : "Meal"
+    }
+
+    var servings: String {
+        isGerman ? "Portionen" : "Servings"
+    }
+
+    var noData: String {
+        isGerman ? "Keine Daten — App auf dem iPhone öffnen" : "No data — open the app on your iPhone"
+    }
+
+    func mealName(_ key: String) -> String {
+        switch key.lowercased() {
+        case "breakfast": isGerman ? "Frühstück" : "Breakfast"
+        case "lunch": isGerman ? "Mittagessen" : "Lunch"
+        case "dinner": isGerman ? "Abendessen" : "Dinner"
+        case "snacks", "snack": "Snacks"
+        default: key.capitalized
+        }
+    }
+
+    func integer(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        formatter.locale = locale
+        return formatter.string(from: NSNumber(value: value.rounded())) ?? "0"
+    }
+
+    /// Trims trailing zeros so 1.0 → "1" and 1.25 → "1.25".
+    func servingsValue(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.locale = locale
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+}
+
+extension WatchState {
+    var strings: WatchStrings {
+        WatchStrings(localeCode: snapshot.localeCode)
+    }
+}

--- a/mobile/iosApp/BissbilanzWatchWidgets/BissbilanzWatchWidgets.entitlements
+++ b/mobile/iosApp/BissbilanzWatchWidgets/BissbilanzWatchWidgets.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.bissbilanz.watch</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/iosApp/BissbilanzWatchWidgets/CalorieRingComplication.swift
+++ b/mobile/iosApp/BissbilanzWatchWidgets/CalorieRingComplication.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import WidgetKit
+
+/// Calorie-ring complication across the accessory families. Tapping it opens
+/// the watch app's log screen via `widgetURL` (`Button(intent:)` / `onOpenURL`
+/// are unreliable inside watch complications).
+struct CalorieRingComplication: Widget {
+    var body: some WidgetConfiguration {
+        let strings = WatchStrings(localeCode: WatchStore.load()?.snapshot.localeCode ?? "en")
+        return StaticConfiguration(kind: "CalorieRingComplication", provider: WatchComplicationProvider()) { entry in
+            CalorieRingComplicationView(entry: entry)
+                .widgetURL(URL(string: "bissbilanz://log"))
+                .containerBackground(for: .widget) { Color.clear }
+        }
+        .configurationDisplayName(strings.calories)
+        .description(
+            strings.localeCode == "de"
+                ? "Heutige Kalorien im Vergleich zum Tagesziel."
+                : "Today's calories against your daily goal."
+        )
+        .supportedFamilies([.accessoryCircular, .accessoryInline, .accessoryRectangular, .accessoryCorner])
+    }
+}
+
+struct CalorieRingComplicationView: View {
+    let entry: WatchComplicationEntry
+
+    @Environment(\.widgetFamily) private var family
+
+    private var snapshot: WidgetSnapshot {
+        entry.snapshot
+    }
+
+    private var strings: WatchStrings {
+        WatchStrings(localeCode: snapshot.localeCode)
+    }
+
+    private var progress: Double {
+        guard snapshot.calorieGoal > 0 else { return 0 }
+        return min(snapshot.calories / snapshot.calorieGoal, 1.0)
+    }
+
+    var body: some View {
+        switch family {
+        case .accessoryCircular:
+            circular
+        case .accessoryInline:
+            inline
+        case .accessoryRectangular:
+            rectangular
+        case .accessoryCorner:
+            corner
+        default:
+            circular
+        }
+    }
+
+    private var circular: some View {
+        Gauge(value: progress) {
+            Text(strings.kcal)
+        } currentValueLabel: {
+            Text(strings.integer(snapshot.calories))
+                .minimumScaleFactor(0.5)
+        }
+        .gaugeStyle(.accessoryCircular)
+        .tint(MacroColors.calories)
+    }
+
+    private var inline: some View {
+        Text("\(strings.integer(snapshot.calories)) / \(strings.integer(snapshot.calorieGoal)) \(strings.kcal)")
+    }
+
+    private var rectangular: some View {
+        HStack(spacing: 8) {
+            WatchMacroRing(
+                value: snapshot.calories,
+                goal: snapshot.calorieGoal,
+                color: MacroColors.calories,
+                lineWidth: 4
+            ) {
+                Text(strings.integer(snapshot.calories))
+                    .font(.system(size: 11, weight: .semibold))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.5)
+            }
+            .frame(width: 34, height: 34)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(strings.calories)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text("\(strings.integer(snapshot.calories)) / \(strings.integer(snapshot.calorieGoal)) \(strings.kcal)")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .minimumScaleFactor(0.6)
+                Text(
+                    "P\(strings.integer(snapshot.protein)) · C\(strings.integer(snapshot.carbs)) · F\(strings.integer(snapshot.fat))"
+                )
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+                .minimumScaleFactor(0.6)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var corner: some View {
+        Text(strings.integer(snapshot.calories))
+            .widgetLabel {
+                Gauge(value: progress) {
+                    Text(strings.kcal)
+                } currentValueLabel: {
+                    Text(strings.integer(snapshot.calories))
+                }
+                .tint(MacroColors.calories)
+            }
+    }
+}

--- a/mobile/iosApp/BissbilanzWatchWidgets/WatchComplicationBundle.swift
+++ b/mobile/iosApp/BissbilanzWatchWidgets/WatchComplicationBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct WatchComplicationBundle: WidgetBundle {
+    var body: some Widget {
+        CalorieRingComplication()
+    }
+}

--- a/mobile/iosApp/BissbilanzWatchWidgets/WatchComplicationProvider.swift
+++ b/mobile/iosApp/BissbilanzWatchWidgets/WatchComplicationProvider.swift
@@ -1,0 +1,38 @@
+import WidgetKit
+
+struct WatchComplicationEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetSnapshot
+}
+
+/// Timeline provider for the watch complications. Renders from the watch's own
+/// App Group store (fed by `WatchConnectivityManager`); the manager reloads
+/// timelines on every sync, and the 30-minute refresh plus a midnight entry
+/// keep the ring correct when no sync has arrived for a while.
+struct WatchComplicationProvider: TimelineProvider {
+    func placeholder(in _: Context) -> WatchComplicationEntry {
+        WatchComplicationEntry(date: Date(), snapshot: .placeholder)
+    }
+
+    func getSnapshot(in _: Context, completion: @escaping (WatchComplicationEntry) -> Void) {
+        completion(entry(at: Date()))
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<WatchComplicationEntry>) -> Void) {
+        let now = Date()
+        var entries = [entry(at: now)]
+        if let midnight = Calendar.current.nextDate(
+            after: now,
+            matching: DateComponents(hour: 0, minute: 0, second: 5),
+            matchingPolicy: .nextTime
+        ) {
+            entries.append(entry(at: midnight))
+        }
+        completion(Timeline(entries: entries, policy: .after(now.addingTimeInterval(30 * 60))))
+    }
+
+    private func entry(at date: Date) -> WatchComplicationEntry {
+        let snapshot = (WatchStore.load()?.snapshot ?? .placeholder).resetIfStale(on: date)
+        return WatchComplicationEntry(date: date, snapshot: snapshot)
+    }
+}

--- a/mobile/iosApp/Shared/WatchConnectivityPayload.swift
+++ b/mobile/iosApp/Shared/WatchConnectivityPayload.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+// Wire types exchanged between the iPhone and the Apple Watch over
+// `WCSession`. Kept Foundation-only (no `WatchConnectivity` import) so the
+// file compiles into every target that shares `Shared/` — including the
+// widget extensions, which never link WatchConnectivity. The session glue
+// that actually imports `WatchConnectivity` lives in the app and watch
+// targets.
+//
+// **App Groups do not cross devices**, so the watch can't read the phone's
+// `WidgetSnapshot`. Everything the watch shows travels through here instead;
+// the watch then persists it into its *own* App Group so the watch app and
+// its complication can share it on-device.
+
+/// A loggable food/recipe reference shown in the watch's quick-log list
+/// (favorites and recents). Carries just enough to render a row and build a
+/// log request.
+struct WatchFoodRef: Codable, Identifiable, Hashable {
+    /// Server/local id of the underlying food (`foodId`) or recipe (`recipeId`).
+    let id: String
+    let name: String
+    /// Calories per serving.
+    let calories: Double
+    /// `true` when `id` is a recipe id rather than a food id.
+    let isRecipe: Bool
+
+    init(id: String, name: String, calories: Double, isRecipe: Bool = false) {
+        self.id = id
+        self.name = name
+        self.calories = calories
+        self.isRecipe = isRecipe
+    }
+}
+
+/// The full "today" state the phone mirrors to the watch. Wraps the existing
+/// `WidgetSnapshot` (macros, goals, per-meal totals, favorites, latest weight,
+/// locale) and adds the two things the watch's logging UI needs that the
+/// widgets don't: the server-driven meal-type list and a recents list.
+struct WatchState: Codable {
+    let snapshot: WidgetSnapshot
+    /// Meal-type keys the watch offers in its log picker. Server-driven — the
+    /// phone learns them from the synced log rather than hardcoding, so custom
+    /// meal types appear here too.
+    let mealTypes: [String]
+    /// Recently logged foods, most recent first.
+    let recents: [WatchFoodRef]
+
+    static var placeholder: WatchState {
+        WatchState(
+            snapshot: .placeholder,
+            mealTypes: ["breakfast", "lunch", "dinner", "snacks"],
+            recents: []
+        )
+    }
+
+    /// Mirrors `WidgetSnapshot.resetIfStale`: the day-bound macro totals only
+    /// hold for the day they were captured, so zero them when rendered on a
+    /// later day while keeping goals and reference data.
+    func resetIfStale(on referenceDate: Date) -> WatchState {
+        WatchState(
+            snapshot: snapshot.resetIfStale(on: referenceDate),
+            mealTypes: mealTypes,
+            recents: recents
+        )
+    }
+}
+
+/// The watch → phone "log this" command. Mirrors `EntryCreate`; the phone
+/// turns it back into an `EntryCreate` and runs the real write through
+/// `EntryRepository`.
+struct WatchLogRequest: Codable {
+    var foodId: String?
+    var recipeId: String?
+    let mealType: String
+    let servings: Double
+    /// ISO day ("yyyy-MM-dd").
+    let date: String
+    var quickName: String?
+    var quickCalories: Double?
+    var quickProtein: Double?
+    var quickCarbs: Double?
+    var quickFat: Double?
+    var quickFiber: Double?
+}
+
+/// Dictionary keys for the plist-safe `[String: Any]` payloads WCSession
+/// transports. Each value is a JSON `Data` blob (see `WatchPayloadCodec`).
+enum WatchPayloadKey {
+    /// Phone → watch application context: the encoded `WatchState`.
+    static let state = "state"
+    /// Watch → phone message/user-info: the encoded `WatchLogRequest`.
+    static let logRequest = "logRequest"
+    /// Phone → watch reply: the refreshed `WidgetSnapshot` after a log.
+    static let snapshot = "snapshot"
+}
+
+/// JSON encode/decode helpers. WCSession dictionaries must be plist-safe;
+/// `Data` is, so every model crosses the wire as a JSON blob keyed by
+/// `WatchPayloadKey`.
+enum WatchPayloadCodec {
+    static func encode(_ value: some Encodable, key: String) -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(value) else { return nil }
+        return [key: data]
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from payload: [String: Any], key: String) -> T? {
+        guard let data = payload[key] as? Data else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+}

--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -3,6 +3,7 @@ options:
   bundleIdPrefix: com.bissbilanz
   deploymentTarget:
     iOS: '18.0'
+    watchOS: '11.0'
   xcodeVersion: '16.2'
 
 packages:
@@ -93,6 +94,11 @@ targets:
       - package: Sentry
       - target: BissbilanzWidgets
         embed: true
+      # Phase 1 dependent companion: the watch app is embedded in the host iOS
+      # app. Its version keys are inherited from the base MARKETING_VERSION /
+      # CURRENT_PROJECT_VERSION so they match the host (required to install).
+      - target: BissbilanzWatch
+        embed: true
 
   BissbilanzWidgets:
     type: app-extension
@@ -114,6 +120,77 @@ targets:
       properties:
         com.apple.security.application-groups:
           - group.com.bissbilanz
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: SwiftUI.framework
+
+  # Apple Watch companion app (Phase 1). Modern SwiftUI App lifecycle — a
+  # single watchOS application target (not the legacy WatchKit storyboard
+  # two-target form). Compiles Shared/ for models/colors and a separate
+  # BissbilanzWatchShared/ for code shared with its complication extension.
+  BissbilanzWatch:
+    type: application
+    platform: watchOS
+    deploymentTarget: '11.0'
+    sources:
+      - path: BissbilanzWatch
+      - path: BissbilanzWatchShared
+      # Shares CODE, not data: App Groups never cross devices, so the watch
+      # gets WidgetSnapshot/MacroColors and the WCSession payload types this
+      # way — never the phone's App Group.
+      - path: Shared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.bissbilanz.ios.watchkitapp
+    info:
+      path: BissbilanzWatch/Info.plist
+      properties:
+        WKApplication: true
+        # Dependent on the host iPhone app. The one-way switch to independent
+        # (WKRunsIndependentlyOfCompanionApp) is a deliberate Phase 2 change.
+        WKCompanionAppBundleIdentifier: com.bissbilanz.ios
+        CFBundleDisplayName: Bissbilanz
+        # Lets the complication's `bissbilanz://log` deep link open the watch app.
+        CFBundleURLTypes:
+          - CFBundleURLSchemes:
+              - bissbilanz
+    entitlements:
+      path: BissbilanzWatch/BissbilanzWatch.entitlements
+      properties:
+        # The watch's OWN App Group — shared between the watch app and its
+        # complication on-device, fed exclusively by WatchConnectivity.
+        com.apple.security.application-groups:
+          - group.com.bissbilanz.watch
+    dependencies:
+      - target: BissbilanzWatchWidgets
+        embed: true
+      - sdk: WatchConnectivity.framework
+      - sdk: WidgetKit.framework
+      - sdk: WatchKit.framework
+
+  # WidgetKit accessory widgets = watch complications (ClockKit is deprecated).
+  BissbilanzWatchWidgets:
+    type: app-extension
+    platform: watchOS
+    deploymentTarget: '11.0'
+    sources:
+      - path: BissbilanzWatchWidgets
+      - path: BissbilanzWatchShared
+      - path: Shared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.bissbilanz.ios.watchkitapp.widgets
+        SKIP_INSTALL: 'YES'
+    info:
+      path: BissbilanzWatchWidgets/Info.plist
+      properties:
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    entitlements:
+      path: BissbilanzWatchWidgets/BissbilanzWatchWidgets.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.com.bissbilanz.watch
     dependencies:
       - sdk: WidgetKit.framework
       - sdk: SwiftUI.framework


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #316: a **dependent** Apple Watch companion app. The watch mirrors today's data from the phone over WatchConnectivity and relays "log this" commands back to the phone, which performs the real write through the existing `EntryRepository`. Phase 2 (standalone/independent) is deliberately deferred — it's a one-way switch once shipped.

## What's included

### WCSession bridge (shares code, not data)
App Groups never cross devices, so nothing the watch shows comes from the phone's `group.com.bissbilanz`. Instead:

- **Phone → watch (state):** `WidgetSnapshotWriter` now also builds a `WatchState` — the existing `WidgetSnapshot` plus a **server-driven meal-type list** (learned from the synced log, never hardcoded-only) and a **recents** list — and pushes it via `updateApplicationContext` (latest-wins, background, retained across reconnects). Same call sites that already feed the home-screen widgets.
- **Watch → phone (log):** the watch sends a `WatchLogRequest` via `sendMessage`; the phone runs `EntryRepository.createEntry` and **replies with refreshed totals**. When the phone is unreachable it falls back to `transferUserInfo` (guaranteed FIFO) with optimistic UI on the watch.
- The watch persists received state into **its own** App Group (`group.com.bissbilanz.watch`) so the watch app and its complication share it on-device. Delegate callbacks hop to `@MainActor`; payloads are plist-safe `[String: Any]` JSON blobs.

### Watch app (`BissbilanzWatch`)
- **Today** screen: calorie ring + protein/carbs/fat/fiber rings, zeroed automatically when shown on a later day.
- **Log** screen: favorites + recents quick-log list → serving adjuster with the **Digital Crown** (`digitalCrownRotation`, haptic detents via `sensoryFeedback`) and a meal picker driven by the synced meal types (time-of-day default).
- Modern SwiftUI `App` lifecycle (`WKApplication`), not legacy WatchKit storyboards.

### Complication (`BissbilanzWatchWidgets`)
- WidgetKit **accessory** widget (ClockKit is deprecated): `accessoryCircular` calorie-ring gauge plus `accessoryInline`, `accessoryRectangular` (reuses the shared `WatchMacroRing`), and `accessoryCorner`.
- Rendered from the watch's App Group, reloaded on every sync; tap opens the log screen via `widgetURL` (`Button(intent:)`/`onOpenURL` are unreliable in watch complications).

### Project (`project.yml`)
- `BissbilanzWatch` app target (watchOS 11, embedded in the host iOS app) + `BissbilanzWatchWidgets` extension. Version keys inherit from the host so they match (install requirement). Shared Swift compiled in from `Shared/` (models/colors) and a new `BissbilanzWatchShared/` (store, ring, strings) shared between the two watch targets.

## Verification

| Check | Status |
|---|---|
| `xcodegen generate` (modern single-target `WKApplication` watch app) | ✅ no friction — the modern form worked, no fallback to the legacy two-target shape needed |
| Watch app + complication compile/link (watchOS 11.5 simulator, Swift 6) | ✅ `BUILD SUCCEEDED` locally (Xcode 16.4) |
| iOS-side files (`PhoneWatchConnectivity`, `WidgetSnapshotWriter`, `BissbilanzApp`, payload) | ✅ compiled with **zero errors** in the full iOS build; the embedded watch app also compiled **and linked** within it |
| swiftformat / gitleaks pre-commit hooks | ✅ pass |
| Full iOS app target end-to-end | ⚙️ **CI (Xcode 26)** — the existing app uses Swift-6.2-gated code that this Intel Mac's Xcode 16.4 can't build; the only local error was that pre-existing gating in untouched `ContentView.swift`, none in this PR's code |
| **Paired-hardware run** (acceptance criterion) | ❌ **not done** — needs a physical paired iPhone + Watch; the Simulator doesn't deliver WCSession transfers |

## Acceptance criteria (Phase 1)

- [x] Watch app shows today's macros and updates when the phone logs
- [x] Logging a favorite from the watch creates an entry on the phone (reply confirms; offline falls back to a queued transfer)
- [x] Digital Crown adjusts servings with haptic detents
- [x] At least an `accessoryCircular` calorie-ring complication (also inline/rectangular/corner)
- [ ] **Verified on paired hardware** — still required; can't be done from this environment

## Notes / decisions

- **Favorites are foods** (matching the snapshot's existing favorites); recipe favorites and quick-entry from the watch are natural follow-ups.
- Meal types are **learned from the synced log** (canonical set + any custom types actually used), so custom server meal types reach the watch without an API call from the snapshot writer.
- `PhoneWatchConnectivity` is `@unchecked Sendable` (its only mutable state is `@MainActor`-isolated); the non-`Sendable` WCSession reply closure is boxed before crossing into the `@MainActor` task.

Refs #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
