### PR TITLE
fix(ci): use generic Simulator destination for iOS CodeQL build

### DIFF
--- a/.github/workflows/codeql-mobile.yml
+++ b/.github/workflows/codeql-mobile.yml
@@ -154,12 +154,20 @@ jobs:
       - name: Build iOS app
         working-directory: mobile/iosApp
         run: |
+          # Use a generic Simulator destination, not a named device: resolving
+          # `name=iPhone 16,OS=latest` makes xcodebuild query/boot a specific
+          # CoreSimulator device, which stalls indefinitely under CodeQL's build
+          # tracer (hit the 60-min timeout). The staged shared.framework is the
+          # arm64 simulator slice and the runner is arm64, so build arm64-only —
+          # otherwise the generic destination also builds x86_64 and can't find a
+          # slice. Mirrors the build in mobile-ios.yml.
           xcodebuild build \
             -project Bissbilanz.xcodeproj \
             -scheme Bissbilanz \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-mobile.yml
+++ b/.github/workflows/codeql-mobile.yml
@@ -76,7 +76,10 @@ jobs:
   swift:
     name: Analyze (swift)
     runs-on: macos-14
-    timeout-minutes: 60
+    # CodeQL traces the Swift compiler, so the build runs far slower than a
+    # normal xcodebuild (~2-4 min) — successful runs land at 35-45 min. 60 was
+    # too tight and an occasional slow runner tipped over it; 90 gives headroom.
+    timeout-minutes: 90
     permissions:
       contents: read
       security-events: write

