### PR TITLE
fix(ios): repair offline sync decode contracts, add pending-changes view

### DIFF
--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -11,7 +11,11 @@ enum APIError: Error, LocalizedError {
     case conflict(serverNewer: Bool)
     case serverError(Int, String?)
     case networkError(Error)
-    case decodingError(Error)
+    /// The HTTP status and (truncated) body are carried alongside the underlying
+    /// `DecodingError` so telemetry records the real response that failed to
+    /// parse — an envelope/key/field mismatch otherwise surfaces as a bare
+    /// decode error with no status or body.
+    case decodingError(Error, statusCode: Int, body: String?)
 
     var errorDescription: String? {
         switch self {
@@ -22,7 +26,7 @@ enum APIError: Error, LocalizedError {
         case .conflict: "Conflict"
         case let .serverError(code, msg): msg ?? "Server error (\(code))"
         case let .networkError(err): err.localizedDescription
-        case let .decodingError(err): "Failed to parse response: \(err.localizedDescription)"
+        case let .decodingError(err, _, _): "Failed to parse response: \(err.localizedDescription)"
         }
     }
 }
@@ -474,7 +478,10 @@ final class BissbilanzAPI {
     // MARK: - Preferences
 
     func getPreferences() async throws -> Preferences {
-        try await get("/api/preferences")
+        // The server wraps the body as `{ preferences: {...} }` (like every other
+        // endpoint), so decode the envelope rather than a bare `Preferences`.
+        let response: PreferencesResponse = try await get("/api/preferences")
+        return response.preferences
     }
 
     func updatePreferences(
@@ -482,10 +489,11 @@ final class BissbilanzAPI {
         idempotencyKey: String? = nil,
         clientEditedAt: String? = nil
     ) async throws -> Preferences {
-        try await patch(
+        let response: PreferencesResponse = try await patch(
             "/api/preferences", body: prefs,
             idempotencyKey: idempotencyKey, clientEditedAt: clientEditedAt
         )
+        return response.preferences
     }
 
     // MARK: - Meal Types
@@ -506,8 +514,11 @@ final class BissbilanzAPI {
 
     // MARK: - Day Properties
 
+    // The server exposes day properties as a single collection route keyed by a
+    // `date` query parameter (GET/DELETE) and a PUT body — there is no `/{date}`
+    // path segment and no POST handler.
     func getDayProperties(date: String) async throws -> DayProperties? {
-        let response: DayPropertiesResponse = try await get("/api/day-properties/\(date)")
+        let response: DayPropertiesResponse = try await get("/api/day-properties", params: ["date": date])
         return response.properties
     }
 
@@ -517,9 +528,9 @@ final class BissbilanzAPI {
         idempotencyKey: String? = nil,
         clientEditedAt: String? = nil
     ) async throws -> DayProperties {
-        let body = DayPropertiesSet(isFastingDay: isFastingDay)
-        let response: DayPropertiesResponse = try await post(
-            "/api/day-properties/\(date)", body: body,
+        let body = DayPropertiesSet(date: date, isFastingDay: isFastingDay)
+        let response: DayPropertiesResponse = try await put(
+            "/api/day-properties", body: body,
             idempotencyKey: idempotencyKey, clientEditedAt: clientEditedAt
         )
         guard let properties = response.properties else {
@@ -534,7 +545,7 @@ final class BissbilanzAPI {
         clientEditedAt: String? = nil
     ) async throws {
         try await deleteRequest(
-            "/api/day-properties/\(date)",
+            "/api/day-properties?date=\(date)",
             idempotencyKey: idempotencyKey, clientEditedAt: clientEditedAt
         )
     }
@@ -586,6 +597,20 @@ final class BissbilanzAPI {
     ) async throws -> T {
         var request = URLRequest(url: URL(string: "\(baseURL)\(path)")!)
         request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode(body)
+        applySyncHeaders(&request, idempotencyKey: idempotencyKey, clientEditedAt: clientEditedAt)
+        return try await performRequest(request)
+    }
+
+    private func put<T: Decodable>(
+        _ path: String,
+        body: some Encodable,
+        idempotencyKey: String? = nil,
+        clientEditedAt: String? = nil
+    ) async throws -> T {
+        var request = URLRequest(url: URL(string: "\(baseURL)\(path)")!)
+        request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(body)
         applySyncHeaders(&request, idempotencyKey: idempotencyKey, clientEditedAt: clientEditedAt)
@@ -660,9 +685,12 @@ final class BissbilanzAPI {
             if let message {
                 context["response_body"] = String(message.prefix(500))
             }
-        case let .decodingError(underlying):
-            context["status_code"] = 200
+        case let .decodingError(underlying, statusCode, body):
+            context["status_code"] = statusCode
             context["decoding_error"] = String(describing: underlying)
+            if let body {
+                context["response_body"] = String(body.prefix(500))
+            }
         case .networkError, .notFound, .gone, .conflict, .unauthorized, .none:
             break
         }
@@ -740,10 +768,25 @@ final class BissbilanzAPI {
         if httpResponse.statusCode >= 400 {
             throw APIError.serverError(httpResponse.statusCode, String(data: data, encoding: .utf8))
         }
+        // A 204 No Content (every DELETE) or any empty 2xx body carries nothing
+        // to decode. `deleteRequest` asks for `EmptyResponse` here; returning the
+        // sentinel avoids the dataCorrupted ("Unexpected end of file") error that
+        // would otherwise dead-letter every queued delete after maxRetries. Real
+        // typed responses still throw on an empty body — the `as? T` cast only
+        // succeeds for the body-less EmptyResponse.
+        if httpResponse.statusCode == 204 || data.isEmpty {
+            if let empty = EmptyResponse() as? T {
+                return empty
+            }
+        }
         do {
             return try decoder.decode(T.self, from: data)
         } catch {
-            throw APIError.decodingError(error)
+            throw APIError.decodingError(
+                error,
+                statusCode: httpResponse.statusCode,
+                body: String(data: data, encoding: .utf8)
+            )
         }
     }
 }

--- a/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
+++ b/mobile/iosApp/Bissbilanz/Migration/LocalDataMigrator.swift
@@ -516,9 +516,7 @@ final class LocalDataMigrator {
         update.showWeightWidget = preferences.showWeightWidget
         update.showMealBreakdownWidget = preferences.showMealBreakdownWidget
         update.showTopFoodsWidget = preferences.showTopFoodsWidget
-        update.showSummaryWidget = preferences.showSummaryWidget
-        update.showDayLogWidget = preferences.showDayLogWidget
-        update.showStreakWidget = preferences.showStreakWidget
+        update.showSleepWidget = preferences.showSleepWidget
         update.widgetOrder = preferences.widgetOrder.isEmpty ? nil : preferences.widgetOrder
         update.startPage = preferences.startPage
         update.favoriteTapAction = preferences.favoriteTapAction

--- a/mobile/iosApp/Bissbilanz/Models/DayProperties.swift
+++ b/mobile/iosApp/Bissbilanz/Models/DayProperties.swift
@@ -1,25 +1,19 @@
 import Foundation
 
+// Matches the server's day-properties response object `{ date, isFastingDay }`
+// (camelCase, no userId) — see src/lib/server/validation/responses/day-properties.ts.
 struct DayProperties: Codable {
     let date: String
-    let userId: String
     let isFastingDay: Bool
-
-    enum CodingKeys: String, CodingKey {
-        case date
-        case userId = "user_id"
-        case isFastingDay = "is_fasting_day"
-    }
 }
 
 struct DayPropertiesResponse: Codable {
     let properties: DayProperties?
 }
 
+// PUT /api/day-properties expects `{ date, isFastingDay }` (camelCase) — the date
+// travels in the body, not the URL path. See dayPropertiesSetSchema.
 struct DayPropertiesSet: Codable {
+    let date: String
     let isFastingDay: Bool
-
-    enum CodingKeys: String, CodingKey {
-        case isFastingDay = "is_fasting_day"
-    }
 }

--- a/mobile/iosApp/Bissbilanz/Models/Preferences.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Preferences.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+// The widget booleans, names and types mirror the server's preferences response
+// schema (src/lib/server/validation/responses/preferences.ts) field-for-field.
+// `summary`, `daylog` and `streaks` are NOT toggles — they are `widgetOrder`
+// section keys server-side, so there are no `showSummary/DayLog/StreakWidget`
+// columns. Keep this in sync with the server contract: a field iOS marks
+// required but the server omits makes the whole response fail to decode.
 struct Preferences: Codable {
     let showChartWidget: Bool
     let showFavoritesWidget: Bool
@@ -7,9 +13,7 @@ struct Preferences: Codable {
     let showWeightWidget: Bool
     let showMealBreakdownWidget: Bool
     let showTopFoodsWidget: Bool
-    let showSummaryWidget: Bool
-    let showDayLogWidget: Bool
-    let showStreakWidget: Bool
+    let showSleepWidget: Bool
     let widgetOrder: [String]
     let startPage: String
     let favoriteTapAction: String
@@ -25,9 +29,7 @@ struct Preferences: Codable {
         showWeightWidget: true,
         showMealBreakdownWidget: true,
         showTopFoodsWidget: true,
-        showSummaryWidget: true,
-        showDayLogWidget: true,
-        showStreakWidget: true,
+        showSleepWidget: true,
         widgetOrder: [],
         startPage: "dashboard",
         favoriteTapAction: "instant",
@@ -38,6 +40,12 @@ struct Preferences: Codable {
     )
 }
 
+/// The server wraps the preferences body as `{ preferences: {...} }` on both GET
+/// and PATCH; decode this envelope, not a bare `Preferences`.
+struct PreferencesResponse: Codable {
+    let preferences: Preferences
+}
+
 struct PreferencesUpdate: Codable {
     var showChartWidget: Bool?
     var showFavoritesWidget: Bool?
@@ -45,9 +53,7 @@ struct PreferencesUpdate: Codable {
     var showWeightWidget: Bool?
     var showMealBreakdownWidget: Bool?
     var showTopFoodsWidget: Bool?
-    var showSummaryWidget: Bool?
-    var showDayLogWidget: Bool?
-    var showStreakWidget: Bool?
+    var showSleepWidget: Bool?
     var widgetOrder: [String]?
     var startPage: String?
     var favoriteTapAction: String?

--- a/mobile/iosApp/Bissbilanz/Models/Recipe.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Recipe.swift
@@ -2,7 +2,10 @@ import Foundation
 
 struct Recipe: Codable, Identifiable, Hashable {
     let id: String
-    let userId: String
+    // Optional: the list endpoint (GET /api/recipes) returns summary items
+    // WITHOUT userId, so a non-optional field would fail the whole list decode
+    // and recipes would never pull. It is redundant client-side anyway.
+    let userId: String?
     let name: String
     let totalServings: Double
     let isFavorite: Bool

--- a/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/EntryRepository.swift
@@ -257,7 +257,7 @@ final class EntryRepository {
     }
 
     func setDayProperties(date: String, isFastingDay: Bool) async throws {
-        upsertDayProperties(DayProperties(date: date, userId: "", isFastingDay: isFastingDay))
+        upsertDayProperties(DayProperties(date: date, isFastingDay: isFastingDay))
         save()
         syncManager.enqueue(.setDayProperties(date: date, isFastingDay: isFastingDay))
     }

--- a/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
+++ b/mobile/iosApp/Bissbilanz/Sync/SyncManager.swift
@@ -36,6 +36,8 @@ final class SyncManager {
     private(set) var lastSyncedAt: Date?
 
     @ObservationIgnored private var isDraining = false
+    /// A pending delayed re-drain scheduled for when the soonest backoff expires.
+    @ObservationIgnored private var retryTask: Task<Void, Never>?
 
     /// Test seam: when false, `scheduleDrain` becomes a no-op so tests
     /// control drain timing explicitly via `drainPendingQueue`.
@@ -136,6 +138,7 @@ final class SyncManager {
         isSyncing = true
         errors = []
         var processed = 0
+        ErrorReporter.addBreadcrumb("drain start", category: "sync", data: ["sync.pending": pendingCount])
         defer {
             isSyncing = false
             isDraining = false
@@ -143,22 +146,37 @@ final class SyncManager {
             if processed > 0 {
                 lastSyncedAt = Date()
             }
+            // Recover backed-off ops without waiting for an external trigger.
+            scheduleRetryDrain()
         }
 
         // Re-fetch the head each iteration instead of iterating a start-of-
         // drain snapshot: operations enqueued while an upload is in flight
         // (their `scheduleDrain` is swallowed by the `isDraining` guard) are
         // picked up by this drain instead of waiting for the next trigger.
-        // Every iteration either removes the head row or returns, so the
+        // Every iteration removes the head row, backs it off, or returns, so the
         // loop terminates. Items whose `nextAttemptAt` is in the future are
-        // skipped via `nextDueRow()` (backoff).
+        // skipped via `nextDueRow()` (backoff) — a backed-off op no longer
+        // stalls the ops queued behind it.
         while let row = nextDueRow() {
             guard let operation = row.operation() else {
                 // Unreadable payload — nothing useful can ever be uploaded.
+                // Capture before dropping: this is the most invisible data-loss
+                // path in the drain (a corrupted or schema-changed payload, else
+                // discarded with no error, notice, or telemetry).
+                ErrorReporter.captureWarning(
+                    "Sync op dropped: undecodable payload",
+                    context: ["sync.type": row.type, "sync.seq": row.seq, "sync.outcome": "dropped_undecodable"]
+                )
                 remove(row)
                 continue
             }
             let isDelete = isDeleteOperation(operation)
+            ErrorReporter.addBreadcrumb(
+                "drain \(operation.typeName)",
+                category: "sync",
+                data: ["sync.op": operation.typeName, "sync.retry_count": row.retryCount]
+            )
             do {
                 try await execute(operation, idempotencyKey: row.idempotencyKey, clientEditedAt: row.clientEditedAt)
                 if !row.isDeleted {
@@ -182,6 +200,10 @@ final class SyncManager {
                     remove(row)
                     processed += 1
                     errors.append("Failed to sync \(operation.summary): HTTP 409")
+                    ErrorReporter.captureWarning(
+                        "Sync op dropped: validation conflict",
+                        context: dropContext(operation, row, outcome: "dropped_validation_conflict", status: 409)
+                    )
 
                 case .notFound where isDelete:
                     remove(row)
@@ -193,11 +215,19 @@ final class SyncManager {
                     conflictNotices.append(
                         "Offline change to \(operation.summary) was lost: the record was deleted on another device."
                     )
+                    ErrorReporter.captureWarning(
+                        "Sync op lost: record deleted elsewhere",
+                        context: dropContext(operation, row, outcome: "lost_deleted_elsewhere", status: 404)
+                    )
 
                 case let .clientError(status):
                     remove(row)
                     processed += 1
                     errors.append("Failed to sync \(operation.summary): HTTP \(status)")
+                    ErrorReporter.captureWarning(
+                        "Sync op dropped: client error",
+                        context: dropContext(operation, row, outcome: "dropped_client_error", status: status)
+                    )
 
                 case .offline:
                     return processed
@@ -208,10 +238,17 @@ final class SyncManager {
                         remove(row)
                         processed += 1
                         errors.append("Gave up syncing \(operation.summary) after \(Self.maxRetries) retries.")
+                        ErrorReporter.captureWarning(
+                            "Sync op dropped: max retries",
+                            context: dropContext(operation, row, outcome: "dropped_max_retries", status: nil)
+                        )
                     } else {
                         row.nextAttemptAt = backoffDate(retryCount: row.retryCount, id: row.id)
                         save()
-                        return processed
+                        // Skip (not abort): a backed-off op is filtered out by
+                        // `nextDueRow`, so the loop advances to the next due op
+                        // instead of stalling the whole queue behind this one.
+                        continue
                     }
                 }
             }
@@ -456,6 +493,59 @@ final class SyncManager {
 
     private func save() {
         try? context.save()
+    }
+
+    /// Structured context for a permanent-drop Sentry warning so a "changes won't
+    /// sync" report is unambiguous from telemetry alone (which op, how many
+    /// retries, the stable idempotency key, and why it was dropped).
+    private func dropContext(
+        _ operation: SyncOperation,
+        _ row: PendingSyncOperation,
+        outcome: String,
+        status: Int?
+    ) -> [String: Any] {
+        var context: [String: Any] = [
+            "sync.op": operation.typeName,
+            "sync.summary": operation.summary,
+            "sync.retry_count": row.retryCount,
+            "sync.idempotency_key": row.idempotencyKey,
+            "sync.outcome": outcome,
+        ]
+        if let status {
+            context["status_code"] = status
+        }
+        return context
+    }
+
+    /// After a drain leaves backed-off rows behind, schedule a single delayed
+    /// re-drain at the soonest `nextAttemptAt`. `scheduleDrain` otherwise only
+    /// fires on enqueue / connectivity-regained / foreground, none of which is
+    /// guaranteed while a backoff window elapses — so a transient failure would
+    /// leave `pendingCount > 0` until the user happens to trigger another drain.
+    private func scheduleRetryDrain() {
+        guard autoDrain else { return }
+        retryTask?.cancel()
+        let now = Date()
+        guard let soonest = queuedRows().map(\.nextAttemptAt).filter({ $0 > now }).min() else {
+            retryTask = nil
+            return
+        }
+        let delay = max(soonest.timeIntervalSinceNow, 0)
+        retryTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.scheduleDrain()
+        }
+    }
+
+    /// User-initiated retry from the pending-changes screen: clear all backoff so
+    /// every queued op is due immediately, then drain.
+    func retryNow() {
+        for row in queuedRows() {
+            row.nextAttemptAt = Date.distantPast
+        }
+        save()
+        scheduleDrain()
     }
 
     /// Test seam: resets `nextAttemptAt` on all queued rows so the next drain

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -706,6 +706,73 @@ enum L10n {
         )
     }
 
+    // MARK: - Pending changes (sync queue) screen
+
+    static var pendingChanges: String {
+        localized("pending_changes", en: "Pending changes", de: "Ausstehende Änderungen")
+    }
+
+    static var pendingChangesEmpty: String {
+        localized("pending_changes_empty", en: "Everything is synced", de: "Alles synchronisiert")
+    }
+
+    static var pendingChangesEmptyDetail: String {
+        localized(
+            "pending_changes_empty_detail",
+            en: "Changes you make offline appear here until they sync.",
+            de: "Offline vorgenommene Änderungen erscheinen hier, bis sie synchronisiert werden."
+        )
+    }
+
+    static var retryNow: String {
+        localized("retry_now", en: "Retry now", de: "Jetzt erneut versuchen")
+    }
+
+    static var syncWaiting: String {
+        localized("sync_waiting", en: "Waiting", de: "Wartet")
+    }
+
+    static func syncRetryStatus(_ count: Int, _ max: Int) -> String {
+        localized(
+            "sync_retry_status",
+            en: "Retry \(count)/\(max)",
+            de: "Versuch \(count)/\(max)"
+        )
+    }
+
+    /// Human-readable title for a queued sync operation, keyed by its stored
+    /// `typeName` (see `SyncOperation.typeName`).
+    static func pendingChangeTitle(forType type: String) -> String {
+        switch type {
+        case "create_food": localized("sync_create_food", en: "Added food", de: "Lebensmittel hinzugefügt")
+        case "update_food": localized("sync_update_food", en: "Edited food", de: "Lebensmittel bearbeitet")
+        case "delete_food": localized("sync_delete_food", en: "Deleted food", de: "Lebensmittel gelöscht")
+        case "toggle_favorite": localized("sync_toggle_favorite", en: "Changed favorite", de: "Favorit geändert")
+        case "create_entry": localized("sync_create_entry", en: "Logged food", de: "Mahlzeit protokolliert")
+        case "update_entry": localized("sync_update_entry", en: "Edited log entry", de: "Eintrag bearbeitet")
+        case "delete_entry": localized("sync_delete_entry", en: "Deleted log entry", de: "Eintrag gelöscht")
+        case "create_recipe": localized("sync_create_recipe", en: "Added recipe", de: "Rezept hinzugefügt")
+        case "update_recipe": localized("sync_update_recipe", en: "Edited recipe", de: "Rezept bearbeitet")
+        case "delete_recipe": localized("sync_delete_recipe", en: "Deleted recipe", de: "Rezept gelöscht")
+        case "set_goals": localized("sync_set_goals", en: "Updated goals", de: "Ziele aktualisiert")
+        case "create_weight": localized("sync_create_weight", en: "Added weight entry", de: "Gewichtseintrag hinzugefügt")
+        case "update_weight": localized("sync_update_weight", en: "Edited weight entry", de: "Gewichtseintrag bearbeitet")
+        case "delete_weight": localized("sync_delete_weight", en: "Deleted weight entry", de: "Gewichtseintrag gelöscht")
+        case "create_sleep": localized("sync_create_sleep", en: "Added sleep entry", de: "Schlafeintrag hinzugefügt")
+        case "update_sleep": localized("sync_update_sleep", en: "Edited sleep entry", de: "Schlafeintrag bearbeitet")
+        case "delete_sleep": localized("sync_delete_sleep", en: "Deleted sleep entry", de: "Schlafeintrag gelöscht")
+        case "create_supplement": localized("sync_create_supplement", en: "Added supplement", de: "Supplement hinzugefügt")
+        case "update_supplement": localized("sync_update_supplement", en: "Edited supplement", de: "Supplement bearbeitet")
+        case "delete_supplement": localized("sync_delete_supplement", en: "Deleted supplement", de: "Supplement gelöscht")
+        case "log_supplement": localized("sync_log_supplement", en: "Logged supplement", de: "Supplement protokolliert")
+        case "unlog_supplement": localized("sync_unlog_supplement", en: "Unlogged supplement", de: "Supplement-Protokoll entfernt")
+        case "set_day_properties": localized("sync_set_day_properties", en: "Updated fasting day", de: "Fastentag aktualisiert")
+        case "delete_day_properties": localized("sync_delete_day_properties", en: "Cleared fasting day", de: "Fastentag entfernt")
+        case "update_preferences": localized("sync_update_preferences", en: "Updated settings", de: "Einstellungen aktualisiert")
+        default: localized("sync_generic_change", en: "Pending change", de: "Ausstehende Änderung")
+        }
+    }
+
     static var account: String {
         localized("account", en: "Account", de: "Konto")
     }

--- a/mobile/iosApp/Bissbilanz/Views/PendingSyncView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/PendingSyncView.swift
@@ -1,0 +1,107 @@
+import SwiftData
+import SwiftUI
+
+/// Shows the offline sync queue — every local change still waiting to upload —
+/// with its kind, age and retry status, plus a manual retry. Reached from the
+/// "N changes waiting to sync" row in Settings.
+///
+/// Reads the queue with `@Query` (the same `mainContext` the `SyncManager`
+/// writes to), so it updates live as ops drain or new ones are enqueued.
+struct PendingSyncView: View {
+    @Environment(SyncManager.self) private var syncManager
+    @Query(sort: \PendingSyncOperation.seq) private var pending: [PendingSyncOperation]
+
+    var body: some View {
+        List {
+            if pending.isEmpty {
+                ContentUnavailableView {
+                    Label(L10n.pendingChangesEmpty, systemImage: "checkmark.circle")
+                } description: {
+                    Text(L10n.pendingChangesEmptyDetail)
+                }
+            } else {
+                if let syncError = syncManager.errors.last {
+                    Section {
+                        HStack(alignment: .firstTextBaseline) {
+                            Image(systemName: "exclamationmark.triangle")
+                                .foregroundStyle(.red)
+                            Text(syncError)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+                Section {
+                    ForEach(pending) { row in
+                        PendingSyncRow(row: row)
+                    }
+                }
+            }
+        }
+        .navigationTitle(L10n.pendingChanges)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if !pending.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        syncManager.retryNow()
+                    } label: {
+                        Label(L10n.retryNow, systemImage: "arrow.clockwise")
+                    }
+                    .disabled(syncManager.isSyncing)
+                }
+            }
+        }
+    }
+}
+
+private struct PendingSyncRow: View {
+    let row: PendingSyncOperation
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: Self.icon(for: row.type))
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L10n.pendingChangeTitle(forType: row.type))
+                    .font(.subheadline)
+                Text(row.createdAt, format: .relative(presentation: .named))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            statusLabel
+        }
+    }
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        if row.retryCount > 0 {
+            Text(L10n.syncRetryStatus(row.retryCount, SyncManager.maxRetries))
+                .font(.caption2)
+                .foregroundStyle(.orange)
+        } else {
+            Text(L10n.syncWaiting)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// SF Symbol per queued op kind (matches the entity, not the action).
+    static func icon(for type: String) -> String {
+        switch type {
+        case "create_food", "update_food", "delete_food", "toggle_favorite": "fork.knife"
+        case "create_entry", "update_entry", "delete_entry": "plus.circle"
+        case "create_recipe", "update_recipe", "delete_recipe": "book"
+        case "set_goals": "target"
+        case "create_weight", "update_weight", "delete_weight": "scalemass"
+        case "create_sleep", "update_sleep", "delete_sleep": "bed.double"
+        case "create_supplement", "update_supplement", "delete_supplement",
+             "log_supplement", "unlog_supplement": "pills"
+        case "set_day_properties", "delete_day_properties": "calendar"
+        case "update_preferences": "gearshape"
+        default: "arrow.triangle.2.circlepath"
+        }
+    }
+}

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -256,12 +256,16 @@ struct SettingsView: View {
                             }
                         }
                         if syncManager.pendingCount > 0 {
-                            HStack {
-                                Image(systemName: "arrow.triangle.2.circlepath")
-                                    .foregroundStyle(.secondary)
-                                Text(L10n.pendingSyncCount(syncManager.pendingCount))
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+                            NavigationLink {
+                                PendingSyncView()
+                            } label: {
+                                HStack {
+                                    Image(systemName: "arrow.triangle.2.circlepath")
+                                        .foregroundStyle(.secondary)
+                                    Text(L10n.pendingSyncCount(syncManager.pendingCount))
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                         }
                         if let syncError = syncManager.errors.last {

--- a/mobile/iosApp/BissbilanzTests/BissbilanzAPITests.swift
+++ b/mobile/iosApp/BissbilanzTests/BissbilanzAPITests.swift
@@ -57,7 +57,7 @@ struct APIErrorTests {
         } catch {
             decodingError = error
         }
-        let apiError = APIError.decodingError(decodingError)
+        let apiError = APIError.decodingError(decodingError, statusCode: 200, body: "{}")
         #expect(apiError.errorDescription?.starts(with: "Failed to parse response") == true)
     }
 }
@@ -241,15 +241,16 @@ struct APIRequestBuildingTests {
         #expect(json["bodyFatChangeRatio"] as? Double == 0.7)
     }
 
-    @Test("DayProperties set uses snake_case keys")
+    @Test("DayProperties set encodes camelCase with date in body")
     func dayPropertiesSetEncoding() throws {
-        let props = DayPropertiesSet(isFastingDay: true)
+        let props = DayPropertiesSet(date: "2026-06-28", isFastingDay: true)
 
         let data = try JSONEncoder().encode(props)
-        let jsonStr = try #require(String(data: data, encoding: .utf8))
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
-        #expect(jsonStr.contains("is_fasting_day"))
-        #expect(!jsonStr.contains("isFastingDay"))
+        #expect(json["date"] as? String == "2026-06-28")
+        #expect(json["isFastingDay"] as? Bool == true)
+        #expect(json["is_fasting_day"] == nil)
     }
 }
 
@@ -507,14 +508,15 @@ struct APIResponseDecodingTests {
         #expect(response.checklist[1].takenAt == nil)
     }
 
-    @Test("DayProperties response decodes snake_case keys")
+    @Test("DayProperties response decodes the server's camelCase wire shape")
     func dayPropertiesDecoding() throws {
+        // Matches the actual server body: { properties: { date, isFastingDay } }
+        // — camelCase, no userId.
         let json = """
         {
             "properties": {
                 "date": "2026-03-12",
-                "user_id": "u1",
-                "is_fasting_day": true
+                "isFastingDay": true
             }
         }
         """.data(using: .utf8)!
@@ -756,9 +758,7 @@ struct APIResponseDecodingTests {
             showWeightWidget: true,
             showMealBreakdownWidget: false,
             showTopFoodsWidget: true,
-            showSummaryWidget: true,
-            showDayLogWidget: false,
-            showStreakWidget: true,
+            showSleepWidget: false,
             widgetOrder: ["chart", "weight", "supplements"],
             startPage: "dashboard",
             favoriteTapAction: "instant",
@@ -772,10 +772,48 @@ struct APIResponseDecodingTests {
         let decoded = try JSONDecoder().decode(Preferences.self, from: data)
 
         #expect(decoded.showFavoritesWidget == false)
-        #expect(decoded.showDayLogWidget == false)
+        #expect(decoded.showSleepWidget == false)
         #expect(decoded.widgetOrder == ["chart", "weight", "supplements"])
         #expect(decoded.visibleNutrients == ["sugar", "sodium"])
         #expect(decoded.locale == "de")
+    }
+
+    @Test("Preferences decode from the server's wrapped wire shape")
+    func preferencesEnvelopeDecoding() throws {
+        // The server wraps preferences as { preferences: {...} } and the inner
+        // object carries showSleepWidget (NOT showSummary/DayLog/Streak) plus keys
+        // iOS doesn't model (mealOrder, favoriteMealTimeframes, updatedAt) — the
+        // decode must succeed via the envelope and ignore the extras.
+        let json = """
+        {
+            "preferences": {
+                "showChartWidget": true,
+                "showFavoritesWidget": false,
+                "showSupplementsWidget": true,
+                "showWeightWidget": true,
+                "showMealBreakdownWidget": true,
+                "showTopFoodsWidget": true,
+                "showSleepWidget": false,
+                "widgetOrder": ["chart", "sleep"],
+                "mealOrder": ["Breakfast", "Lunch"],
+                "startPage": "dashboard",
+                "favoriteTapAction": "instant",
+                "favoriteMealAssignmentMode": "time_based",
+                "visibleNutrients": ["sugar"],
+                "locale": null,
+                "timeZone": "Europe/Zurich",
+                "updatedAt": "2026-06-28T00:00:00.000Z",
+                "favoriteMealTimeframes": []
+            }
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(PreferencesResponse.self, from: json)
+        #expect(response.preferences.showFavoritesWidget == false)
+        #expect(response.preferences.showSleepWidget == false)
+        #expect(response.preferences.widgetOrder == ["chart", "sleep"])
+        #expect(response.preferences.locale == nil)
+        #expect(response.preferences.timeZone == "Europe/Zurich")
     }
 
     @Test("Daily stats response decodes")

--- a/mobile/iosApp/BissbilanzTests/LocalModelTests.swift
+++ b/mobile/iosApp/BissbilanzTests/LocalModelTests.swift
@@ -245,9 +245,7 @@ struct LocalModelTests {
             showWeightWidget: false,
             showMealBreakdownWidget: true,
             showTopFoodsWidget: false,
-            showSummaryWidget: true,
-            showDayLogWidget: true,
-            showStreakWidget: false,
+            showSleepWidget: true,
             widgetOrder: ["chart", "weight"],
             startPage: "dashboard",
             favoriteTapAction: "instant",
@@ -270,7 +268,7 @@ struct LocalModelTests {
 
     @Test("LocalDayProperties round-trips")
     func localDayPropertiesRoundTrip() throws {
-        let properties = DayProperties(date: "2026-06-01", userId: "u1", isFastingDay: true)
+        let properties = DayProperties(date: "2026-06-01", isFastingDay: true)
 
         let local = LocalDayProperties(properties: properties)
         let restored = try #require(local.toDayProperties())
@@ -278,7 +276,6 @@ struct LocalModelTests {
         #expect(local.date == "2026-06-01")
         #expect(local.isFastingDay == true)
         #expect(restored.date == "2026-06-01")
-        #expect(restored.userId == "u1")
         #expect(restored.isFastingDay == true)
     }
 }

--- a/mobile/iosApp/BissbilanzTests/LocalStoreTests.swift
+++ b/mobile/iosApp/BissbilanzTests/LocalStoreTests.swift
@@ -74,6 +74,6 @@ struct LocalStoreTests {
     }
 
     private func dayProperties(_ date: String, fasting: Bool) -> DayProperties {
-        DayProperties(date: date, userId: "", isFastingDay: fasting)
+        DayProperties(date: date, isFastingDay: fasting)
     }
 }

--- a/mobile/iosApp/BissbilanzTests/MigratorTests.swift
+++ b/mobile/iosApp/BissbilanzTests/MigratorTests.swift
@@ -44,7 +44,6 @@ struct MigratorTests {
         harness.context.insert(LocalPreferences(preferences: .defaults))
         harness.context.insert(LocalDayProperties(properties: DayProperties(
             date: "2026-06-01",
-            userId: "",
             isFastingDay: true
         )))
         try harness.context.save()
@@ -77,16 +76,16 @@ struct MigratorTests {
         """)
         harness.stub("POST", "/api/goals", json: "{}")
         harness.stub("PATCH", "/api/preferences", json: """
-        {
+        {"preferences": {
             "showChartWidget": true, "showFavoritesWidget": true, "showSupplementsWidget": true,
             "showWeightWidget": true, "showMealBreakdownWidget": true, "showTopFoodsWidget": true,
-            "showSummaryWidget": true, "showDayLogWidget": true, "showStreakWidget": true,
+            "showSleepWidget": true,
             "widgetOrder": [], "startPage": "dashboard", "favoriteTapAction": "instant",
             "favoriteMealAssignmentMode": "time_based", "visibleNutrients": []
-        }
+        }}
         """)
-        harness.stub("POST", "/api/day-properties/2026-06-01", json: """
-        {"properties": {"date": "2026-06-01", "user_id": "u1", "is_fasting_day": true}}
+        harness.stub("PUT", "/api/day-properties", json: """
+        {"properties": {"date": "2026-06-01", "isFastingDay": true}}
         """)
     }
 
@@ -158,7 +157,7 @@ struct MigratorTests {
             "POST /api/supplements/s-server/log",
             "POST /api/goals",
             "PATCH /api/preferences",
-            "POST /api/day-properties/2026-06-01",
+            "PUT /api/day-properties",
         ])
 
         // The uploaded recipe and entry already carried the server food id.

--- a/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
+++ b/mobile/iosApp/BissbilanzTests/RepositoryTests.swift
@@ -143,7 +143,7 @@ struct RepositoryTests {
     func dayPropertiesWriteLocallyAndQueue() async throws {
         let harness = try RepositoryHarness()
         let repo = harness.entryRepository
-        harness.stub("POST", "/api/day-properties/2026-06-01", status: 500, json: #"{"error": "boom"}"#)
+        harness.stub("PUT", "/api/day-properties", status: 500, json: #"{"error": "boom"}"#)
 
         try await repo.setDayProperties(date: "2026-06-01", isFastingDay: true)
         await harness.syncManager.drainPendingQueue()

--- a/mobile/iosApp/BissbilanzTests/SyncManagerTests.swift
+++ b/mobile/iosApp/BissbilanzTests/SyncManagerTests.swift
@@ -61,7 +61,7 @@ struct SyncManagerTests {
         #expect(harness.recordedRequests.contains("POST /api/goals"))
     }
 
-    @Test("5xx responses stop draining and back off, then drop after the retry cap")
+    @Test("5xx backs off the failing op without blocking ops behind it, then drops after the retry cap")
     func serverErrorRetriesThenDrops() async throws {
         let harness = try RepositoryHarness()
         harness.stub("POST", "/api/foods", status: 500, json: #"{"error": "boom"}"#)
@@ -70,22 +70,28 @@ struct SyncManagerTests {
         harness.syncManager.enqueue(.createFood(body: makeFoodCreate(), localId: LocalStore.makeTempId()))
         harness.syncManager.enqueue(.setGoals(body: .defaults))
 
-        // Attempts 1 through (maxRetries - 1): each fails with 5xx, sets nextAttemptAt
-        // in the future, and stops the drain. We reset backoff after each attempt so the
-        // next drain picks the item up immediately (avoiding real time delays in tests).
-        for expectedRetry in 1 ..< SyncManager.maxRetries {
+        // First drain: createFood fails 5xx and is backed off (retryCount 1) but no
+        // longer stalls the queue — setGoals behind it is processed and removed.
+        await harness.syncManager.drainPendingQueue()
+        #expect(harness.syncManager.queuedRows().count == 1)
+        #expect(harness.syncManager.queuedRows().first?.type == "create_food")
+        #expect(harness.syncManager.queuedRows().first?.retryCount == 1)
+        #expect(harness.recordedRequests.contains("POST /api/goals"))
+        harness.syncManager.resetBackoffForTesting()
+
+        // Attempts 2..<maxRetries: createFood keeps failing and re-backing off. Reset
+        // the backoff after each so the next drain picks it up without a real delay.
+        for expectedRetry in 2 ..< SyncManager.maxRetries {
             await harness.syncManager.drainPendingQueue()
-            #expect(harness.syncManager.queuedRows().count == 2)
+            #expect(harness.syncManager.queuedRows().count == 1)
             #expect(harness.syncManager.queuedRows().first?.retryCount == expectedRetry)
-            #expect(!harness.recordedRequests.contains("POST /api/goals"))
             harness.syncManager.resetBackoffForTesting()
         }
 
-        // Final attempt hits the cap: the op is dropped and draining continues.
+        // Final attempt hits the cap: the op is dropped with a give-up error.
         await harness.syncManager.drainPendingQueue()
         #expect(harness.syncManager.queuedRows().isEmpty)
         #expect(harness.syncManager.errors.contains { $0.contains("Gave up syncing create food") })
-        #expect(harness.recordedRequests.contains("POST /api/goals"))
     }
 
     @Test("A final 401 stops draining and keeps the queue")
@@ -263,6 +269,24 @@ struct SyncManagerTests {
         #expect(drained == 2)
         #expect(harness.syncManager.queuedRows().isEmpty)
         #expect(harness.recordedRequests == ["POST /api/goals", "DELETE /api/foods/f1"])
+    }
+
+    @Test("A queued delete drains successfully against a real 204 empty body")
+    func deleteAgainstEmpty204Succeeds() async throws {
+        let harness = try RepositoryHarness()
+        // A genuine No Content response: status 204 with a 0-byte body — exactly
+        // what every server DELETE returns. Regression guard for the decode that
+        // used to throw "Unexpected end of file" and dead-letter every delete
+        // (the prior tests stubbed `{}`, a 2-byte body that decodes fine and hid
+        // the bug).
+        harness.stub("DELETE", "/api/foods/f1", status: 204, json: "")
+
+        harness.syncManager.enqueue(.deleteFood(id: "f1"))
+        let drained = await harness.syncManager.drainPendingQueue()
+
+        #expect(drained == 1)
+        #expect(harness.syncManager.queuedRows().isEmpty)
+        #expect(harness.syncManager.errors.isEmpty)
     }
 
     @Test("Deleting a temp row while its create is in flight does not resurrect it")


### PR DESCRIPTION
## Why

The iOS app showed "N changes waiting to sync" that never cleared. The offline sync queue (`SyncManager`) treats any **decode failure** of an API response as `retryable`, retries 5×, then **drops the operation** — so a deterministic decode mismatch silently loses the change. Production Sentry shows these as the top, *escalating* iOS errors on the current 1.22.0 build.

A contract audit (iOS hand-written models vs. server response schemas, every sync domain) confirmed the cause and surfaced several more mismatches. An adversarial review of the diff then validated compile-/logic-/contract-correctness (iOS only compiles in macOS CI).

## Root causes fixed

| # | Symptom | Cause | Fix |
|---|---------|-------|-----|
| 1 | **All deletions never sync** | Every server `DELETE` returns `204` (empty body); the client decoded `EmptyResponse` from 0 bytes → `dataCorrupted`. | `decodeResponse` treats `204`/empty as success. One change covers every delete/unlog op. |
| 2 | **Preference changes never sync** | `GET`/`PATCH /api/preferences` return `{ preferences: {...} }`; client decoded a bare `Preferences` → `keyNotFound 'showChartWidget'`. | Add `PreferencesResponse` envelope. |
| 3 | **(same)** | `Preferences` required `showSummary/DayLog/StreakWidget` (not server fields), lacked `showSleepWidget`; the `.strict()` update schema also rejected them → login migration `400`. | Align the model to the server contract. |
| 4 | **Fasting-day changes silently lost** | `setDayProperties` used a non-existent `POST /api/day-properties/{date}` → `404`. | `PUT /api/day-properties` with `{ date, isFastingDay }`; `?date=` for get/delete; camelCase model. |
| 5 | **Recipes never pulled to a device** | `Recipe.userId` is absent from list responses → whole list decode threw. | `Recipe.userId` optional. |

## Telemetry (so this can't go undiagnosed again)

- `APIError.decodingError` now carries the real **status code + response body** (was hardcoded `200`, no body).
- The sync drain emits **breadcrumbs** (drain start, per-op with `sync.op`/`sync.retry_count`) and a **`captureWarning` on every permanent-drop branch** — max-retries, client-error, validation-conflict, deleted-elsewhere, and the previously-invisible **undecodable-payload** drop.
- Drain robustness: a backed-off op no longer aborts the whole pass (`continue`, not `return`), and a delayed re-drain self-heals transient failures instead of leaving `pendingCount` stuck.

## Detail view

New **Pending Changes** screen (tap the "N changes waiting to sync" row in Settings): a live list of each queued op with its kind icon, human-readable localized title (en/de for all 24 op types), age, and retry status, plus a **Retry now** action.

## Tests

Updated for the new model/API shapes; added regression tests for the **204 empty-body delete** (prior tests stubbed `{}`, which hid the bug) and the **wrapped preferences** response.

## Validation

iOS builds only in macOS CI — pushed over SSH so the iOS build + CodeQL jobs run. All changes are iOS-only (no server/OpenAPI changes).

## Known follow-ups (not in this PR)

- Deleting a recipe **with logged entries** returns `409 has_entries` (no `X-Sync-Conflict` header) → dropped with a generic error and the recipe reappears on next refresh. Needs a force-delete UX decision.
- `getWeightStats` calls a non-existent `/api/weight/stats` (always 404, `try?`-guarded → silent nil).
- `ServingUnit` decodes server strings into a closed enum with no unknown fallback (latent; not breaking today).
