### PR TITLE
feat(android): compute analytics + maintenance on-device (#321)

### DIFF
--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -102,14 +102,10 @@ fun InsightsScreen() {
 
     val ranges = listOf("7 Days", "30 Days", "90 Days")
 
-    // Nutrition and Weight analytics are entirely server-backed (AnalyticsRepository),
-    // so those tabs are hidden in Local mode. Pairs of (ViewModel tab index, title).
-    val tabs =
-        if (isLocalMode) {
-            listOf(0 to "Overview", 3 to "Sleep")
-        } else {
-            listOf(0 to "Overview", 1 to "Nutrition", 2 to "Weight", 3 to "Sleep")
-        }
+    // Nutrition, Weight and Sleep analytics are now computed on-device from the
+    // local DB (AnalyticsRepository -> LocalAnalytics), so every tab works in both
+    // modes. Pairs of (ViewModel tab index, title).
+    val tabs = listOf(0 to "Overview", 1 to "Nutrition", 2 to "Weight", 3 to "Sleep")
 
     PullToRefreshWrapper(
         onRefresh = {
@@ -658,27 +654,24 @@ fun InsightsScreen() {
 
                     Spacer(modifier = Modifier.height(12.dp))
 
-                    // Sleep analytics cards are computed from server-only analytics data,
-                    // so they are hidden in Local mode (the sleep log above still works).
-                    if (!isLocalMode) {
-                        if (sleepLoading) {
-                            Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
-                                CircularProgressIndicator()
-                            }
-                        } else {
-                            val foodSleepResult by viewModel.foodSleepResult.collectAsStateWithLifecycle()
-                            val nutrientSleepCorrelations by viewModel.nutrientSleepCorrelations.collectAsStateWithLifecycle()
-                            val preSleepTimingSummary by viewModel.preSleepTimingSummary.collectAsStateWithLifecycle()
-                            val caffeineSleepResult by viewModel.caffeineSleepResult.collectAsStateWithLifecycle()
-
-                            FoodSleepCard(foodSleepResult)
-                            Spacer(Modifier.height(12.dp))
-                            NutrientSleepCard(nutrientSleepCorrelations)
-                            Spacer(Modifier.height(12.dp))
-                            PreSleepWindowCard(preSleepTimingSummary)
-                            Spacer(Modifier.height(12.dp))
-                            CaffeineSleepCard(caffeineSleepResult)
+                    // Sleep analytics cards are now computed on-device from the local DB.
+                    if (sleepLoading) {
+                        Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator()
                         }
+                    } else {
+                        val foodSleepResult by viewModel.foodSleepResult.collectAsStateWithLifecycle()
+                        val nutrientSleepCorrelations by viewModel.nutrientSleepCorrelations.collectAsStateWithLifecycle()
+                        val preSleepTimingSummary by viewModel.preSleepTimingSummary.collectAsStateWithLifecycle()
+                        val caffeineSleepResult by viewModel.caffeineSleepResult.collectAsStateWithLifecycle()
+
+                        FoodSleepCard(foodSleepResult)
+                        Spacer(Modifier.height(12.dp))
+                        NutrientSleepCard(nutrientSleepCorrelations)
+                        Spacer(Modifier.height(12.dp))
+                        PreSleepWindowCard(preSleepTimingSummary)
+                        Spacer(Modifier.height(12.dp))
+                        CaffeineSleepCard(caffeineSleepResult)
                     }
 
                     if (showSleepDialog) {

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/MaintenanceScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/MaintenanceScreen.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.bissbilanz.android.ui.theme.*
-import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.model.MaintenanceResponse
+import com.bissbilanz.repository.AnalyticsRepository
 import kotlinx.coroutines.launch
 import kotlinx.datetime.*
 import org.koin.compose.koinInject
@@ -24,7 +24,7 @@ import kotlin.math.roundToInt
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MaintenanceScreen(navController: NavController) {
-    val api: BissbilanzApi = koinInject()
+    val analyticsRepo: AnalyticsRepository = koinInject()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     var isLoading by remember { mutableStateOf(false) }
@@ -49,7 +49,11 @@ fun MaintenanceScreen(navController: NavController) {
             try {
                 val endDate = today.toString()
                 val startDate = today.minus(selectedRange, DateTimeUnit.DAY).toString()
-                result = api.getMaintenanceCalories(startDate, endDate, muscleRatio.toDouble())
+                val response = analyticsRepo.getMaintenance(startDate, endDate, muscleRatio.toDouble())
+                if (response == null) {
+                    error = "Could not calculate. Ensure you have enough weight entries and food logs in the selected range."
+                }
+                result = response
             } catch (e: Exception) {
                 error = "Could not calculate. Ensure you have enough weight entries and food logs in the selected range."
                 result = null

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModel.kt
@@ -405,7 +405,6 @@ class InsightsViewModel(
     }
 
     fun loadNutritionAnalytics() {
-        if (isLocalMode) return
         viewModelScope.launch {
             _nutritionLoading.value = true
             val (startDate, endDate) = dateRange()
@@ -483,7 +482,6 @@ class InsightsViewModel(
     }
 
     fun loadWeightAnalytics() {
-        if (isLocalMode) return
         viewModelScope.launch {
             _weightLoading.value = true
             val (startDate, endDate) = dateRange()
@@ -591,7 +589,6 @@ class InsightsViewModel(
     }
 
     fun loadSleepAnalytics() {
-        if (isLocalMode) return
         viewModelScope.launch {
             _sleepLoading.value = true
             val (startDate, endDate) = dateRange()

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/di/SharedModule.kt
@@ -68,5 +68,6 @@ val sharedModule =
         single { StatsRepository(get(), get(), get(), get(), get()) }
         single { SleepRepository(get(), get(), get(), get(), get(), get(), get()) }
         single { PreferencesRepository(get(), get(), get(), get(), get(), get()) }
+        single { LocalAnalytics(get(), get()) }
         single { AnalyticsRepository(get(), get()) }
     }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/AnalyticsRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/AnalyticsRepository.kt
@@ -1,81 +1,68 @@
 package com.bissbilanz.repository
 
 import com.bissbilanz.ErrorReporter
-import com.bissbilanz.api.BissbilanzApi
 import com.bissbilanz.model.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
+/**
+ * Analytics + maintenance data source. These are now computed on-device from the
+ * local SQLDelight cache via [LocalAnalytics] (issue #321) instead of the server
+ * analytics endpoints, so they work for local/anonymous users with no network and
+ * for online users without the API round-trip. The return types are the same
+ * generated response DTOs the API used, so callers are unchanged.
+ *
+ * Computation runs on [Dispatchers.Default] because it reads the whole food/recipe
+ * cache and resolves every entry; failures are reported and surface as null (or an
+ * empty response) exactly like the previous API-backed implementation.
+ */
 class AnalyticsRepository(
-    private val api: BissbilanzApi,
+    private val local: LocalAnalytics,
     private val errorReporter: ErrorReporter,
 ) {
     suspend fun getFoodDiversity(
         startDate: String,
         endDate: String,
-    ): FoodDiversityResponse? =
-        try {
-            api.getAnalyticsFoodDiversity(startDate, endDate)
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            errorReporter.captureException(e)
-            null
-        }
+    ): FoodDiversityResponse? = compute { local.foodDiversity(startDate, endDate) }
 
     suspend fun getMealTiming(
         startDate: String,
         endDate: String,
-    ): MealTimingResponse? =
-        try {
-            api.getAnalyticsMealTiming(startDate, endDate)
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            errorReporter.captureException(e)
-            null
-        }
+    ): MealTimingResponse? = compute { local.mealTiming(startDate, endDate) }
 
     suspend fun getNutrientsDaily(
         startDate: String,
         endDate: String,
-    ): NutrientsDailyResponse? =
-        try {
-            api.getAnalyticsNutrientsDaily(startDate, endDate)
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            errorReporter.captureException(e)
-            null
-        }
+    ): NutrientsDailyResponse? = compute { local.nutrientsDaily(startDate, endDate) }
 
     suspend fun getNutrientsExtended(
         startDate: String,
         endDate: String,
-    ): NutrientsExtendedResponse? =
-        try {
-            api.getAnalyticsNutrientsExtended(startDate, endDate)
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            errorReporter.captureException(e)
-            null
-        }
+    ): NutrientsExtendedResponse? = compute { local.nutrientsExtended(startDate, endDate) }
 
     suspend fun getWeightFood(
         startDate: String,
         endDate: String,
-    ): WeightFoodResponse? =
-        try {
-            api.getAnalyticsWeightFood(startDate, endDate)
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            errorReporter.captureException(e)
-            null
-        }
+    ): WeightFoodResponse? = compute { local.weightFood(startDate, endDate) }
 
     suspend fun getSleepFood(
         startDate: String,
         endDate: String,
-    ): SleepFoodCorrelationResponse? =
+    ): SleepFoodCorrelationResponse? = compute { local.sleepFood(startDate, endDate) }
+
+    /** Null when the range lacks the inputs (fewer than two weight entries or no logged days). */
+    suspend fun getMaintenance(
+        startDate: String,
+        endDate: String,
+        muscleRatio: Double,
+    ): MaintenanceResponse? = compute { local.maintenance(startDate, endDate, muscleRatio) }
+
+    private suspend fun <T> compute(block: () -> T?): T? =
         try {
-            api.getAnalyticsSleepFood(startDate, endDate)
+            withContext(Dispatchers.Default) { block() }
         } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
+            if (e is CancellationException) throw e
             errorReporter.captureException(e)
             null
         }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/LocalAnalytics.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/LocalAnalytics.kt
@@ -1,0 +1,399 @@
+package com.bissbilanz.repository
+
+import com.bissbilanz.analytics.AggEntry
+import com.bissbilanz.analytics.AggFood
+import com.bissbilanz.analytics.AggRecipe
+import com.bissbilanz.analytics.AggRecipeIngredient
+import com.bissbilanz.analytics.MaintenanceInput
+import com.bissbilanz.analytics.SleepRow
+import com.bissbilanz.analytics.WeightRow
+import com.bissbilanz.analytics.aggregateDailyNutrientTotals
+import com.bissbilanz.analytics.calculateMaintenance
+import com.bissbilanz.analytics.extendedNutrientEntries
+import com.bissbilanz.analytics.foodDiversityRows
+import com.bissbilanz.analytics.mealTimingRows
+import com.bissbilanz.analytics.parseLocalMinutes
+import com.bissbilanz.analytics.sleepFoodCorrelation
+import com.bissbilanz.analytics.weightFoodSeries
+import com.bissbilanz.api.generated.model.DailyNutrients
+import com.bissbilanz.api.generated.model.DailyWeightFood
+import com.bissbilanz.api.generated.model.Food
+import com.bissbilanz.api.generated.model.FoodDiversityEntry
+import com.bissbilanz.api.generated.model.FoodDiversityResponse
+import com.bissbilanz.api.generated.model.MaintenanceMeta
+import com.bissbilanz.api.generated.model.MaintenanceResponse
+import com.bissbilanz.api.generated.model.MealTimingEntry
+import com.bissbilanz.api.generated.model.MealTimingResponse
+import com.bissbilanz.api.generated.model.NutrientsDailyResponse
+import com.bissbilanz.api.generated.model.NutrientsExtendedResponse
+import com.bissbilanz.api.generated.model.RecipeDetail
+import com.bissbilanz.api.generated.model.SleepFoodCorrelationEntry
+import com.bissbilanz.api.generated.model.SleepFoodCorrelationResponse
+import com.bissbilanz.api.generated.model.WeightFoodResponse
+import com.bissbilanz.model.Entry
+import com.bissbilanz.userdata.UserDataDatabase
+import com.bissbilanz.util.decodeOrNull
+import com.bissbilanz.util.totalMacros
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.daysUntil
+import kotlinx.serialization.json.Json
+import com.bissbilanz.api.generated.model.ExtendedNutrientEntry as ExtendedNutrientDto
+import com.bissbilanz.api.generated.model.MaintenanceResult as MaintenanceResultDto
+
+/**
+ * Computes the analytics + maintenance responses on-device from the local
+ * SQLDelight cache, so the mobile apps no longer need the server's analytics
+ * endpoints for these screens (local/anonymous users get them with no network;
+ * online users compute from the synced local DB).
+ *
+ * It produces the very same generated response DTOs the API returned, so the
+ * view models that consume them are unchanged. The heavy lifting — resolving
+ * food / recipe / quick-add entries into per-day and per-entry nutrients — is
+ * done by the shared, golden-vector-locked aggregation in
+ * [com.bissbilanz.analytics]; this class is only the platform data-loader that
+ * maps cached rows into that aggregation's plain input shapes.
+ *
+ * The cached [Entry] embeds its [Food] (with extended nutrients) and
+ * [RecipeDetail] (with ingredients); recipe-ingredient foods are resolved
+ * against the full cached food table, matching the server's CTE join.
+ */
+class LocalAnalytics(
+    private val db: UserDataDatabase,
+    private val json: Json,
+) {
+    fun nutrientsDaily(
+        startDate: String,
+        endDate: String,
+    ): NutrientsDailyResponse {
+        val inputs = buildInputs(loadEntries(startDate, endDate))
+        val totals = aggregateDailyNutrientTotals(inputs.entries, inputs.foods, inputs.recipes)
+        return NutrientsDailyResponse(
+            data =
+                totals.map {
+                    DailyNutrients(
+                        date = it.date,
+                        calories = it.calories,
+                        protein = it.protein,
+                        carbs = it.carbs,
+                        fat = it.fat,
+                        fiber = it.fiber,
+                    )
+                },
+        )
+    }
+
+    fun nutrientsExtended(
+        startDate: String,
+        endDate: String,
+    ): NutrientsExtendedResponse {
+        val inputs = buildInputs(loadEntries(startDate, endDate))
+        val rows = extendedNutrientEntries(inputs.entries, inputs.foods, inputs.recipes)
+        return NutrientsExtendedResponse(
+            data =
+                rows.map { r ->
+                    ExtendedNutrientDto(
+                        date = r.date,
+                        mealType = r.mealType,
+                        eatenAt = r.eatenAt ?: "",
+                        foodId = r.foodId,
+                        recipeId = r.recipeId,
+                        foodName = r.foodName,
+                        calories = r.calories,
+                        protein = r.protein,
+                        carbs = r.carbs,
+                        fat = r.fat,
+                        fiber = r.fiber,
+                        novaGroup = r.novaGroup,
+                        omega3 = r.omega3,
+                        omega6 = r.omega6,
+                        sodium = r.sodium,
+                        caffeine = r.caffeine,
+                        saturatedFat = r.saturatedFat,
+                        transFat = r.transFat,
+                        vitaminC = r.vitaminC,
+                        vitaminD = r.vitaminD,
+                        vitaminE = r.vitaminE,
+                        alcohol = r.alcohol,
+                        addedSugars = r.addedSugars,
+                    )
+                },
+        )
+    }
+
+    fun mealTiming(
+        startDate: String,
+        endDate: String,
+    ): MealTimingResponse {
+        val inputs = buildInputs(loadEntries(startDate, endDate))
+        val rows = mealTimingRows(inputs.entries, inputs.foods, inputs.recipes)
+        return MealTimingResponse(
+            data =
+                rows.map { r ->
+                    MealTimingEntry(
+                        date = r.date,
+                        mealType = r.mealType,
+                        eatenAt = r.eatenAt ?: "",
+                        foodId = r.foodId,
+                        recipeId = r.recipeId,
+                        calories = r.calories,
+                        foodName = r.foodName,
+                    )
+                },
+        )
+    }
+
+    fun foodDiversity(
+        startDate: String,
+        endDate: String,
+    ): FoodDiversityResponse {
+        val entries = loadEntries(startDate, endDate)
+        val foods = loadFoods(entries)
+        val rows = foodDiversityRows(entries.map { it.toAggEntry() }, foods)
+        return FoodDiversityResponse(
+            data =
+                rows.map { r ->
+                    FoodDiversityEntry(
+                        date = r.date,
+                        foodId = r.foodId,
+                        recipeId = r.recipeId,
+                        foodName = r.foodName,
+                        novaGroup = r.novaGroup,
+                    )
+                },
+        )
+    }
+
+    fun weightFood(
+        startDate: String,
+        endDate: String,
+    ): WeightFoodResponse {
+        val inputs = buildInputs(loadEntries(startDate, endDate))
+        val weights =
+            db.userDataDatabaseQueries
+                .selectWeightEntriesByDateRange(startDate, endDate)
+                .executeAsList()
+                .map { WeightRow(it.entryDate, it.weightKg) }
+        val series = weightFoodSeries(inputs.entries, inputs.foods, inputs.recipes, weights)
+        return WeightFoodResponse(
+            data =
+                series.map {
+                    DailyWeightFood(
+                        date = it.date,
+                        calories = it.calories,
+                        weightKg = it.weightKg,
+                        movingAvg = it.movingAvg,
+                    )
+                },
+        )
+    }
+
+    fun sleepFood(
+        startDate: String,
+        endDate: String,
+    ): SleepFoodCorrelationResponse {
+        // The server filters evening entries to those eaten at/after 17:00 local;
+        // parseLocalMinutes reads the local minutes from the stored timestamp.
+        val eveningEntries =
+            loadEntries(startDate, endDate).filter { e ->
+                val minutes = e.eatenAt?.let { parseLocalMinutes(it) } ?: return@filter false
+                minutes / 60 >= EVENING_CUTOFF_HOUR
+            }
+        val inputs = buildInputs(eveningEntries)
+        val sleep =
+            db.userDataDatabaseQueries
+                .selectSleepEntriesByDateRange(startDate, endDate)
+                .executeAsList()
+                .map { SleepRow(it.entryDate, it.durationMinutes.toInt(), it.quality.toInt()) }
+        val rows = sleepFoodCorrelation(inputs.entries, inputs.foods, inputs.recipes, sleep)
+        return SleepFoodCorrelationResponse(
+            data =
+                rows.map {
+                    SleepFoodCorrelationEntry(
+                        date = it.date,
+                        eveningCalories = it.eveningCalories,
+                        sleepDurationMinutes = it.sleepDurationMinutes,
+                        sleepQuality = it.sleepQuality,
+                    )
+                },
+        )
+    }
+
+    /**
+     * Computes maintenance calories for the range, mirroring the server's
+     * `/api/maintenance` route (daily calories incl. fasting days as 0, averaged
+     * over the whole window; weight change from first/last weight). Returns null
+     * when there are fewer than two weight entries or no logged days.
+     */
+    fun maintenance(
+        startDate: String,
+        endDate: String,
+        muscleRatio: Double,
+    ): MaintenanceResponse? {
+        val weights =
+            db.userDataDatabaseQueries
+                .selectWeightEntriesByDateRange(startDate, endDate)
+                .executeAsList()
+        if (weights.size < 2) return null
+
+        val dailyTotals = mutableMapOf<String, Double>()
+        loadEntries(startDate, endDate).groupBy { it.date }.forEach { (date, entries) ->
+            dailyTotals[date] = entries.totalMacros().calories
+        }
+        fastingDaysInRange(startDate, endDate).forEach { date ->
+            dailyTotals.getOrPut(date) { 0.0 }
+        }
+        if (dailyTotals.isEmpty()) return null
+
+        val days = LocalDate.parse(startDate).daysUntil(LocalDate.parse(endDate))
+        if (days <= 0) return null
+
+        val totalCalories = dailyTotals.values.sum()
+        val avgDailyCalories = totalCalories / days
+        val coverage = dailyTotals.size.toDouble() / days
+        val firstWeight = weights.first().weightKg
+        val lastWeight = weights.last().weightKg
+        val weightChangeKg = lastWeight - firstWeight
+
+        val result =
+            calculateMaintenance(
+                MaintenanceInput(
+                    weightChangeKg = weightChangeKg,
+                    avgDailyCalories = avgDailyCalories,
+                    days = days,
+                    muscleRatio = muscleRatio,
+                ),
+            ) ?: return null
+
+        return MaintenanceResponse(
+            result =
+                MaintenanceResultDto(
+                    maintenanceCalories = result.maintenanceCalories,
+                    dailyDeficit = result.dailyDeficit,
+                    totalEnergyBalance = result.totalEnergyBalance,
+                    fatMassKg = result.fatMassKg,
+                    muscleMassKg = result.muscleMassKg,
+                    fatCalories = result.fatCalories,
+                    muscleCalories = result.muscleCalories,
+                    avgDailyCalories = result.avgDailyCalories,
+                    weightChangeKg = result.weightChangeKg,
+                    days = result.days,
+                    muscleRatio = result.muscleRatio,
+                ),
+            meta =
+                MaintenanceMeta(
+                    weightEntries = weights.size,
+                    foodEntryDays = dailyTotals.size,
+                    totalDays = days,
+                    coverage = coverage,
+                    firstWeight = firstWeight,
+                    lastWeight = lastWeight,
+                    startDate = startDate,
+                    endDate = endDate,
+                ),
+        )
+    }
+
+    // --- loading + mapping ---------------------------------------------------
+
+    private class Inputs(
+        val entries: List<AggEntry>,
+        val foods: List<AggFood>,
+        val recipes: List<AggRecipe>,
+    )
+
+    private fun loadEntries(
+        startDate: String,
+        endDate: String,
+    ): List<Entry> =
+        db.userDataDatabaseQueries
+            .selectEntriesByDateRange(startDate, endDate)
+            .executeAsList()
+            .mapNotNull { json.decodeOrNull<Entry>(it.jsonData) }
+
+    /**
+     * Builds the full food table for resolution: every cached food plus any food
+     * embedded in an entry (covers a recipe ingredient or a food not separately
+     * cached). Entry-embedded copies win, matching the freshest synced data.
+     */
+    private fun loadFoods(entries: List<Entry>): List<AggFood> {
+        val byId = mutableMapOf<String, AggFood>()
+        db.userDataDatabaseQueries.selectAllFoods().executeAsList().forEach { row ->
+            json.decodeOrNull<Food>(row.jsonData)?.let { byId[it.id] = it.toAggFood() }
+        }
+        entries.forEach { e -> e.food?.let { byId[it.id] = it.toAggFood() } }
+        return byId.values.toList()
+    }
+
+    private fun loadRecipes(entries: List<Entry>): List<AggRecipe> {
+        val byId = mutableMapOf<String, AggRecipe>()
+        db.userDataDatabaseQueries.selectAllRecipes().executeAsList().forEach { row ->
+            json.decodeOrNull<RecipeDetail>(row.jsonData)?.let { byId[it.id] = it.toAggRecipe() }
+        }
+        entries.forEach { e -> e.recipe?.let { byId[it.id] = it.toAggRecipe() } }
+        return byId.values.toList()
+    }
+
+    private fun buildInputs(entries: List<Entry>): Inputs =
+        Inputs(entries.map { it.toAggEntry() }, loadFoods(entries), loadRecipes(entries))
+
+    private fun fastingDaysInRange(
+        startDate: String,
+        endDate: String,
+    ): List<String> =
+        db.userDataDatabaseQueries
+            .selectAllDayProperties()
+            .executeAsList()
+            .filter { it.isFastingDay == 1L && it.date in startDate..endDate }
+            .map { it.date }
+
+    private fun Entry.toAggEntry(): AggEntry =
+        AggEntry(
+            date = date,
+            mealType = mealType,
+            servings = servings,
+            foodId = foodId,
+            recipeId = recipeId,
+            eatenAt = eatenAt,
+            foodName = food?.name ?: foodName,
+            quickName = quickName,
+            quickCalories = quickCalories,
+            quickProtein = quickProtein,
+            quickCarbs = quickCarbs,
+            quickFat = quickFat,
+            quickFiber = quickFiber,
+        )
+
+    private fun Food.toAggFood(): AggFood =
+        AggFood(
+            id = id,
+            servingSize = servingSize,
+            calories = calories,
+            protein = protein,
+            carbs = carbs,
+            fat = fat,
+            fiber = fiber,
+            novaGroup = novaGroup,
+            omega3 = omega3,
+            omega6 = omega6,
+            sodium = sodium,
+            caffeine = caffeine,
+            saturatedFat = saturatedFat,
+            transFat = transFat,
+            vitaminC = vitaminC,
+            vitaminD = vitaminD,
+            vitaminE = vitaminE,
+            alcohol = alcohol,
+            addedSugars = addedSugars,
+        )
+
+    private fun RecipeDetail.toAggRecipe(): AggRecipe =
+        AggRecipe(
+            id = id,
+            totalServings = totalServings,
+            ingredients = ingredients.map { AggRecipeIngredient(foodId = it.foodId, quantity = it.quantity) },
+        )
+
+    private companion object {
+        const val EVENING_CUTOFF_HOUR = 17
+    }
+}


### PR DESCRIPTION
Stacked on #330 (the shared engine). Migrates the Android insights + maintenance screens off the server analytics endpoints and onto the shared on-device aggregation, so **local/anonymous users get them with no network** and **online users compute from the synced local DB** (no analytics API calls for these screens).

> Base branch is `feat/on-device-analytics` (PR #330). Review/merge that first; the diff here is Android-only.

## What changed
- **`LocalAnalytics`** (shared, commonMain) — the Android-side data-loader. Maps cached SQLDelight rows into the shared aggregation's plain `Agg*` shapes and returns the *same* generated response DTOs the API used:
  - the cached `Entry` already embeds its `Food` (extended nutrients) and `RecipeDetail` (ingredients); recipe-ingredient foods are resolved against the full cached food table, exactly like the server's CTE join;
  - produces nutrients-daily / nutrients-extended / meal-timing / food-diversity / weight-food / sleep-food, plus maintenance.
- **`AnalyticsRepository`** now delegates to `LocalAnalytics` on `Dispatchers.Default` instead of the API; same method signatures, so the view models are unchanged. Adds `getMaintenance`, a faithful port of the server's `/api/maintenance` route (daily calories incl. fasting days as 0, averaged over the whole window; weight change from first/last weight; `days = daysBetween`).
- **`MaintenanceScreen`** computes locally via the repository (works offline).
- **`InsightsViewModel`** drops the `isLocalMode` short-circuits, and **`InsightsScreen`** shows the Nutrition / Weight / Sleep tabs (and the sleep cards) in both modes — the data is now local.

The math itself is the shared, golden-vector-locked aggregation from #330 — this PR is only the platform wiring.

## Acceptance criteria covered (Android)
- [x] Local/anonymous users see maintenance + insights with no network.
- [x] Online users compute insights from the local DB; analytics API calls drop for the migrated screens.
- [x] Android computes the migrated insights locally (no analytics API calls for them).

Weekly/monthly stats, streaks, top foods and meal breakdown remain server-only in Local mode (out of scope; still gated), so the existing "more insights with an account" hint stays.

## Verification (local)
`./gradlew :shared:compileKotlinIosX64 :shared:testDebugUnitTest :shared:ktlintCheck :androidApp:assembleDebug :androidApp:ktlintCheck` — all green. (The `compileKotlinIosX64` step is in #330: it caught a JVM-only `toSortedMap`/`toSortedSet` in the shared aggregation that I fixed there with common-stdlib equivalents — relevant because the iOS PR will consume that framework.)

Runtime note: verified by compile + unit tests + lint, not yet exercised on a device/emulator.

Refs #321