### PR TITLE
feat(ios): compute maintenance on-device via shared Kotlin (#321)

### DIFF
--- a/mobile/iosApp/Bissbilanz/Persistence/LocalMaintenance.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalMaintenance.swift
@@ -1,0 +1,90 @@
+import Foundation
+import shared
+import SwiftData
+
+/// Computes maintenance calories on-device from the local SwiftData store using
+/// the shared Kotlin calculator (`MaintenanceKt.calculateMaintenance`), so the
+/// screen works for local/anonymous users with no network and for online users
+/// without an API round-trip (issue #321).
+///
+/// This mirrors the server's `/api/maintenance` route: daily calories are summed
+/// per day (fasting days counted as 0) and averaged over the whole window, and
+/// the weight change is taken from the first and last weight in range. The math
+/// itself lives in the shared module, so iOS and the server stay in agreement.
+enum LocalMaintenance {
+    /// `days` is the analysis window length (the picker's `weeks * 7`), which
+    /// equals the server's `daysBetween(startDate, endDate)`. `bodyFatRatio` is
+    /// the fraction of the weight change attributed to fat (the slider value);
+    /// the shared calculator takes the complementary muscle ratio.
+    ///
+    /// Returns nil when the range lacks the inputs — fewer than two weight
+    /// entries or no logged/fasting days — matching the server contract.
+    static func compute(
+        context: ModelContext,
+        startDate: String,
+        endDate: String,
+        days: Int,
+        bodyFatRatio: Double
+    ) -> MaintenanceResponse? {
+        guard days > 0 else { return nil }
+
+        let weightDescriptor = FetchDescriptor<LocalWeightEntry>(
+            predicate: #Predicate { $0.entryDate >= startDate && $0.entryDate <= endDate },
+            sortBy: [SortDescriptor(\.entryDate)]
+        )
+        let weights = (try? context.fetch(weightDescriptor)) ?? []
+        guard weights.count >= 2 else { return nil }
+
+        let entryDescriptor = FetchDescriptor<LocalEntry>(
+            predicate: #Predicate { $0.date >= startDate && $0.date <= endDate }
+        )
+        let entries = (try? context.fetch(entryDescriptor)) ?? []
+        var dailyTotals: [String: Double] = [:]
+        for entry in entries {
+            dailyTotals[entry.date, default: 0] += entry.calories * entry.servings
+        }
+
+        let fastingDescriptor = FetchDescriptor<LocalDayProperties>(
+            predicate: #Predicate { $0.isFastingDay && $0.date >= startDate && $0.date <= endDate }
+        )
+        for fasting in (try? context.fetch(fastingDescriptor)) ?? [] where dailyTotals[fasting.date] == nil {
+            dailyTotals[fasting.date] = 0
+        }
+        guard !dailyTotals.isEmpty else { return nil }
+
+        let totalCalories = dailyTotals.values.reduce(0, +)
+        let avgDailyCalories = totalCalories / Double(days)
+        let coverage = Double(dailyTotals.count) / Double(days)
+        let firstWeight = weights.first!.weightKg
+        let lastWeight = weights.last!.weightKg
+        let weightChange = lastWeight - firstWeight
+
+        guard let result = MaintenanceKt.calculateMaintenance(
+            input: MaintenanceInput(
+                weightChangeKg: weightChange,
+                avgDailyCalories: avgDailyCalories,
+                days: Int32(days),
+                muscleRatio: 1 - bodyFatRatio
+            )
+        )
+        else { return nil }
+
+        // The shared result reports fat/muscle as unsigned masses; the screen
+        // shows a directional change, so carry the sign of the weight change.
+        let direction: Double = weightChange < 0 ? -1 : (weightChange > 0 ? 1 : 0)
+        return MaintenanceResponse(
+            maintenanceCalories: result.maintenanceCalories,
+            avgDailyCalories: result.avgDailyCalories,
+            dailyDeficitSurplus: result.dailyDeficit,
+            weightChange: weightChange,
+            startWeight: firstWeight,
+            endWeight: lastWeight,
+            totalDays: days,
+            weightEntryCount: weights.count,
+            foodEntryDays: dailyTotals.count,
+            coveragePercent: coverage * 100,
+            fatChange: direction * result.fatMassKg,
+            muscleChange: direction * result.muscleMassKg
+        )
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -1300,6 +1300,14 @@ enum L10n {
         )
     }
 
+    static var maintenanceInsufficientData: String {
+        localized(
+            "maintenance_insufficient_data",
+            en: "Not enough data. Log at least two weights and some food in this range.",
+            de: "Nicht genug Daten. Erfasse mindestens zwei Gewichte und einige Mahlzeiten in diesem Zeitraum."
+        )
+    }
+
     static var kcalPerDay: String {
         localized("kcal_per_day", en: "kcal/day", de: "kcal/Tag")
     }

--- a/mobile/iosApp/Bissbilanz/Views/MaintenanceView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/MaintenanceView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct MaintenanceView: View {
-    @Environment(BissbilanzAPI.self) private var api
+    @Environment(\.modelContext) private var modelContext
 
     @State private var selectedWeeks = 4
     @State private var bodyFatRatio = 0.5
@@ -83,7 +83,7 @@ struct MaintenanceView: View {
 
     private var calculateButton: some View {
         Button {
-            Task { await calculate() }
+            calculate()
         } label: {
             if isCalculating {
                 ProgressView()
@@ -167,24 +167,25 @@ struct MaintenanceView: View {
         .font(.subheadline)
     }
 
-    private func calculate() async {
+    private func calculate() {
         isCalculating = true
         error = nil
 
         let endDate = Date()
-        let startDate = endDate.adding(days: -selectedWeeks * 7)
+        let days = selectedWeeks * 7
+        let startDate = endDate.adding(days: -days)
 
-        let request = MaintenanceRequest(
+        let response = LocalMaintenance.compute(
+            context: modelContext,
             startDate: startDate.isoDateString,
             endDate: endDate.isoDateString,
-            bodyFatChangeRatio: bodyFatRatio
+            days: days,
+            bodyFatRatio: bodyFatRatio
         )
-
-        do {
-            result = try await api.calculateMaintenance(request)
-        } catch {
-            self.error = error.localizedDescription
+        if response == nil {
+            error = L10n.maintenanceInsufficientData
         }
+        result = response
         isCalculating = false
     }
 }


### PR DESCRIPTION
Stacked on #330 (the shared engine). `MaintenanceView` now computes maintenance calories from the local SwiftData store using the shared Kotlin calculator instead of calling `/api/maintenance` — so it works for **local/anonymous users with no network** and for online users **without an API round-trip** (issue #321).

> Base branch is `feat/on-device-analytics` (PR #330). Review/merge that first; the diff here is iOS-only.

## What changed
- **`LocalMaintenance`** (new) — sums daily calories from local `LocalEntry` rows (fasting days counted as 0, averaged over the window), takes the weight change from the first/last weight in range, and calls **`MaintenanceKt.calculateMaintenance`** via the SKIE-bridged shared framework. Same math the server runs; kept in lockstep by the golden-vector suite in #330.
- **`MaintenanceView`** drops the `BissbilanzAPI` dependency, reads the SwiftData model context, and shows a localized "not enough data" message when the range lacks two weights or any logged day. The slider's body-fat ratio maps to the calculator's complementary muscle ratio; `days = weeks * 7` matches the server's `daysBetween`.

This is the first consumer of the shared **maintenance** calculator on iOS — complementing PR #326, which moved the weight-chart math (`classifyWeightTrend` / `weightMovingAverage` / `linearRegression`) onto the shared framework.

## Acceptance criteria touched (iOS)
- [x] Local/anonymous users see maintenance with no network.
- [x] iOS consumes the shared Kotlin calculator (no Swift maintenance math).

iOS doesn't currently have the rich analytics-cards screen that Android does (its `InsightsView` is a server-stats dashboard), so the nutrition/weight/sleep *insight* migration isn't part of this PR; the shared aggregation in #330 is in place for it when those screens land.

## Verification (local, Intel Mac → x86_64 simulator)
- `./gradlew :shared:linkDebugFrameworkIosX64` — shared framework builds; SKIE exports the new `calculateMaintenance` / `MaintenanceInput` / `MaintenanceResult` cleanly. ✅
- `xcodebuild build -scheme Bissbilanz -destination 'generic/platform=iOS Simulator' -configuration Debug CODE_SIGNING_ALLOWED=NO ARCHS=x86_64` — app compiles + links. ✅
- `swiftformat` clean.

Refs #321