### PR TITLE
fix(android): barcode teardown crash + suppress expected-auth Sentry noise

### DIFF
--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/BissbilanzApplication.kt
@@ -18,6 +18,7 @@ import com.bissbilanz.android.ui.viewmodels.WeightViewModel
 import com.bissbilanz.android.widget.FavoritesWidgetWorker
 import com.bissbilanz.android.widget.MacroWidget
 import com.bissbilanz.android.widget.QuickWeightWidget
+import com.bissbilanz.api.UnauthorizedException
 import com.bissbilanz.auth.AuthManager
 import com.bissbilanz.auth.SecureStorage
 import com.bissbilanz.cache.DatabaseDriverFactory
@@ -35,6 +36,7 @@ import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import java.io.IOException
 
 class BissbilanzApplication : Application() {
     override fun onCreate() {
@@ -48,6 +50,10 @@ class BissbilanzApplication : Application() {
                 options.isAttachViewHierarchy = true
                 options.tracesSampleRate = 0.2
                 options.environment = if (BuildConfig.DEBUG) "development" else "production"
+                options.setBeforeSend { event, _ ->
+                    val throwable = event.throwable
+                    if (throwable != null && throwable.isAuthOrTransient()) null else event
+                }
             }
         }
 
@@ -130,4 +136,14 @@ class BissbilanzApplication : Application() {
         } catch (_: ClassNotFoundException) {
             false
         }
+}
+
+private fun Throwable.isAuthOrTransient(): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is UnauthorizedException) return true
+        if (current is IOException) return true
+        current = current.cause
+    }
+    return false
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/BarcodeScannerScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/BarcodeScannerScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavController
 import com.bissbilanz.ErrorReporter
@@ -58,6 +59,7 @@ import org.koin.compose.koinInject
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import androidx.compose.ui.geometry.Size as ComposeSize
 
 enum class ScanState { SCANNING, SEARCHING, NOT_FOUND }
@@ -305,9 +307,15 @@ private fun CameraPreview(
                     ).build(),
             )
         }
+    val disposed = remember { AtomicBoolean(false) }
+    val cameraProviderRef = remember { arrayOfNulls<ProcessCameraProvider>(1) }
+    val imageAnalysisRef = remember { arrayOfNulls<ImageAnalysis>(1) }
 
     DisposableEffect(Unit) {
         onDispose {
+            disposed.set(true)
+            imageAnalysisRef[0]?.clearAnalyzer()
+            cameraProviderRef[0]?.unbindAll()
             analyzerExecutor.shutdown()
             scanner.close()
         }
@@ -319,7 +327,12 @@ private fun CameraPreview(
             val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
 
             cameraProviderFuture.addListener({
+                if (disposed.get() || lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+                    return@addListener
+                }
                 val cameraProvider = cameraProviderFuture.get()
+                cameraProviderRef[0] = cameraProvider
+
                 val preview =
                     Preview.Builder().build().also {
                         it.surfaceProvider = previewView.surfaceProvider
@@ -341,9 +354,10 @@ private fun CameraPreview(
                         .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                         .setResolutionSelector(resolutionSelector)
                         .build()
+                imageAnalysisRef[0] = imageAnalysis
 
                 imageAnalysis.setAnalyzer(analyzerExecutor) { imageProxy ->
-                    if (!isScanning()) {
+                    if (disposed.get() || !isScanning()) {
                         imageProxy.close()
                         return@setAnalyzer
                     }
@@ -357,13 +371,19 @@ private fun CameraPreview(
                             mediaImage,
                             imageProxy.imageInfo.rotationDegrees,
                         )
-                    scanner
-                        .process(image)
-                        .addOnSuccessListener(analyzerExecutor) { barcodes ->
-                            barcodes.firstOrNull()?.rawValue?.let { value ->
-                                mainHandler.post { onBarcodeScanned(value) }
-                            }
-                        }.addOnCompleteListener(analyzerExecutor) { imageProxy.close() }
+                    try {
+                        scanner
+                            .process(image)
+                            .addOnSuccessListener(analyzerExecutor) { barcodes ->
+                                if (!disposed.get()) {
+                                    barcodes.firstOrNull()?.rawValue?.let { value ->
+                                        mainHandler.post { onBarcodeScanned(value) }
+                                    }
+                                }
+                            }.addOnCompleteListener(analyzerExecutor) { imageProxy.close() }
+                    } catch (_: Exception) {
+                        imageProxy.close()
+                    }
                 }
 
                 cameraProvider.unbindAll()


### PR DESCRIPTION
## Sentry issues closed

- **BISSBILANZ-25** — NPE in `BarcodeScannerScreen` CameraX/ML Kit teardown race (fix 5)
- **BISSBILANZ-1D**, **BISSBILANZ-1B**, **BISSBILANZ-1C** — `UnauthorizedException` / transient `IOException` leaking to Sentry via SDK auto-capture (fix 6)

## Fix 5 — BarcodeScanner teardown NPE

Root cause: `onDispose` only shut down the executor and closed the ML Kit scanner but never unbound CameraX. An in-flight `ImageAnalysis` frame delivered on the executor thread could call `scanner.process()` after `scanner.close()`.

Changes in `BarcodeScannerScreen.kt`:
- Added `AtomicBoolean disposed` flag and remembered refs for `ProcessCameraProvider` and `ImageAnalysis`.
- Analyzer entry point now guards `if (disposed.get() || !isScanning())` before touching the scanner.
- `scanner.process()` wrapped in try/catch so any late frame after close cannot propagate.
- Camera provider future listener bails before binding when `disposed.get()` or lifecycle is `DESTROYED`.
- `onDispose` rewritten: `disposed.set(true)` → `imageAnalysis.clearAnalyzer()` → `cameraProvider.unbindAll()` → `executor.shutdown()` → `scanner.close()`.

## Fix 6 — Suppress expected-auth / transient Sentry noise

Root cause: `UnauthorizedException` ("Not authenticated") thrown from the Ktor bearer `refreshTokens` block on expired sessions leaks to Sentry via the SDK's uncaught-exception auto-capture, which `SentryErrorReporter.captureException` does not intercept.

Changes in `BissbilanzApplication.kt`:
- Added `options.setBeforeSend` that drops any event whose throwable root-cause chain contains an `UnauthorizedException` or `IOException`.
- Logic mirrors the existing `SentryErrorReporter.isTransientNetworkFailure()` + `UnauthorizedException` guard exactly.
- Private `Throwable.isAuthOrTransient()` extension walks the full cause chain (same pattern as `SentryErrorReporter`).

## Verification

- **ktlint**: `./gradlew :shared:ktlintCheck :androidApp:ktlintCheck` — BUILD SUCCESSFUL
- **assembleDebug**: `./gradlew androidApp:assembleDebug` — BUILD SUCCESSFUL (warnings are pre-existing, no errors)
- On-device verification still needed to confirm the teardown race is no longer reproducible under rapid back-navigation during an active scan.