### PR TITLE
fix(crawler): create output dir before writing dataset

### DIFF
--- a/crawler/lib/jsonl-writer.test.ts
+++ b/crawler/lib/jsonl-writer.test.ts
@@ -46,3 +46,16 @@ test('writes a header line then product lines, all schema-valid, with a correct 
 	expect(datasetProductSchema.safeParse(JSON.parse(lines[1])).success).toBe(true);
 	expect(JSON.parse(lines[0])._dataset.source).toBe('off');
 });
+
+test('creates the output directory if it does not exist', async () => {
+	const path = join(tmpdir(), `crawler-test-mkdir-${process.pid}`, 'nested', 'out.jsonl');
+	const w = new DatasetWriter(path, {
+		key: 'migros',
+		name: 'Migros',
+		source: 'migros',
+		priority: 10
+	});
+	await w.open();
+	await w.close();
+	expect(await Bun.file(path).exists()).toBe(true);
+});

--- a/crawler/lib/jsonl-writer.ts
+++ b/crawler/lib/jsonl-writer.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { datasetProductSchema, type DatasetProduct } from '$lib/server/catalog/dataset-schema';
 
 export type DatasetHeaderInput = {
@@ -22,6 +24,7 @@ export class DatasetWriter {
 	}
 
 	async open(): Promise<void> {
+		mkdirSync(dirname(this.#path), { recursive: true });
 		this.#sink = Bun.file(this.#path).writer();
 		const headerLine = JSON.stringify({
 			_dataset: {


### PR DESCRIPTION
A fresh `crawl` (off|migros) failed with `ENOENT` because `DatasetWriter.open()` opened a Bun FileSink at `data/catalog/<file>` without ensuring the parent directory exists. The fixture tests only ever wrote to an existing tmpdir, so they never caught it.

Fix: `mkdir -p` the output dir in `open()`. Adds a regression test (writer creates a missing nested dir). 38 crawler tests pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)