### PR TITLE
fix(ios): resolve TestFlight beta feedback (6 items)

### DIFF
--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -55,7 +55,7 @@ final class BissbilanzAPI {
     // MARK: - Foods
 
     func searchFoods(query: String) async throws -> [Food] {
-        let response: FoodsResponse = try await get("/api/foods", params: ["search": query])
+        let response: FoodsResponse = try await get("/api/foods", params: ["q": query])
         return response.foods
     }
 

--- a/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
@@ -21,13 +21,9 @@ struct FoodEditSheet: View {
     @State private var isSaving = false
     @State private var errorMessage: String?
 
-    // Populated by the nutrition-label scanner and only shown once a scan has
-    // happened, so the manual create flow stays unchanged.
-    @State private var sugar = ""
-    @State private var saturatedFat = ""
-    @State private var salt = ""
-    @State private var sodium = ""
-    @State private var didScanLabel = false
+    // Additional nutrients keyed by their FoodCreate field name. The user can
+    // add any supported nutrient here; the label scanner also fills a few.
+    @State private var additionalValues: [String: String] = [:]
     @State private var showLabelScanner = false
 
     let initialBarcode: String?
@@ -81,12 +77,26 @@ struct FoodEditSheet: View {
                     macroField(L10n.fiber, text: $fiber, unit: "g")
                 }
 
-                if didScanLabel {
-                    Section(L10n.additionalNutrients) {
-                        macroField(L10n.sugar, text: $sugar, unit: "g")
-                        macroField(L10n.saturatedFat, text: $saturatedFat, unit: "g")
-                        macroField(L10n.salt, text: $salt, unit: "g")
-                        macroField(L10n.sodium, text: $sodium, unit: "mg")
+                Section(L10n.additionalNutrients) {
+                    ForEach(addedNutrients) { spec in
+                        additionalNutrientField(spec)
+                    }
+                    .onDelete(perform: removeAdditionalNutrients)
+
+                    Menu {
+                        ForEach(Self.nutrientCatalog) { category in
+                            if category.nutrients.contains(where: { additionalValues[$0.key] == nil }) {
+                                Menu(category.title) {
+                                    ForEach(category.nutrients) { spec in
+                                        if additionalValues[spec.key] == nil {
+                                            Button(spec.label) { additionalValues[spec.key] = "" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } label: {
+                        Label(L10n.addNutrient, systemImage: "plus.circle")
                     }
                 }
 
@@ -140,6 +150,25 @@ struct FoodEditSheet: View {
         }
     }
 
+    /// Catalog rows the user has added a value row for, in catalog order.
+    private var addedNutrients: [AdditionalNutrientSpec] {
+        Self.nutrientCatalog.flatMap(\.nutrients).filter { additionalValues[$0.key] != nil }
+    }
+
+    private func additionalNutrientField(_ spec: AdditionalNutrientSpec) -> some View {
+        macroField(spec.label, text: Binding(
+            get: { additionalValues[spec.key] ?? "" },
+            set: { additionalValues[spec.key] = $0 }
+        ), unit: spec.unit)
+    }
+
+    private func removeAdditionalNutrients(at offsets: IndexSet) {
+        let specs = addedNutrients
+        for index in offsets {
+            additionalValues[specs[index].key] = nil
+        }
+    }
+
     private func prefill() {
         if let bc = initialBarcode, existingFood == nil {
             barcode = bc
@@ -156,6 +185,15 @@ struct FoodEditSheet: View {
         fat = "\(food.fat)"
         fiber = "\(food.fiber)"
         isFavorite = food.isFavorite
+
+        // Surface any extended nutrients already stored on the food so they can
+        // be reviewed and edited alongside newly added ones.
+        let encoded = (try? JSONPatch.dictionary(of: food)) ?? [:]
+        for spec in Self.nutrientCatalog.flatMap(\.nutrients) {
+            if let number = encoded[spec.key] as? NSNumber {
+                additionalValues[spec.key] = Self.numberString(number.doubleValue)
+            }
+        }
     }
 
     /// Prefills the editable fields from an OCR'd nutrition label. Values are
@@ -169,15 +207,10 @@ struct FoodEditSheet: View {
         if let value = parsed.carbs { carbs = Self.numberString(value) }
         if let value = parsed.fat { fat = Self.numberString(value) }
         if let value = parsed.fiber { fiber = Self.numberString(value) }
-        if let value = parsed.sugar { sugar = Self.numberString(value) }
-        if let value = parsed.saturatedFat { saturatedFat = Self.numberString(value) }
-        if let value = parsed.salt { salt = Self.numberString(value) }
-        if let value = parsed.sodium { sodium = Self.numberString(value) }
-        didScanLabel = true
-    }
-
-    private func parsedValue(_ text: String) -> Double? {
-        text.isEmpty ? nil : Double.parseUserInput(text)
+        if let value = parsed.sugar { additionalValues["sugar"] = Self.numberString(value) }
+        if let value = parsed.saturatedFat { additionalValues["saturatedFat"] = Self.numberString(value) }
+        if let value = parsed.salt { additionalValues["salt"] = Self.numberString(value) }
+        if let value = parsed.sodium { additionalValues["sodium"] = Self.numberString(value) }
     }
 
     /// Renders a parsed value without a trailing ".0".
@@ -189,7 +222,7 @@ struct FoodEditSheet: View {
         isSaving = true
         errorMessage = nil
 
-        let foodData = FoodCreate(
+        var foodData = FoodCreate(
             name: name,
             brand: brand.isEmpty ? nil : brand,
             servingSize: Double.parseUserInput(servingSize) ?? 100,
@@ -199,13 +232,21 @@ struct FoodEditSheet: View {
             carbs: Double.parseUserInput(carbs) ?? 0,
             fat: Double.parseUserInput(fat) ?? 0,
             fiber: Double.parseUserInput(fiber) ?? 0,
-            saturatedFat: parsedValue(saturatedFat),
-            sugar: parsedValue(sugar),
-            sodium: parsedValue(sodium),
-            salt: parsedValue(salt),
             barcode: barcode.isEmpty ? nil : barcode,
             isFavorite: isFavorite
         )
+
+        // Overlay the additional nutrient values onto the matching FoodCreate
+        // fields by their JSON key. Blank or unparseable rows are skipped.
+        var patch: [String: Any] = [:]
+        for (key, text) in additionalValues {
+            if let value = Double.parseUserInput(text) {
+                patch[key] = value
+            }
+        }
+        if !patch.isEmpty {
+            foodData = (try? JSONPatch.merged(FoodCreate.self, base: foodData, patch: patch)) ?? foodData
+        }
 
         do {
             let saved: Food = if let existing = existingFood {
@@ -220,4 +261,75 @@ struct FoodEditSheet: View {
         }
         isSaving = false
     }
+
+    // Supported extended nutrients, grouped for the "Add Nutrient" menu. Keys
+    // match the FoodCreate JSON fields; units mirror the food detail view.
+    private static let nutrientCatalog: [AdditionalNutrientCategory] = [
+        AdditionalNutrientCategory(title: "Fat Breakdown", nutrients: [
+            AdditionalNutrientSpec(key: "saturatedFat", label: "Saturated Fat", unit: "g"),
+            AdditionalNutrientSpec(key: "monounsaturatedFat", label: "Monounsaturated Fat", unit: "g"),
+            AdditionalNutrientSpec(key: "polyunsaturatedFat", label: "Polyunsaturated Fat", unit: "g"),
+            AdditionalNutrientSpec(key: "transFat", label: "Trans Fat", unit: "g"),
+            AdditionalNutrientSpec(key: "cholesterol", label: "Cholesterol", unit: "mg"),
+            AdditionalNutrientSpec(key: "omega3", label: "Omega-3", unit: "g"),
+            AdditionalNutrientSpec(key: "omega6", label: "Omega-6", unit: "g"),
+        ]),
+        AdditionalNutrientCategory(title: "Sugars & Carbs", nutrients: [
+            AdditionalNutrientSpec(key: "sugar", label: "Sugar", unit: "g"),
+            AdditionalNutrientSpec(key: "addedSugars", label: "Added Sugars", unit: "g"),
+            AdditionalNutrientSpec(key: "sugarAlcohols", label: "Sugar Alcohols", unit: "g"),
+            AdditionalNutrientSpec(key: "starch", label: "Starch", unit: "g"),
+        ]),
+        AdditionalNutrientCategory(title: "Minerals", nutrients: [
+            AdditionalNutrientSpec(key: "sodium", label: "Sodium", unit: "mg"),
+            AdditionalNutrientSpec(key: "potassium", label: "Potassium", unit: "mg"),
+            AdditionalNutrientSpec(key: "calcium", label: "Calcium", unit: "mg"),
+            AdditionalNutrientSpec(key: "iron", label: "Iron", unit: "mg"),
+            AdditionalNutrientSpec(key: "magnesium", label: "Magnesium", unit: "mg"),
+            AdditionalNutrientSpec(key: "phosphorus", label: "Phosphorus", unit: "mg"),
+            AdditionalNutrientSpec(key: "zinc", label: "Zinc", unit: "mg"),
+            AdditionalNutrientSpec(key: "copper", label: "Copper", unit: "mg"),
+            AdditionalNutrientSpec(key: "manganese", label: "Manganese", unit: "mg"),
+            AdditionalNutrientSpec(key: "selenium", label: "Selenium", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "iodine", label: "Iodine", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "fluoride", label: "Fluoride", unit: "mg"),
+            AdditionalNutrientSpec(key: "chromium", label: "Chromium", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "molybdenum", label: "Molybdenum", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "chloride", label: "Chloride", unit: "mg"),
+        ]),
+        AdditionalNutrientCategory(title: "Vitamins", nutrients: [
+            AdditionalNutrientSpec(key: "vitaminA", label: "Vitamin A", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "vitaminC", label: "Vitamin C", unit: "mg"),
+            AdditionalNutrientSpec(key: "vitaminD", label: "Vitamin D", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "vitaminE", label: "Vitamin E", unit: "mg"),
+            AdditionalNutrientSpec(key: "vitaminK", label: "Vitamin K", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "vitaminB1", label: "Vitamin B1", unit: "mg"),
+            AdditionalNutrientSpec(key: "vitaminB2", label: "Vitamin B2", unit: "mg"),
+            AdditionalNutrientSpec(key: "vitaminB3", label: "Vitamin B3", unit: "mg"),
+            AdditionalNutrientSpec(key: "vitaminB5", label: "Vitamin B5", unit: "mg"),
+            AdditionalNutrientSpec(key: "vitaminB6", label: "Vitamin B6", unit: "mg"),
+            AdditionalNutrientSpec(key: "vitaminB7", label: "Vitamin B7", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "vitaminB9", label: "Vitamin B9", unit: "\u{00B5}g"),
+            AdditionalNutrientSpec(key: "vitaminB12", label: "Vitamin B12", unit: "\u{00B5}g"),
+        ]),
+        AdditionalNutrientCategory(title: "Other", nutrients: [
+            AdditionalNutrientSpec(key: "caffeine", label: "Caffeine", unit: "mg"),
+            AdditionalNutrientSpec(key: "alcohol", label: "Alcohol", unit: "g"),
+            AdditionalNutrientSpec(key: "water", label: "Water", unit: "g"),
+            AdditionalNutrientSpec(key: "salt", label: "Salt", unit: "g"),
+        ]),
+    ]
+}
+
+private struct AdditionalNutrientSpec: Identifiable {
+    let key: String
+    let label: String
+    let unit: String
+    var id: String { key }
+}
+
+private struct AdditionalNutrientCategory: Identifiable {
+    let title: String
+    let nutrients: [AdditionalNutrientSpec]
+    var id: String { title }
 }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -1006,7 +1006,11 @@ enum L10n {
     }
 
     static var additionalNutrients: String {
-        localized("additional_nutrients", en: "Additional (from label)", de: "Zusätzlich (vom Etikett)")
+        localized("additional_nutrients", en: "Additional Nutrients", de: "Weitere Nährstoffe")
+    }
+
+    static var addNutrient: String {
+        localized("add_nutrient", en: "Add Nutrient", de: "Nährstoff hinzufügen")
     }
 
     static var sugar: String {

--- a/mobile/iosApp/Bissbilanz/Views/BarcodeScannerView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/BarcodeScannerView.swift
@@ -16,6 +16,10 @@ struct BarcodeScannerView: View {
     @State private var notFound = false
     @State private var notFoundBarcode: String?
     @State private var showCreateFood = false
+    // Holds a freshly created food until the create sheet has fully dismissed,
+    // so its detail isn't presented mid-dismissal (which races into an empty
+    // sheet).
+    @State private var pendingCreatedFood: Food?
     @State private var cameraPermission: AVAuthorizationStatus = .notDetermined
     @State private var isTorchOn = false
 
@@ -126,11 +130,21 @@ struct BarcodeScannerView: View {
         .onChange(of: foundFood) { _, newValue in
             if newValue == nil { resetScanner() }
         }
-        .sheet(isPresented: $showCreateFood) {
+        .sheet(isPresented: $showCreateFood, onDismiss: {
+            // Chain to the new food's detail only after the create sheet has
+            // finished dismissing; presenting during the dismissal animation
+            // surfaces an empty sheet. A dismissal with nothing pending means
+            // the user cancelled — resume scanning.
+            if let created = pendingCreatedFood {
+                pendingCreatedFood = nil
+                foundFood = created
+            } else {
+                resetScanner()
+            }
+        }) {
             NavigationStack {
                 FoodEditSheet(barcode: notFoundBarcode) { food in
-                    foundFood = food
-                    showCreateFood = false
+                    pendingCreatedFood = food
                     scannedBarcode = nil
                     notFoundBarcode = nil
                 }

--- a/mobile/iosApp/Bissbilanz/Views/FoodDetailView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodDetailView.swift
@@ -26,6 +26,21 @@ struct FoodDetailView: View {
                 foodContent(food)
             }
         }
+        .safeAreaInset(edge: .bottom) {
+            if food != nil, !isLoading, error == nil {
+                Button {
+                    showLogSheet = true
+                } label: {
+                    Label(L10n.logFood, systemImage: "plus.circle.fill")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .padding(.horizontal)
+                .padding(.bottom, 8)
+            }
+        }
         .navigationTitle(food?.name ?? L10n.foods)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -43,12 +58,6 @@ struct FoodDetailView: View {
                     .accessibilityLabel(food.isFavorite ? L10n.removeFromFavorites : L10n.addToFavorites)
 
                     Menu {
-                        Button {
-                            showLogSheet = true
-                        } label: {
-                            Label(L10n.logFood, systemImage: "plus.circle")
-                        }
-
                         Button {
                             showEditSheet = true
                         } label: {
@@ -124,11 +133,11 @@ struct FoodDetailView: View {
             }
 
             Section(L10n.mainMacros) {
-                NutrientRow(label: L10n.calories, value: food.calories, unit: "kcal", color: MacroColors.calories)
-                NutrientRow(label: L10n.protein, value: food.protein, unit: "g", color: MacroColors.protein)
-                NutrientRow(label: L10n.carbs, value: food.carbs, unit: "g", color: MacroColors.carbs)
-                NutrientRow(label: L10n.fat, value: food.fat, unit: "g", color: MacroColors.fat)
-                NutrientRow(label: L10n.fiber, value: food.fiber, unit: "g", color: MacroColors.fiber)
+                NutrientRow(label: L10n.calories, value: food.calories, unit: "kcal")
+                NutrientRow(label: L10n.protein, value: food.protein, unit: "g")
+                NutrientRow(label: L10n.carbs, value: food.carbs, unit: "g")
+                NutrientRow(label: L10n.fat, value: food.fat, unit: "g")
+                NutrientRow(label: L10n.fiber, value: food.fiber, unit: "g")
             }
 
             NutrientSection(title: L10n.fatBreakdown, nutrients: food.fatBreakdownNutrients)

--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -292,13 +292,13 @@ struct LogFoodSheet: View {
                     }
                 }
 
-                Section(L10n.meal) {
+                Section {
                     Picker(L10n.meal, selection: $mealType) {
                         ForEach(mealTypes, id: \.self) { meal in
                             Text(L10n.mealName(meal)).tag(meal)
                         }
                     }
-                    .pickerStyle(.segmented)
+                    .pickerStyle(.menu)
                 }
 
                 Section(L10n.nutrition) {

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -282,6 +282,29 @@ struct SettingsView: View {
                         } label: {
                             Label(L10n.signOut, systemImage: "rectangle.portrait.and.arrow.right")
                         }
+                        // Anchor the confirmation to the sign-out button itself —
+                        // attached to the enclosing List it presents as a popover
+                        // pointing at an unrelated row.
+                        .confirmationDialog(
+                            L10n.signOut + "?",
+                            isPresented: $showLogoutConfirmation,
+                            titleVisibility: .visible
+                        ) {
+                            Button(L10n.signOut, role: .destructive) {
+                                // The local store and pending queue belong to the
+                                // signed-out account — wipe them so nothing leaks
+                                // into the next session (Local mode or another
+                                // account).
+                                migrator.wipeLocalData()
+                                authManager.logout()
+                                // Reset the mode so the next start shows the login
+                                // screen with the mode choice again.
+                                appModeManager.clear()
+                            }
+                            Button(L10n.cancel, role: .cancel) {}
+                        } message: {
+                            Text(L10n.signOutConfirmation)
+                        }
                     }
                 }
 
@@ -304,20 +327,6 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle(L10n.settings)
-            .confirmationDialog(L10n.signOut + "?", isPresented: $showLogoutConfirmation) {
-                Button(L10n.signOut, role: .destructive) {
-                    // The local store and pending queue belong to the
-                    // signed-out account — wipe them so nothing leaks into
-                    // the next session (Local mode or another account).
-                    migrator.wipeLocalData()
-                    authManager.logout()
-                    // Reset the mode so the next start shows the login screen
-                    // with the mode choice again.
-                    appModeManager.clear()
-                }
-            } message: {
-                Text(L10n.signOutConfirmation)
-            }
             .sheet(isPresented: $isEditingGoals) {
                 goalsEditor
             }


### PR DESCRIPTION
Addresses all six TestFlight screenshot-feedback submissions from the 1.22.1 beta. One commit per item.

## Fixes

1. **Search filter does nothing** — the iOS client sent the term as `?search=` but the server (`/api/foods`) reads `?q=`, so every query returned the full food list alphabetically. Now sends `q`, matching the Android client and OpenAPI spec. (`12605475`)

2. **Log Food hidden + colored macro labels** (barcode → food detail) — moved *Log Food* out of the top-right overflow menu into a prominent bottom-pinned CTA (`safeAreaInset`); the favorite star and edit/delete stay in the toolbar. Main macro labels now render in the default primary color to match the other nutrient sections. (`f17ddf0a`)

3. **Meal type in a nested card** — the log-food meal picker was a segmented control inside its own form-section card. Replaced with a menu (dropdown) picker in an untitled section — a single labeled dropdown row. (`187ef3b0`)

4. **Empty bottom sheet after barcode → create → label** — creating a food from the "not found" flow set `foundFood` (presenting the detail sheet) while the create sheet was still dismissing, racing into an empty sheet. The new food is now stashed and promoted from the create sheet's `onDismiss`, after dismissal completes; cancelling resumes scanning. (`61f70930`)

5. **Can't add arbitrary nutrients on create** — the create/edit sheet only exposed sugar/saturated fat/salt/sodium, and only after a label scan. Replaced with an always-available **Additional Nutrients** section: an *Add Nutrient* menu (grouped by category) covering all supported extended nutrients (caffeine, vitamins, minerals, …), each editable with swipe-to-delete. Values are overlaid onto `FoodCreate` by JSON key via `JSONPatch.merged`; editing an existing food now surfaces its stored extended nutrients. (`d86103cb`)

   _Note:_ truly free-form nutrients (e.g. taurine, ginseng extract) aren't in the schema, so this exposes the full supported catalog rather than free-text entries.

6. **Sign-out confirmation mis-anchored** — the confirmation `confirmationDialog` was attached to the Settings `List`, so on iOS 26 it presented as a popover pointing at an unrelated row. Moved onto the Sign Out button (with an explicit Cancel), matching the delete-confirmation pattern. (`7a1dd959`)

## Notes
- iOS-only; no schema/API changes. The server-side search param (`q`) was already correct — only the iOS client was wrong.
- Built and reviewed on Linux (no Swift toolchain locally); relies on the macOS CI build to compile-check.