### PR TITLE
chore(ios): add privacy manifests for UserDefaults required-reason API

### DIFF
--- a/mobile/iosApp/Bissbilanz/PrivacyInfo.xcprivacy
+++ b/mobile/iosApp/Bissbilanz/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<!-- Required-reason API declarations. The app reads/writes its own
+	     UserDefaults (CA92.1, e.g. selected_tabs, app_locale, HealthKit sync
+	     toggles) and the shared App Group defaults (1C8F.1, the widget snapshot
+	     in group.com.bissbilanz). The static KMP shared framework's
+	     NSUserDefaults usage (IosPlainStorage) links into this binary, so it is
+	     covered here too. No FileTimestamp/SystemBootTime/DiskSpace/
+	     ActiveKeyboards APIs are used. -->
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/mobile/iosApp/BissbilanzWatch/PrivacyInfo.xcprivacy
+++ b/mobile/iosApp/BissbilanzWatch/PrivacyInfo.xcprivacy
@@ -8,9 +8,9 @@
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
-	<!-- The watch app reads/writes the watch App Group defaults (1C8F.1) via
-	     BissbilanzWatchShared/WatchStore.swift (group.com.bissbilanz.watch).
-	     CA92.1 covers access to the app's own defaults. -->
+	<!-- The watch app only reads/writes the watch App Group defaults (1C8F.1)
+	     via BissbilanzWatchShared/WatchStore.swift (group.com.bissbilanz.watch);
+	     it never touches UserDefaults.standard. -->
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
@@ -18,7 +18,6 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
 				<string>1C8F.1</string>
 			</array>
 		</dict>

--- a/mobile/iosApp/BissbilanzWatch/PrivacyInfo.xcprivacy
+++ b/mobile/iosApp/BissbilanzWatch/PrivacyInfo.xcprivacy
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<!-- The watch app reads/writes the watch App Group defaults (1C8F.1) via
+	     BissbilanzWatchShared/WatchStore.swift (group.com.bissbilanz.watch).
+	     CA92.1 covers access to the app's own defaults. -->
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/mobile/iosApp/BissbilanzWatchWidgets/PrivacyInfo.xcprivacy
+++ b/mobile/iosApp/BissbilanzWatchWidgets/PrivacyInfo.xcprivacy
@@ -8,10 +8,9 @@
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
-	<!-- The watch complication widget reads the watch App Group defaults
+	<!-- The watch complication widget only reads the watch App Group defaults
 	     (1C8F.1) via BissbilanzWatchShared/WatchStore.swift
-	     (group.com.bissbilanz.watch). CA92.1 covers the extension's own
-	     defaults. -->
+	     (group.com.bissbilanz.watch); it never touches UserDefaults.standard. -->
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
@@ -19,7 +18,6 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
 				<string>1C8F.1</string>
 			</array>
 		</dict>

--- a/mobile/iosApp/BissbilanzWatchWidgets/PrivacyInfo.xcprivacy
+++ b/mobile/iosApp/BissbilanzWatchWidgets/PrivacyInfo.xcprivacy
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<!-- The watch complication widget reads the watch App Group defaults
+	     (1C8F.1) via BissbilanzWatchShared/WatchStore.swift
+	     (group.com.bissbilanz.watch). CA92.1 covers the extension's own
+	     defaults. -->
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/mobile/iosApp/BissbilanzWidgets/PrivacyInfo.xcprivacy
+++ b/mobile/iosApp/BissbilanzWidgets/PrivacyInfo.xcprivacy
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<!-- The widget extension reads the shared App Group defaults (1C8F.1) for
+	     the WidgetSnapshot in group.com.bissbilanz (Shared/WidgetSnapshot.swift).
+	     CA92.1 covers any access to the extension's own defaults. -->
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/mobile/iosApp/BissbilanzWidgets/PrivacyInfo.xcprivacy
+++ b/mobile/iosApp/BissbilanzWidgets/PrivacyInfo.xcprivacy
@@ -8,9 +8,9 @@
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
-	<!-- The widget extension reads the shared App Group defaults (1C8F.1) for
-	     the WidgetSnapshot in group.com.bissbilanz (Shared/WidgetSnapshot.swift).
-	     CA92.1 covers any access to the extension's own defaults. -->
+	<!-- The widget extension only reads the shared App Group defaults (1C8F.1)
+	     for the WidgetSnapshot in group.com.bissbilanz
+	     (Shared/WidgetSnapshot.swift); it never touches UserDefaults.standard. -->
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
@@ -18,7 +18,6 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
 				<string>1C8F.1</string>
 			</array>
 		</dict>


### PR DESCRIPTION
## What

Adds a `PrivacyInfo.xcprivacy` manifest to each of the four distributable iOS/watchOS bundles:

- `Bissbilanz/` (iOS app)
- `BissbilanzWidgets/` (iOS widget extension)
- `BissbilanzWatch/` (watchOS app)
- `BissbilanzWatchWidgets/` (watch complication widget)

## Why

App Store Connect emits an **ITMS-91053 "Missing API declaration"** warning email on every upload because the app accesses the `NSPrivacyAccessedAPICategoryUserDefaults` required-reason API without declaring a reason. It's a warning today (not an upload block), but it's the only repo-side gap flagged while auditing external-TestFlight readiness, and Apple is tightening these into hard errors over time.

## Details

- **Only `UserDefaults` is used** — scanned all Swift sources + the KMP shared framework. No file-timestamp / system-boot-time / disk-space / active-keyboards APIs are present.
- Reason codes:
  - `CA92.1` — the app's own `UserDefaults.standard` (e.g. `selected_tabs`, `app_locale`, HealthKit sync toggles).
  - `1C8F.1` — the shared App Group defaults (`group.com.bissbilanz` widget snapshot in `Shared/WidgetSnapshot.swift`; `group.com.bissbilanz.watch` in `BissbilanzWatchShared/WatchStore.swift`).
- The static KMP `shared.framework` (`IosPlainStorage` → `NSUserDefaults`) links into the host binary, so the app manifest covers it. Sentry 9.17.1 ships its own manifest.
- `NSPrivacyTracking = false`, no tracking domains, no collected data types.
- **One manifest per target folder, intentionally not in shared `Shared/`** — XcodeGen auto-adds each `.xcprivacy` to its target's *Copy Bundle Resources*; a single copy in the shared dir (compiled into all four targets) would trigger "Multiple commands produce PrivacyInfo.xcprivacy".

## Verification

- All four files validate as well-formed property lists.
- Full verification (XcodeGen bundling each manifest at its bundle root) runs on CI via `mobile-ios.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)