### PR TITLE
feat(mobile): polish UX, performance, accessibility and i18n (iOS + Android)

### DIFF
--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/insights/MacroImpactCard.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/insights/MacroImpactCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -21,9 +22,11 @@ import kotlin.math.abs
 fun MacroImpactCard(correlations: List<NutrientCorrelation>) {
     CollapsibleCard(title = "Macro Impact on Weight", sectionId = "macro_impact") {
         val filtered =
-            correlations
-                .filter { it.correlation.confidence != ConfidenceLevel.INSUFFICIENT }
-                .sortedByDescending { abs(it.correlation.r) }
+            remember(correlations) {
+                correlations
+                    .filter { it.correlation.confidence != ConfidenceLevel.INSUFFICIENT }
+                    .sortedByDescending { abs(it.correlation.r) }
+            }
         if (filtered.isEmpty()) {
             Text(
                 stringResource(R.string.insights_not_enough_data),

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/insights/NutrientSleepCard.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/components/insights/NutrientSleepCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -21,9 +22,11 @@ import kotlin.math.abs
 fun NutrientSleepCard(correlations: List<NutrientCorrelation>) {
     CollapsibleCard(title = "Nutrients & Sleep", sectionId = "nutrient_sleep") {
         val filtered =
-            correlations
-                .filter { it.correlation.confidence != ConfidenceLevel.INSUFFICIENT }
-                .sortedByDescending { abs(it.correlation.r) }
+            remember(correlations) {
+                correlations
+                    .filter { it.correlation.confidence != ConfidenceLevel.INSUFFICIENT }
+                    .sortedByDescending { abs(it.correlation.r) }
+            }
         if (filtered.isEmpty()) {
             Text(
                 stringResource(R.string.insights_not_enough_data),

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -68,6 +68,7 @@ import com.bissbilanz.model.DailyStatsEntry
 import com.bissbilanz.model.Goals
 import com.bissbilanz.model.MealBreakdownEntry
 import com.bissbilanz.model.SleepCreate
+import com.bissbilanz.model.SleepEntry
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -447,6 +448,7 @@ fun InsightsScreen() {
                     val sleepEntries by viewModel.sleepEntries.collectAsStateWithLifecycle()
                     val sleepFoodCorrelation by viewModel.sleepFoodCorrelation.collectAsStateWithLifecycle()
                     var showSleepDialog by remember { mutableStateOf(false) }
+                    var sleepEntryToDelete by remember { mutableStateOf<SleepEntry?>(null) }
 
                     CollapsibleCard(title = stringResource(R.string.sleep_section_title), sectionId = "sleep") {
                         Row(
@@ -487,7 +489,11 @@ fun InsightsScreen() {
                                 )
                                 Spacer(modifier = Modifier.height(8.dp))
 
-                                Text("Duration Trend", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.SemiBold)
+                                Text(
+                                    stringResource(R.string.sleep_duration_trend),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
                                 Spacer(modifier = Modifier.height(4.dp))
                                 SimpleLineChart(
                                     data = sleepEntries.sortedBy { it.entryDate }.map { it.durationMinutes.toFloat() / 60f },
@@ -523,7 +529,7 @@ fun InsightsScreen() {
                                         fontWeight = FontWeight.Bold,
                                     )
                                     Text(
-                                        "Avg Duration",
+                                        stringResource(R.string.sleep_avg_duration),
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
@@ -557,10 +563,13 @@ fun InsightsScreen() {
                                         }
                                     }
                                     IconButton(
-                                        onClick = { viewModel.deleteSleepEntry(entry.id) },
-                                        modifier = Modifier.size(32.dp),
+                                        onClick = { sleepEntryToDelete = entry },
                                     ) {
-                                        Icon(Icons.Default.Delete, contentDescription = "Delete", modifier = Modifier.size(16.dp))
+                                        Icon(
+                                            Icons.Default.Delete,
+                                            contentDescription = stringResource(R.string.sleep_delete_content_desc),
+                                            modifier = Modifier.size(16.dp),
+                                        )
                                     }
                                 }
                                 HorizontalDivider()
@@ -571,9 +580,9 @@ fun InsightsScreen() {
                     // Sleep-Food Correlation
                     if (sleepFoodCorrelation.isNotEmpty() && sleepFoodCorrelation.size >= 3) {
                         Spacer(modifier = Modifier.height(12.dp))
-                        CollapsibleCard(title = "Sleep & Evening Eating", sectionId = "sleepfood") {
+                        CollapsibleCard(title = stringResource(R.string.sleep_evening_eating_title), sectionId = "sleepfood") {
                             Text(
-                                "How evening calories relate to your sleep",
+                                stringResource(R.string.sleep_evening_eating_description),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -597,7 +606,7 @@ fun InsightsScreen() {
                                             fontWeight = FontWeight.Bold,
                                         )
                                         Text(
-                                            "Light evening",
+                                            stringResource(R.string.sleep_light_evening),
                                             style = MaterialTheme.typography.labelSmall,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
@@ -615,7 +624,7 @@ fun InsightsScreen() {
                                             fontWeight = FontWeight.Bold,
                                         )
                                         Text(
-                                            "Heavy evening",
+                                            stringResource(R.string.sleep_heavy_evening),
                                             style = MaterialTheme.typography.labelSmall,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
@@ -687,6 +696,28 @@ fun InsightsScreen() {
                                     ),
                                 )
                                 showSleepDialog = false
+                            },
+                        )
+                    }
+
+                    sleepEntryToDelete?.let { entry ->
+                        AlertDialog(
+                            onDismissRequest = { sleepEntryToDelete = null },
+                            title = { Text(stringResource(R.string.sleep_delete_dialog_title)) },
+                            text = { Text(stringResource(R.string.sleep_delete_dialog_text, entry.entryDate)) },
+                            confirmButton = {
+                                TextButton(
+                                    onClick = {
+                                        viewModel.deleteSleepEntry(entry.id)
+                                        sleepEntryToDelete = null
+                                    },
+                                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                                ) { Text(stringResource(R.string.action_delete)) }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { sleepEntryToDelete = null }) {
+                                    Text(stringResource(R.string.dialog_cancel))
+                                }
                             },
                         )
                     }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/theme/Motion.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/theme/Motion.kt
@@ -12,4 +12,3 @@ object Motion {
 }
 
 val GentleSpring = spring<Float>(dampingRatio = Motion.GENTLE_DAMPING, stiffness = Motion.GENTLE_STIFFNESS)
-val SnapSpring = spring<Float>(dampingRatio = Motion.SNAP_DAMPING, stiffness = Motion.SNAP_STIFFNESS)

--- a/mobile/androidApp/src/androidMain/res/values-de/strings.xml
+++ b/mobile/androidApp/src/androidMain/res/values-de/strings.xml
@@ -41,6 +41,16 @@
     <string name="sleep_no_entries">Noch keine Schlafeinträge. Tippe +, um Schlaf zu erfassen.</string>
     <string name="sleep_quality_trend">Qualitätsverlauf</string>
     <string name="sleep_avg_quality">Ø Qualität</string>
+    <string name="sleep_duration_trend">Dauerverlauf</string>
+    <string name="sleep_avg_duration">Ø Dauer</string>
+    <string name="sleep_evening_eating_title">Schlaf &amp; Abendessen</string>
+    <string name="sleep_evening_eating_description">Wie Abendkalorien mit deinem Schlaf zusammenhängen</string>
+    <string name="sleep_light_evening">Leichter Abend</string>
+    <string name="sleep_heavy_evening">Schwerer Abend</string>
+    <string name="sleep_delete_content_desc">Schlafeintrag löschen</string>
+    <string name="sleep_delete_dialog_title">Schlafeintrag löschen</string>
+    <string name="sleep_delete_dialog_text">Schlafeintrag vom %1$s löschen?</string>
+    <string name="action_delete">Löschen</string>
     <string name="sleep_log_dialog_title">Schlaf erfassen</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Abbrechen</string>

--- a/mobile/androidApp/src/androidMain/res/values/strings.xml
+++ b/mobile/androidApp/src/androidMain/res/values/strings.xml
@@ -41,6 +41,16 @@
     <string name="sleep_no_entries">No sleep entries yet. Tap + to log your sleep.</string>
     <string name="sleep_quality_trend">Quality Trend</string>
     <string name="sleep_avg_quality">Avg Quality</string>
+    <string name="sleep_duration_trend">Duration Trend</string>
+    <string name="sleep_avg_duration">Avg Duration</string>
+    <string name="sleep_evening_eating_title">Sleep &amp; Evening Eating</string>
+    <string name="sleep_evening_eating_description">How evening calories relate to your sleep</string>
+    <string name="sleep_light_evening">Light evening</string>
+    <string name="sleep_heavy_evening">Heavy evening</string>
+    <string name="sleep_delete_content_desc">Delete sleep entry</string>
+    <string name="sleep_delete_dialog_title">Delete Sleep Entry</string>
+    <string name="sleep_delete_dialog_text">Delete sleep entry from %1$s?</string>
+    <string name="action_delete">Delete</string>
     <string name="sleep_log_dialog_title">Log Sleep</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_cancel">Cancel</string>

--- a/mobile/iosApp/Bissbilanz/Components/ErrorView.swift
+++ b/mobile/iosApp/Bissbilanz/Components/ErrorView.swift
@@ -10,7 +10,7 @@ struct ErrorView: View {
                 .font(.largeTitle)
                 .foregroundStyle(.secondary)
 
-            Text("Something went wrong")
+            Text(L10n.somethingWentWrong)
                 .font(.headline)
 
             Text(error.localizedDescription)
@@ -19,7 +19,7 @@ struct ErrorView: View {
                 .multilineTextAlignment(.center)
 
             if let retryAction {
-                Button("Try Again", action: retryAction)
+                Button(L10n.retry, action: retryAction)
                     .buttonStyle(.bordered)
             }
         }

--- a/mobile/iosApp/Bissbilanz/Components/LoadingView.swift
+++ b/mobile/iosApp/Bissbilanz/Components/LoadingView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct LoadingView: View {
-    var message: String = "Loading..."
+    var message: String = L10n.loading
 
     var body: some View {
         VStack(spacing: 12) {

--- a/mobile/iosApp/Bissbilanz/Components/ToastView.swift
+++ b/mobile/iosApp/Bissbilanz/Components/ToastView.swift
@@ -4,6 +4,8 @@ struct ToastModifier: ViewModifier {
     @Binding var message: String?
     var duration: TimeInterval = 2.0
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func body(content: Content) -> some View {
         content
             .overlay(alignment: .bottom) {
@@ -21,12 +23,12 @@ struct ToastModifier: ViewModifier {
                         .onAppear {
                             Task {
                                 try? await Task.sleep(for: .seconds(duration))
-                                withAnimation(.easeOut(duration: 0.3)) { self.message = nil }
+                                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.3)) { self.message = nil }
                             }
                         }
                 }
             }
-            .animation(.spring(duration: 0.3), value: message)
+            .animation(reduceMotion ? nil : .spring(duration: 0.3), value: message)
     }
 }
 

--- a/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
@@ -54,7 +54,7 @@ struct FoodEditSheet: View {
                 }
 
                 Section {
-                    TextField("Name", text: $name)
+                    TextField(L10n.name, text: $name)
                     TextField(L10n.brand, text: $brand)
                     TextField(L10n.barcode, text: $barcode)
                         .keyboardType(.numberPad)
@@ -65,7 +65,7 @@ struct FoodEditSheet: View {
                         TextField("100", text: $servingSize)
                             .keyboardType(.decimalPad)
                             .frame(width: 80)
-                        Picker("Unit", selection: $servingUnit) {
+                        Picker(L10n.unit, selection: $servingUnit) {
                             ForEach(ServingUnit.allCases, id: \.self) { unit in
                                 Text(unit.displayName).tag(unit)
                             }
@@ -91,7 +91,7 @@ struct FoodEditSheet: View {
                 }
 
                 Section {
-                    Toggle("Favorite", isOn: $isFavorite)
+                    Toggle(L10n.favorite, isOn: $isFavorite)
                 }
 
                 if let errorMessage {

--- a/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
@@ -23,7 +23,7 @@ struct QuickEntrySheet: View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Name", text: $name)
+                    TextField(L10n.name, text: $name)
                     Picker(L10n.meal, selection: $mealType) {
                         ForEach(mealTypes, id: \.self) { meal in
                             Text(L10n.mealName(meal)).tag(meal)

--- a/mobile/iosApp/Bissbilanz/Sheets/RecipeEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/RecipeEditSheet.swift
@@ -31,7 +31,7 @@ struct RecipeEditSheet: View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Recipe Name", text: $name)
+                    TextField(L10n.recipeName, text: $name)
                     HStack {
                         Text(L10n.totalServings)
                         Spacer()
@@ -180,7 +180,7 @@ struct FoodPickerSheet: View {
                     ContentUnavailableView(
                         L10n.search,
                         systemImage: "magnifyingglass",
-                        description: Text("Type at least 2 characters")
+                        description: Text(L10n.typeToSearchHint)
                     )
                 } else if isSearching {
                     LoadingView()
@@ -206,7 +206,7 @@ struct FoodPickerSheet: View {
                     .listStyle(.plain)
                 }
             }
-            .navigationTitle("Select Food")
+            .navigationTitle(L10n.selectFood)
             .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $query, prompt: L10n.searchFoods)
             .onChange(of: query) { _, newValue in

--- a/mobile/iosApp/Bissbilanz/Sheets/SupplementEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/SupplementEditSheet.swift
@@ -39,11 +39,11 @@ struct SupplementEditSheet: View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Name", text: $name)
+                    TextField(L10n.name, text: $name)
                 }
 
-                Section("Schedule") {
-                    Picker("Type", selection: $scheduleType) {
+                Section(L10n.schedule) {
+                    Picker(L10n.type, selection: $scheduleType) {
                         Text(L10n.daily).tag(ScheduleType.daily)
                         Text(L10n.everyOtherDay).tag(ScheduleType.everyOtherDay)
                         Text(L10n.weekly).tag(ScheduleType.weekly)
@@ -62,18 +62,18 @@ struct SupplementEditSheet: View {
                                 } label: {
                                     Text(weekdays[day])
                                         .font(.caption2)
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.vertical, 6)
+                                        .frame(maxWidth: .infinity, minHeight: 36)
                                         .background(scheduleDays.contains(day) ? Color.accentColor : Color.clear)
                                         .foregroundStyle(scheduleDays.contains(day) ? .white : .primary)
                                         .clipShape(RoundedRectangle(cornerRadius: 6))
+                                        .contentShape(RoundedRectangle(cornerRadius: 6))
                                 }
                                 .buttonStyle(.plain)
                             }
                         }
                     }
 
-                    Picker("Time of Day", selection: $timeOfDay) {
+                    Picker(L10n.timeOfDay, selection: $timeOfDay) {
                         Text(L10n.morning).tag("morning")
                         Text(L10n.noon).tag("noon")
                         Text(L10n.evening).tag("evening")
@@ -82,17 +82,17 @@ struct SupplementEditSheet: View {
                 }
 
                 Section {
-                    Toggle("Active", isOn: $isActive)
+                    Toggle(L10n.active, isOn: $isActive)
                 }
 
                 Section(L10n.ingredients) {
                     ForEach($ingredientRows) { $row in
                         HStack {
-                            TextField("Name", text: $row.name)
-                            TextField("Dose", text: $row.dosage)
+                            TextField(L10n.name, text: $row.name)
+                            TextField(L10n.dose, text: $row.dosage)
                                 .keyboardType(.decimalPad)
                                 .frame(width: 60)
-                            TextField("Unit", text: $row.dosageUnit)
+                            TextField(L10n.unit, text: $row.dosageUnit)
                                 .frame(width: 40)
                         }
                     }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -61,6 +61,54 @@ enum L10n {
         localized("retry", en: "Retry", de: "Erneut versuchen")
     }
 
+    static var name: String {
+        localized("name", en: "Name", de: "Name")
+    }
+
+    static var favorite: String {
+        localized("favorite", en: "Favorite", de: "Favorit")
+    }
+
+    static var active: String {
+        localized("active", en: "Active", de: "Aktiv")
+    }
+
+    static var type: String {
+        localized("type", en: "Type", de: "Typ")
+    }
+
+    static var unit: String {
+        localized("unit", en: "Unit", de: "Einheit")
+    }
+
+    static var dose: String {
+        localized("dose", en: "Dose", de: "Dosis")
+    }
+
+    static var schedule: String {
+        localized("schedule", en: "Schedule", de: "Zeitplan")
+    }
+
+    static var timeOfDay: String {
+        localized("time_of_day", en: "Time of Day", de: "Tageszeit")
+    }
+
+    static var recipeName: String {
+        localized("recipe_name", en: "Recipe Name", de: "Rezeptname")
+    }
+
+    static var selectFood: String {
+        localized("select_food", en: "Select Food", de: "Lebensmittel auswählen")
+    }
+
+    static var somethingWentWrong: String {
+        localized("something_went_wrong", en: "Something went wrong", de: "Etwas ist schiefgelaufen")
+    }
+
+    static var typeToSearchHint: String {
+        localized("type_to_search_hint", en: "Type at least 2 characters", de: "Mindestens 2 Zeichen eingeben")
+    }
+
     static var done: String {
         localized("done", en: "Done", de: "Fertig")
     }

--- a/mobile/iosApp/Bissbilanz/Views/CalendarView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/CalendarView.swift
@@ -24,12 +24,18 @@ struct CalendarView: View {
         Calendar.current.component(.month, from: currentMonth)
     }
 
+    /// Date-string → day, so each grid cell is an O(1) lookup instead of a
+    /// linear scan of `calendarDays` (the grid renders 28–42 cells per month).
+    private var daysByDate: [String: CalendarDay] {
+        Dictionary(calendarDays.map { ($0.date, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
     private var daysLogged: Int {
-        calendarDays.filter { $0.calories > 0 }.count
+        calendarDays.count { $0.calories > 0 }
     }
 
     private var daysOnTarget: Int {
-        calendarDays.filter(\.metGoal).count
+        calendarDays.count(where: \.metGoal)
     }
 
     private var avgCalories: Double {
@@ -99,6 +105,7 @@ struct CalendarView: View {
             LazyVGrid(columns: columns, spacing: 4) {
                 let offset = currentMonth.weekdayOffset
                 let daysInMonth = currentMonth.daysInMonth
+                let dayMap = daysByDate
 
                 ForEach(0 ..< (offset + daysInMonth), id: \.self) { index in
                     if index < offset {
@@ -106,7 +113,7 @@ struct CalendarView: View {
                     } else {
                         let dayNum = index - offset + 1
                         let dateStr = String(format: "%04d-%02d-%02d", year, month, dayNum)
-                        let calDay = calendarDays.first { $0.date == dateStr }
+                        let calDay = dayMap[dateStr]
 
                         let isToday = dateStr == DateFormatting.today
                         NavigationLink(value: dateStr) {

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -70,7 +70,7 @@ struct DashboardView: View {
                     ZStack {
                         dayContent
                             .id(dateString)
-                            .transition(.push(from: slideEdge))
+                            .transition(reduceMotion ? .identity : .push(from: slideEdge))
                     }
                 }
                 .padding()
@@ -307,28 +307,6 @@ struct DashboardView: View {
         }
     }
 
-    // MARK: - Fasting Day Banner
-
-    private var fastingBanner: some View {
-        HStack {
-            Image(systemName: "leaf")
-                .foregroundStyle(.orange)
-            Text(L10n.fastingDay)
-                .font(.subheadline)
-                .fontWeight(.medium)
-            Spacer()
-            Button {
-                Task { await toggleFastingDay() }
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .padding(12)
-        .background(.orange.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-    }
-
     // MARK: - Weight Widget
 
     private func weightWidget(_ entry: WeightEntry) -> some View {
@@ -367,7 +345,7 @@ struct DashboardView: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
                 Spacer()
-                let taken = supplementChecklist.filter(\.taken).count
+                let taken = supplementChecklist.count(where: \.taken)
                 Text("\(taken)/\(supplementChecklist.count)")
                     .font(.caption)
                     .foregroundStyle(taken == supplementChecklist.count ? .green : .secondary)

--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -20,9 +20,11 @@ struct FoodSearchView: View {
     @State private var errorMessage: String?
     @State private var toastMessage: String?
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         VStack(spacing: 0) {
-            Picker("", selection: $selectedTab.animation()) {
+            Picker("", selection: $selectedTab.animation(reduceMotion ? nil : .default)) {
                 Text(L10n.search).tag(0)
                 Text(L10n.recent).tag(1)
                 Text(L10n.favorites).tag(2)

--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -16,6 +16,7 @@ struct InsightsView: View {
     @State private var isLoading = true
     @State private var calendarMonth = Date()
     @ScaledMetric(relativeTo: .largeTitle) private var streakNumberSize = 36.0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         NavigationStack {
@@ -64,7 +65,7 @@ struct InsightsView: View {
     // MARK: - Date Range Picker
 
     private var dateRangePicker: some View {
-        Picker(L10n.period, selection: $selectedRange.animation()) {
+        Picker(L10n.period, selection: $selectedRange.animation(reduceMotion ? nil : .default)) {
             Text("7d").tag(7)
             Text("30d").tag(30)
             Text("90d").tag(90)


### PR DESCRIPTION
Polish pass over both mobile apps focused on performance, accessibility, internationalization, and dead-code removal. Surgical, high-signal changes only. Each candidate was verified against the actual code before acting — notably, several "optimistic update / silent failure" audit findings turned out to be **correct** for this local-first architecture (writes are local-DB-first and the sync queue reconciles the server), so those paths were intentionally left unchanged.

Validation: iOS lints clean (`swiftformat`) and is compile-checked by the iOS Build & Test action. **Android was built, unit-tested, and ktlint-checked locally** (`assembleDebug` + `testDebugUnitTest` → BUILD SUCCESSFUL) in addition to CI.

---

## iOS

**Performance**
- CalendarView rendered every month cell (28–42/month) with an O(n²) `calendarDays.first { … }` scan — replaced with a date-keyed dictionary for O(1) lookups. Switched the calendar/dashboard counters to `count(where:)`.

**Accessibility (Reduce Motion)**
- Honored `accessibilityReduceMotion` in the toast animations, the dashboard day-push transition, and the food-search/insights segmented pickers.

**Internationalization (de+en)**
- Localized ~16 hardcoded English form labels via the existing `L10n` enum (`Name`, `Favorite`, `Active`, `Type`, `Unit`, `Dose`, `Schedule`, `Time of Day`, `Recipe Name`, `Select Food`, error/loading copy, recipe food-picker hint).

**UX / cleanup**
- Enlarged the supplement weekday toggles to a ~36pt touch target.
- Removed the dead `fastingBanner` view in DashboardView.

---

## Android

**UX**
- Sleep-entry deletion in Insights now shows a confirmation dialog, matching the delete-confirmation pattern already used in the weight / food / entry screens (was an immediate, unconfirmed delete).

**Accessibility**
- Restored the default 48dp touch target on the sleep delete button (it was constrained to 32dp, below the Material/WCAG minimum).

**Internationalization (de+en)**
- Finished localizing the Insights sleep section: `Duration Trend`, `Avg Duration`, the "Sleep & Evening Eating" card title/description, "Light/Heavy evening" labels, and the new delete-confirmation dialog — all added to `values/` and `values-de/strings.xml`, mirroring the existing `sleep_*` resources.

**Performance**
- Memoized the correlation `filter + sortedByDescending` in `MacroImpactCard` / `NutrientSleepCard` with `remember(correlations)` so it isn't recomputed on every recomposition.

**Cleanup**
- Removed the unused `SnapSpring` motion spec (the underlying `SNAP_*` constants are still used directly elsewhere).