--- a/mobile/iosApp/Bissbilanz/Components/KeyboardToolbar.swift
+++ b/mobile/iosApp/Bissbilanz/Components/KeyboardToolbar.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+extension View {
+    /// Finishing touches every native data-entry form gets: a "Done" button
+    /// above the keyboard (decimal and number pads have no return key, so this
+    /// is the only way to dismiss them) plus interactive swipe-to-dismiss while
+    /// scrolling the form. Attach to the `Form`/`List` of an editing sheet.
+    func keyboardDismissable() -> some View {
+        scrollDismissesKeyboard(.interactively)
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button(L10n.done) {
+                        UIApplication.shared.sendAction(
+                            #selector(UIResponder.resignFirstResponder),
+                            to: nil,
+                            from: nil,
+                            for: nil
+                        )
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Components/MacroRingView.swift
+++ b/mobile/iosApp/Bissbilanz/Components/MacroRingView.swift
@@ -78,6 +78,13 @@ struct MacroRingView: View {
         }
         .onAppear { syncProgress() }
         .onChange(of: progress) { _, _ in syncProgress() }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(accessibilityValueText)
+    }
+
+    private var accessibilityValueText: String {
+        goal > 0 ? "\(Int(current)) / \(Int(goal))" : "\(Int(current))"
     }
 
     private func syncProgress() {

--- a/mobile/iosApp/Bissbilanz/Components/MealCard.swift
+++ b/mobile/iosApp/Bissbilanz/Components/MealCard.swift
@@ -31,6 +31,8 @@ struct MealCard: View {
                 Spacer()
                 Text("\(Int(mealCalories)) cal")
                     .font(.subheadline)
+                    .monospacedDigit()
+                    .contentTransition(.numericText(value: mealCalories))
                     .foregroundStyle(.secondary)
             }
 
@@ -45,6 +47,7 @@ struct MealCard: View {
                         .foregroundStyle(.secondary)
                     Text("\(Int(entry.totalCalories))")
                         .font(.caption)
+                        .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
             }

--- a/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
@@ -68,6 +68,8 @@ struct EntryEditSheet: View {
                 if let errorMessage { Text(errorMessage) }
             }
         }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
     }
 
     private func save() async {

--- a/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
@@ -102,6 +102,7 @@ struct FoodEditSheet: View {
                     }
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(existingFood != nil ? L10n.editFood : L10n.createFood)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
@@ -39,6 +39,7 @@ struct QuickEntrySheet: View {
                     macroField(L10n.fiber, text: $fiber, unit: "g")
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(L10n.quickEntry)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/iosApp/Bissbilanz/Sheets/RecipeEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/RecipeEditSheet.swift
@@ -80,6 +80,7 @@ struct RecipeEditSheet: View {
                     }
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(existingRecipe != nil ? L10n.editRecipe : L10n.createRecipe)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/iosApp/Bissbilanz/Sheets/SupplementEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/SupplementEditSheet.swift
@@ -118,6 +118,7 @@ struct SupplementEditSheet: View {
                     }
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(existingSupplement != nil ? L10n.editSupplement : L10n.createSupplement)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -65,6 +65,26 @@ enum L10n {
         localized("done", en: "Done", de: "Fertig")
     }
 
+    static var expand: String {
+        localized("expand", en: "Expand", de: "Erweitern")
+    }
+
+    static var collapse: String {
+        localized("collapse", en: "Collapse", de: "Einklappen")
+    }
+
+    static var more: String {
+        localized("more", en: "More", de: "Mehr")
+    }
+
+    static var addToFavorites: String {
+        localized("add_to_favorites", en: "Add to favorites", de: "Zu Favoriten hinzufügen")
+    }
+
+    static var removeFromFavorites: String {
+        localized("remove_from_favorites", en: "Remove from favorites", de: "Aus Favoriten entfernen")
+    }
+
     static var today: String {
         localized("today", en: "Today", de: "Heute")
     }

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -431,6 +431,7 @@ struct DashboardView: View {
                         .frame(width: 44, height: 44)
                 }
                 .circularGlassBackground()
+                .accessibilityLabel(L10n.scanBarcode)
 
                 Button {
                     showQuickEntry = true
@@ -441,6 +442,7 @@ struct DashboardView: View {
                         .frame(width: 44, height: 44)
                 }
                 .circularGlassBackground()
+                .accessibilityLabel(L10n.quickEntry)
 
                 Button {
                     showFoodSearch = true
@@ -453,6 +455,7 @@ struct DashboardView: View {
                         .frame(width: 56, height: 56)
                 }
                 .circularGlassBackground(tint: MacroColors.calories)
+                .accessibilityLabel(L10n.addFood)
             }
             .padding()
         }
@@ -537,7 +540,7 @@ struct DashboardView: View {
             return SupplementChecklist(
                 supplement: entry.supplement,
                 taken: nowTaken,
-                takenAt: nowTaken ? ISO8601DateFormatter().string(from: Date()) : nil
+                takenAt: nowTaken ? DateFormatting.isoDateTimeString(from: Date()) : nil
             )
         }
         UIImpactFeedbackGenerator(style: .light).impactOccurred()

--- a/mobile/iosApp/Bissbilanz/Views/DayLogView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DayLogView.swift
@@ -39,18 +39,21 @@ struct DayLogView: View {
                     Image(systemName: "doc.on.doc")
                 }
                 .disabled(isCopying)
+                .accessibilityLabel(L10n.copyYesterday)
 
                 Button {
                     showQuickEntry = true
                 } label: {
                     Image(systemName: "pencil")
                 }
+                .accessibilityLabel(L10n.quickEntry)
 
                 Button {
                     showFoodSearch = true
                 } label: {
                     Image(systemName: "plus")
                 }
+                .accessibilityLabel(L10n.addFood)
             }
         }
         .refreshable { await loadEntries() }
@@ -147,6 +150,8 @@ struct DayLogView: View {
                             Text("\(Int(cal)) cal")
                                 .font(.caption)
                                 .fontWeight(.bold)
+                                .monospacedDigit()
+                                .contentTransition(.numericText(value: cal))
                                 .foregroundStyle(MacroColors.calories)
                         }
                         HStack(spacing: 12) {
@@ -155,12 +160,15 @@ struct DayLogView: View {
                             let f = mealEntries.reduce(0.0) { $0 + $1.totalFat }
                             Text("P \(Int(p))g")
                                 .font(.caption2)
+                                .monospacedDigit()
                                 .foregroundStyle(MacroColors.protein)
                             Text("C \(Int(c))g")
                                 .font(.caption2)
+                                .monospacedDigit()
                                 .foregroundStyle(MacroColors.carbs)
                             Text("F \(Int(f))g")
                                 .font(.caption2)
+                                .monospacedDigit()
                                 .foregroundStyle(MacroColors.fat)
                         }
                     }
@@ -181,15 +189,18 @@ struct DayLogView: View {
                         .foregroundStyle(.primary)
                     Text("\(entry.servings, specifier: "%.2g")x \u{00B7} \(Int(entry.totalCalories)) cal")
                         .font(.caption)
+                        .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
                 VStack(alignment: .trailing, spacing: 2) {
                     Text("P\(Int(entry.totalProtein))")
                         .font(.caption2)
+                        .monospacedDigit()
                         .foregroundStyle(MacroColors.protein)
                     Text("C\(Int(entry.totalCarbs)) F\(Int(entry.totalFat))")
                         .font(.caption2)
+                        .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
             }
@@ -216,7 +227,7 @@ struct DayLogView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-        entries = entryRepository.entries(date: date)
+        withAnimation { entries = entryRepository.entries(date: date) }
     }
 
     private func copyYesterday() async {
@@ -225,7 +236,8 @@ struct DayLogView: View {
         let yesterday = viewedDate.adding(days: -1).isoDateString
         do {
             try await entryRepository.copyEntries(fromDate: yesterday, toDate: date)
-            entries = entryRepository.entries(date: date)
+            withAnimation { entries = entryRepository.entries(date: date) }
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/mobile/iosApp/Bissbilanz/Views/FoodDetailView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodDetailView.swift
@@ -36,8 +36,11 @@ struct FoodDetailView: View {
                     } label: {
                         Image(systemName: food.isFavorite ? "star.fill" : "star")
                             .foregroundStyle(food.isFavorite ? .yellow : .secondary)
+                            .contentTransition(.symbolEffect(.replace))
+                            .symbolEffect(.bounce, value: food.isFavorite)
                     }
                     .disabled(isTogglingFavorite)
+                    .accessibilityLabel(food.isFavorite ? L10n.removeFromFavorites : L10n.addToFavorites)
 
                     Menu {
                         Button {
@@ -62,6 +65,7 @@ struct FoodDetailView: View {
                     } label: {
                         Image(systemName: "ellipsis.circle")
                     }
+                    .accessibilityLabel(L10n.more)
                 }
             }
         }
@@ -275,6 +279,7 @@ struct FoodDetailView: View {
     private func toggleFavorite() async {
         guard let food else { return }
         isTogglingFavorite = true
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         do {
             self.food = try await foodRepository.toggleFavorite(foodId: food.id, isFavorite: !food.isFavorite)
         } catch {

--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -55,6 +55,7 @@ struct FoodSearchView: View {
                 } label: {
                     Image(systemName: "plus")
                 }
+                .accessibilityLabel(L10n.createFood)
             }
         }
         .navigationDestination(for: Food.self) { food in

--- a/mobile/iosApp/Bissbilanz/Views/RecipeListView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/RecipeListView.swift
@@ -235,6 +235,7 @@ struct LogRecipeSheet: View {
                     DatePicker(L10n.today, selection: $date, displayedComponents: .date)
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(L10n.log)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -386,6 +386,7 @@ struct SettingsView: View {
                     goalField(L10n.fiber + " (g)", text: $editFiber)
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(L10n.editGoals)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/iosApp/Bissbilanz/Views/SleepView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SleepView.swift
@@ -85,6 +85,7 @@ struct SleepView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
+                    .accessibilityLabel(L10n.logSleep)
                 }
             }
             .sheet(isPresented: $showAddSheet) {
@@ -553,6 +554,7 @@ struct AddSleepSheet: View {
                     TextField(L10n.notes, text: $notes)
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(existingEntry != nil ? L10n.edit : L10n.logSleep)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/iosApp/Bissbilanz/Views/SupplementsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SupplementsView.swift
@@ -53,12 +53,14 @@ struct SupplementsView: View {
                         } label: {
                             Image(systemName: "clock.arrow.circlepath")
                         }
+                        .accessibilityLabel(L10n.supplementHistory)
 
                         Button {
                             showCreateSheet = true
                         } label: {
                             Image(systemName: "plus")
                         }
+                        .accessibilityLabel(L10n.createSupplement)
                     }
                 }
             }
@@ -96,6 +98,8 @@ struct SupplementsView: View {
                     Spacer()
                     Text("\(takenCount)/\(totalCount)")
                         .font(.subheadline)
+                        .monospacedDigit()
+                        .contentTransition(.numericText(value: Double(takenCount)))
                         .foregroundStyle(.secondary)
                 }
 
@@ -169,6 +173,8 @@ struct SupplementsView: View {
                     Image(systemName: isTaken ? "checkmark.circle.fill" : "circle")
                         .font(.title2)
                         .foregroundStyle(isTaken ? .green : .secondary)
+                        .contentTransition(.symbolEffect(.replace))
+                        .symbolEffect(.bounce, value: isTaken)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text(supplement.name)
@@ -203,8 +209,10 @@ struct SupplementsView: View {
                                 Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
+                                    .contentTransition(.symbolEffect(.replace))
                             }
                             .buttonStyle(.plain)
+                            .accessibilityLabel(isExpanded ? L10n.collapse : L10n.expand)
                         }
                     }
                 }
@@ -234,6 +242,7 @@ struct SupplementsView: View {
                     }
                 }
                 .padding(.leading, 44)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
     }
@@ -287,6 +296,7 @@ struct SupplementsView: View {
 
     private func toggleSupplement(_ supplement: Supplement, isTaken: Bool) async {
         let dateString = DateFormatting.today
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         do {
             if isTaken {
                 try await supplementRepository.unlogSupplement(id: supplement.id, date: dateString)
@@ -296,7 +306,7 @@ struct SupplementsView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-        loggedIds = supplementRepository.loggedSupplementIds(date: dateString)
+        withAnimation { loggedIds = supplementRepository.loggedSupplementIds(date: dateString) }
     }
 
     private func deleteSupplement(_ supplement: Supplement) async {

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -238,6 +238,7 @@ struct WeightView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
+                    .accessibilityLabel(L10n.logWeight)
                 }
             }
             .sheet(isPresented: $showAddSheet) {
@@ -316,6 +317,8 @@ struct WeightView: View {
             Text(String(format: "%.1f kg", entries.first?.weightKg ?? 0))
                 .font(.title2)
                 .fontWeight(.bold)
+                .monospacedDigit()
+                .contentTransition(.numericText(value: entries.first?.weightKg ?? 0))
                 .foregroundStyle(.blue)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
@@ -752,6 +755,7 @@ struct AddWeightSheet: View {
                     TextField(L10n.notes, text: $notes)
                 }
             }
+            .keyboardDismissable()
             .navigationTitle(existingEntry != nil ? L10n.edit : L10n.logWeight)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -776,6 +780,8 @@ struct AddWeightSheet: View {
                 if let errorMessage { Text(errorMessage) }
             }
         }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
     }
 
     private func writeToHealthIfEnabled(kg: Double) async {


### PR DESCRIPTION
## Problem

The `Analyze (swift)` job in **CodeQL (Mobile)** stalled 50+ minutes on the "Build iOS app" step and hit its 60-minute timeout (e.g. PR #338's run), getting cancelled. It was passing before but the named-simulator destination is a latent hang.

## Cause

The step built with:

```
-destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
```

Resolving a **named** device makes `xcodebuild` query/boot a specific CoreSimulator device. Under CodeQL's build tracer that query can deadlock indefinitely — which is what we saw (stuck on "Build iOS app", no progress to "Perform CodeQL analysis", killed at the 60-min cap). The regular `iOS Build & Test` job passed in the same run, so the app compiles fine — this is purely a CI destination-resolution issue.

## Fix

Build with a **generic** simulator destination (no device resolution), matching the proven build in `mobile-ios.yml`:

```
-destination 'generic/platform=iOS Simulator' ... ARCHS=arm64
```

`ARCHS=arm64` is required because the staged `shared.framework` is the arm64 simulator slice only — without it the generic destination also builds x86_64 and fails on the missing slice.

CodeQL coverage is unaffected: `build-mode: manual` still compiles all Swift via the generic build, so the tracer observes the same sources.

## Validation

This PR touches the workflow file, so the `pull_request` paths filter triggers `CodeQL (Mobile)` here — a green `Analyze (swift)` on this PR confirms the fix.