### PR TITLE
fix(ios): TestFlight feedback — insights, weight chart, sleep, serving size

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5211,7 +5211,7 @@
 						"maximum": 1440
 					},
 					"quality": {
-						"type": "integer",
+						"type": "number",
 						"minimum": 1,
 						"maximum": 10
 					},
@@ -5278,7 +5278,7 @@
 						"maximum": 1440
 					},
 					"quality": {
-						"type": "integer",
+						"type": "number",
 						"minimum": 1,
 						"maximum": 10
 					},
@@ -8734,9 +8734,7 @@
 						"maximum": 9007199254740991
 					},
 					"quality": {
-						"type": "integer",
-						"minimum": -9007199254740991,
-						"maximum": 9007199254740991
+						"type": "number"
 					},
 					"bedtime": {
 						"anyOf": [

--- a/drizzle/0040_eminent_nuke.sql
+++ b/drizzle/0040_eminent_nuke.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sleep_entries" ALTER COLUMN "quality" SET DATA TYPE real;

--- a/drizzle/meta/0040_snapshot.json
+++ b/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,3657 @@
+{
+  "id": "eb9c1d34-58d5-4450-b6ec-dc3220adfd90",
+  "prevId": "5fa4567e-09dc-42f4-9201-9822e54a9794",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalog_access": {
+      "name": "catalog_access",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_access_user_id_users_id_fk": {
+          "name": "catalog_access_user_id_users_id_fk",
+          "tableFrom": "catalog_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "catalog_access_dataset_id_catalog_datasets_id_fk": {
+          "name": "catalog_access_dataset_id_catalog_datasets_id_fk",
+          "tableFrom": "catalog_access",
+          "tableTo": "catalog_datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "catalog_access_user_id_dataset_id_pk": {
+          "name": "catalog_access_user_id_dataset_id_pk",
+          "columns": [
+            "user_id",
+            "dataset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_datasets": {
+      "name": "catalog_datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "catalog_datasets_key_unique": {
+          "name": "catalog_datasets_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_foods": {
+      "name": "catalog_foods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "serving_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saturated_fat": {
+          "name": "saturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monounsaturated_fat": {
+          "name": "monounsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polyunsaturated_fat": {
+          "name": "polyunsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trans_fat": {
+          "name": "trans_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cholesterol": {
+          "name": "cholesterol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega3": {
+          "name": "omega3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega6": {
+          "name": "omega6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_sugars": {
+          "name": "added_sugars",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar_alcohols": {
+          "name": "sugar_alcohols",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starch": {
+          "name": "starch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sodium": {
+          "name": "sodium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "potassium": {
+          "name": "potassium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calcium": {
+          "name": "calcium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iron": {
+          "name": "iron",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magnesium": {
+          "name": "magnesium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phosphorus": {
+          "name": "phosphorus",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zinc": {
+          "name": "zinc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copper": {
+          "name": "copper",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manganese": {
+          "name": "manganese",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selenium": {
+          "name": "selenium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iodine": {
+          "name": "iodine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fluoride": {
+          "name": "fluoride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chromium": {
+          "name": "chromium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "molybdenum": {
+          "name": "molybdenum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chloride": {
+          "name": "chloride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_a": {
+          "name": "vitamin_a",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_c": {
+          "name": "vitamin_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_d": {
+          "name": "vitamin_d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_e": {
+          "name": "vitamin_e",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_k": {
+          "name": "vitamin_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b1": {
+          "name": "vitamin_b1",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b2": {
+          "name": "vitamin_b2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b3": {
+          "name": "vitamin_b3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b5": {
+          "name": "vitamin_b5",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b6": {
+          "name": "vitamin_b6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b7": {
+          "name": "vitamin_b7",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b9": {
+          "name": "vitamin_b9",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b12": {
+          "name": "vitamin_b12",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caffeine": {
+          "name": "caffeine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alcohol": {
+          "name": "alcohol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "water": {
+          "name": "water",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nutri_score": {
+          "name": "nutri_score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nova_group": {
+          "name": "nova_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additives": {
+          "name": "additives",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingredients_text": {
+          "name": "ingredients_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawled_at": {
+          "name": "crawled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_catalog_foods_dataset": {
+          "name": "idx_catalog_foods_dataset",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_catalog_foods_dataset_barcode": {
+          "name": "idx_catalog_foods_dataset_barcode",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_foods_dataset_id_catalog_datasets_id_fk": {
+          "name": "catalog_foods_dataset_id_catalog_datasets_id_fk",
+          "tableFrom": "catalog_foods",
+          "tableTo": "catalog_datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_foods_serving_positive": {
+          "name": "catalog_foods_serving_positive",
+          "value": "\"catalog_foods\".\"serving_size\" > 0"
+        },
+        "catalog_foods_nutrition_nonnegative": {
+          "name": "catalog_foods_nutrition_nonnegative",
+          "value": "\"catalog_foods\".\"calories\" >= 0 AND \"catalog_foods\".\"protein\" >= 0 AND \"catalog_foods\".\"carbs\" >= 0 AND \"catalog_foods\".\"fat\" >= 0 AND \"catalog_foods\".\"fiber\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_meal_types": {
+      "name": "custom_meal_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_meal_types_user_id": {
+          "name": "idx_custom_meal_types_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_meal_types_user_id_users_id_fk": {
+          "name": "custom_meal_types_user_id_users_id_fk",
+          "tableFrom": "custom_meal_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.day_properties": {
+      "name": "day_properties",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_fasting_day": {
+          "name": "is_fasting_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "day_properties_user_id_users_id_fk": {
+          "name": "day_properties_user_id_users_id_fk",
+          "tableFrom": "day_properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "day_properties_user_id_date_pk": {
+          "name": "day_properties_user_id_date_pk",
+          "columns": [
+            "user_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorite_meal_timeframes": {
+      "name": "favorite_meal_timeframes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_meal_type_id": {
+          "name": "custom_meal_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_favorite_meal_timeframes_user_id": {
+          "name": "idx_favorite_meal_timeframes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_favorite_meal_timeframes_custom_meal_type_id": {
+          "name": "idx_favorite_meal_timeframes_custom_meal_type_id",
+          "columns": [
+            {
+              "expression": "custom_meal_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorite_meal_timeframes_user_id_users_id_fk": {
+          "name": "favorite_meal_timeframes_user_id_users_id_fk",
+          "tableFrom": "favorite_meal_timeframes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorite_meal_timeframes_custom_meal_type_id_custom_meal_types_id_fk": {
+          "name": "favorite_meal_timeframes_custom_meal_type_id_custom_meal_types_id_fk",
+          "tableFrom": "favorite_meal_timeframes",
+          "tableTo": "custom_meal_types",
+          "columnsFrom": [
+            "custom_meal_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorite_meal_timeframes_minute_bounds": {
+          "name": "favorite_meal_timeframes_minute_bounds",
+          "value": "\"favorite_meal_timeframes\".\"start_minute\" >= 0 AND \"favorite_meal_timeframes\".\"start_minute\" <= 1439 AND \"favorite_meal_timeframes\".\"end_minute\" >= 1 AND \"favorite_meal_timeframes\".\"end_minute\" <= 1439"
+        },
+        "favorite_meal_timeframes_valid_range": {
+          "name": "favorite_meal_timeframes_valid_range",
+          "value": "\"favorite_meal_timeframes\".\"start_minute\" < \"favorite_meal_timeframes\".\"end_minute\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.food_entries": {
+      "name": "food_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplement_id": {
+          "name": "supplement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meal_type": {
+          "name": "meal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_name": {
+          "name": "quick_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_calories": {
+          "name": "quick_calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_protein": {
+          "name": "quick_protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_carbs": {
+          "name": "quick_carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_fat": {
+          "name": "quick_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quick_fiber": {
+          "name": "quick_fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eaten_at": {
+          "name": "eaten_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_food_entries_user_date": {
+          "name": "idx_food_entries_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_food_id": {
+          "name": "idx_food_entries_food_id",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_recipe_id": {
+          "name": "idx_food_entries_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_supplement_id": {
+          "name": "idx_food_entries_supplement_id",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_user_supplement_date": {
+          "name": "idx_food_entries_user_supplement_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_supplement_day_food_unique": {
+          "name": "idx_food_entries_supplement_day_food_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "supplement_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_food_entries_created_at": {
+          "name": "idx_food_entries_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "food_entries_user_id_users_id_fk": {
+          "name": "food_entries_user_id_users_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "food_entries_food_id_foods_id_fk": {
+          "name": "food_entries_food_id_foods_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "food_entries_recipe_id_recipes_id_fk": {
+          "name": "food_entries_recipe_id_recipes_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "food_entries_supplement_id_supplements_id_fk": {
+          "name": "food_entries_supplement_id_supplements_id_fk",
+          "tableFrom": "food_entries",
+          "tableTo": "supplements",
+          "columnsFrom": [
+            "supplement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "food_entries_servings_positive": {
+          "name": "food_entries_servings_positive",
+          "value": "\"food_entries\".\"servings\" > 0"
+        },
+        "food_entries_has_source": {
+          "name": "food_entries_has_source",
+          "value": "\"food_entries\".\"food_id\" IS NOT NULL OR \"food_entries\".\"recipe_id\" IS NOT NULL OR \"food_entries\".\"quick_calories\" IS NOT NULL"
+        },
+        "food_entries_meal_type_length": {
+          "name": "food_entries_meal_type_length",
+          "value": "length(\"food_entries\".\"meal_type\") > 0 AND length(\"food_entries\".\"meal_type\") <= 50"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.foods": {
+      "name": "foods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "food_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'food'"
+        },
+        "serving_size": {
+          "name": "serving_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "serving_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein": {
+          "name": "protein",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fat": {
+          "name": "fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiber": {
+          "name": "fiber",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saturated_fat": {
+          "name": "saturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monounsaturated_fat": {
+          "name": "monounsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polyunsaturated_fat": {
+          "name": "polyunsaturated_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trans_fat": {
+          "name": "trans_fat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cholesterol": {
+          "name": "cholesterol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega3": {
+          "name": "omega3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omega6": {
+          "name": "omega6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar": {
+          "name": "sugar",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_sugars": {
+          "name": "added_sugars",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar_alcohols": {
+          "name": "sugar_alcohols",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starch": {
+          "name": "starch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sodium": {
+          "name": "sodium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "potassium": {
+          "name": "potassium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calcium": {
+          "name": "calcium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iron": {
+          "name": "iron",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magnesium": {
+          "name": "magnesium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phosphorus": {
+          "name": "phosphorus",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zinc": {
+          "name": "zinc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copper": {
+          "name": "copper",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manganese": {
+          "name": "manganese",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selenium": {
+          "name": "selenium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iodine": {
+          "name": "iodine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fluoride": {
+          "name": "fluoride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chromium": {
+          "name": "chromium",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "molybdenum": {
+          "name": "molybdenum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chloride": {
+          "name": "chloride",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_a": {
+          "name": "vitamin_a",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_c": {
+          "name": "vitamin_c",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_d": {
+          "name": "vitamin_d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_e": {
+          "name": "vitamin_e",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_k": {
+          "name": "vitamin_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b1": {
+          "name": "vitamin_b1",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b2": {
+          "name": "vitamin_b2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b3": {
+          "name": "vitamin_b3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b5": {
+          "name": "vitamin_b5",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b6": {
+          "name": "vitamin_b6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b7": {
+          "name": "vitamin_b7",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b9": {
+          "name": "vitamin_b9",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vitamin_b12": {
+          "name": "vitamin_b12",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caffeine": {
+          "name": "caffeine",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alcohol": {
+          "name": "alcohol",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "water": {
+          "name": "water",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nutri_score": {
+          "name": "nutri_score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nova_group": {
+          "name": "nova_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additives": {
+          "name": "additives",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingredients_text": {
+          "name": "ingredients_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_foods_user_id": {
+          "name": "idx_foods_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_barcode": {
+          "name": "idx_foods_barcode",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "barcode IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_user_name": {
+          "name": "idx_foods_user_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_foods_user_kind": {
+          "name": "idx_foods_user_kind",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foods_user_id_users_id_fk": {
+          "name": "foods_user_id_users_id_fk",
+          "tableFrom": "foods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "foods_serving_positive": {
+          "name": "foods_serving_positive",
+          "value": "\"foods\".\"serving_size\" > 0"
+        },
+        "foods_nutrition_nonnegative": {
+          "name": "foods_nutrition_nonnegative",
+          "value": "\"foods\".\"calories\" >= 0 AND \"foods\".\"protein\" >= 0 AND \"foods\".\"carbs\" >= 0 AND \"foods\".\"fat\" >= 0 AND \"foods\".\"fiber\" >= 0"
+        },
+        "foods_fat_breakdown_nonneg": {
+          "name": "foods_fat_breakdown_nonneg",
+          "value": "(\"foods\".\"saturated_fat\" IS NULL OR \"foods\".\"saturated_fat\" >= 0) AND (\"foods\".\"monounsaturated_fat\" IS NULL OR \"foods\".\"monounsaturated_fat\" >= 0) AND (\"foods\".\"polyunsaturated_fat\" IS NULL OR \"foods\".\"polyunsaturated_fat\" >= 0) AND (\"foods\".\"trans_fat\" IS NULL OR \"foods\".\"trans_fat\" >= 0) AND (\"foods\".\"cholesterol\" IS NULL OR \"foods\".\"cholesterol\" >= 0) AND (\"foods\".\"omega3\" IS NULL OR \"foods\".\"omega3\" >= 0) AND (\"foods\".\"omega6\" IS NULL OR \"foods\".\"omega6\" >= 0)"
+        },
+        "foods_sugar_carb_nonneg": {
+          "name": "foods_sugar_carb_nonneg",
+          "value": "(\"foods\".\"sugar\" IS NULL OR \"foods\".\"sugar\" >= 0) AND (\"foods\".\"added_sugars\" IS NULL OR \"foods\".\"added_sugars\" >= 0) AND (\"foods\".\"sugar_alcohols\" IS NULL OR \"foods\".\"sugar_alcohols\" >= 0) AND (\"foods\".\"starch\" IS NULL OR \"foods\".\"starch\" >= 0)"
+        },
+        "foods_minerals_nonneg": {
+          "name": "foods_minerals_nonneg",
+          "value": "(\"foods\".\"sodium\" IS NULL OR \"foods\".\"sodium\" >= 0) AND (\"foods\".\"potassium\" IS NULL OR \"foods\".\"potassium\" >= 0) AND (\"foods\".\"calcium\" IS NULL OR \"foods\".\"calcium\" >= 0) AND (\"foods\".\"iron\" IS NULL OR \"foods\".\"iron\" >= 0) AND (\"foods\".\"magnesium\" IS NULL OR \"foods\".\"magnesium\" >= 0) AND (\"foods\".\"phosphorus\" IS NULL OR \"foods\".\"phosphorus\" >= 0) AND (\"foods\".\"zinc\" IS NULL OR \"foods\".\"zinc\" >= 0) AND (\"foods\".\"copper\" IS NULL OR \"foods\".\"copper\" >= 0) AND (\"foods\".\"manganese\" IS NULL OR \"foods\".\"manganese\" >= 0) AND (\"foods\".\"selenium\" IS NULL OR \"foods\".\"selenium\" >= 0) AND (\"foods\".\"iodine\" IS NULL OR \"foods\".\"iodine\" >= 0) AND (\"foods\".\"fluoride\" IS NULL OR \"foods\".\"fluoride\" >= 0) AND (\"foods\".\"chromium\" IS NULL OR \"foods\".\"chromium\" >= 0) AND (\"foods\".\"molybdenum\" IS NULL OR \"foods\".\"molybdenum\" >= 0) AND (\"foods\".\"chloride\" IS NULL OR \"foods\".\"chloride\" >= 0)"
+        },
+        "foods_vitamins_nonneg": {
+          "name": "foods_vitamins_nonneg",
+          "value": "(\"foods\".\"vitamin_a\" IS NULL OR \"foods\".\"vitamin_a\" >= 0) AND (\"foods\".\"vitamin_c\" IS NULL OR \"foods\".\"vitamin_c\" >= 0) AND (\"foods\".\"vitamin_d\" IS NULL OR \"foods\".\"vitamin_d\" >= 0) AND (\"foods\".\"vitamin_e\" IS NULL OR \"foods\".\"vitamin_e\" >= 0) AND (\"foods\".\"vitamin_k\" IS NULL OR \"foods\".\"vitamin_k\" >= 0) AND (\"foods\".\"vitamin_b1\" IS NULL OR \"foods\".\"vitamin_b1\" >= 0) AND (\"foods\".\"vitamin_b2\" IS NULL OR \"foods\".\"vitamin_b2\" >= 0) AND (\"foods\".\"vitamin_b3\" IS NULL OR \"foods\".\"vitamin_b3\" >= 0) AND (\"foods\".\"vitamin_b5\" IS NULL OR \"foods\".\"vitamin_b5\" >= 0) AND (\"foods\".\"vitamin_b6\" IS NULL OR \"foods\".\"vitamin_b6\" >= 0) AND (\"foods\".\"vitamin_b7\" IS NULL OR \"foods\".\"vitamin_b7\" >= 0) AND (\"foods\".\"vitamin_b9\" IS NULL OR \"foods\".\"vitamin_b9\" >= 0) AND (\"foods\".\"vitamin_b12\" IS NULL OR \"foods\".\"vitamin_b12\" >= 0)"
+        },
+        "foods_other_nutrients_nonneg": {
+          "name": "foods_other_nutrients_nonneg",
+          "value": "(\"foods\".\"caffeine\" IS NULL OR \"foods\".\"caffeine\" >= 0) AND (\"foods\".\"alcohol\" IS NULL OR \"foods\".\"alcohol\" >= 0) AND (\"foods\".\"water\" IS NULL OR \"foods\".\"water\" >= 0) AND (\"foods\".\"salt\" IS NULL OR \"foods\".\"salt\" >= 0)"
+        },
+        "foods_nutri_score_valid": {
+          "name": "foods_nutri_score_valid",
+          "value": "\"foods\".\"nutri_score\" IS NULL OR \"foods\".\"nutri_score\" IN ('a', 'b', 'c', 'd', 'e')"
+        },
+        "foods_nova_group_valid": {
+          "name": "foods_nova_group_valid",
+          "value": "\"foods\".\"nova_group\" IS NULL OR (\"foods\".\"nova_group\" >= 1 AND \"foods\".\"nova_group\" <= 4)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_idempotency_keys_created_at": {
+          "name": "idx_idempotency_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_user_id_users_id_fk": {
+          "name": "idempotency_keys_user_id_users_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_user_id_key_pk": {
+          "name": "idempotency_keys_user_id_key_pk",
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_codes_client_id": {
+          "name": "idx_oauth_codes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_codes_expires_at": {
+          "name": "idx_oauth_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_codes_method_check": {
+          "name": "oauth_codes_method_check",
+          "value": "code_challenge_method = 'S256'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorizations": {
+      "name": "oauth_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_authorizations_user_id": {
+          "name": "idx_oauth_authorizations_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_authorizations_client_id": {
+          "name": "idx_oauth_authorizations_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_authorizations_user_client": {
+          "name": "idx_oauth_authorizations_user_client",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorizations_user_id_users_id_fk": {
+          "name": "oauth_authorizations_user_id_users_id_fk",
+          "tableFrom": "oauth_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorizations_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorizations_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorizations",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_redirect_uris": {
+          "name": "allowed_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_user_id": {
+          "name": "idx_oauth_clients_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['mcp:access']::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_tokens_client_id": {
+          "name": "idx_oauth_tokens_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_user_id": {
+          "name": "idx_oauth_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_expires_at": {
+          "name": "idx_oauth_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_access_token_hash": {
+          "name": "idx_oauth_tokens_access_token_hash",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_tokens_refresh_token_hash": {
+          "name": "idx_oauth_tokens_refresh_token_hash",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_tokens_user_id_users_id_fk": {
+          "name": "oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_ingredients": {
+      "name": "recipe_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serving_unit": {
+          "name": "serving_unit",
+          "type": "serving_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_recipe_ingredients_recipe_id": {
+          "name": "idx_recipe_ingredients_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_ingredients_food_id": {
+          "name": "idx_recipe_ingredients_food_id",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_ingredients_recipe_id_recipes_id_fk": {
+          "name": "recipe_ingredients_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_ingredients_food_id_foods_id_fk": {
+          "name": "recipe_ingredients_food_id_foods_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recipe_ingredients_quantity_positive": {
+          "name": "recipe_ingredients_quantity_positive",
+          "value": "\"recipe_ingredients\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_servings": {
+          "name": "total_servings",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_recipes_user_id": {
+          "name": "idx_recipes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_created_at": {
+          "name": "idx_recipes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_user_id_users_id_fk": {
+          "name": "recipes_user_id_users_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recipes_servings_positive": {
+          "name": "recipes_servings_positive",
+          "value": "\"recipes\".\"total_servings\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sleep_entries": {
+      "name": "sleep_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bedtime": {
+          "name": "bedtime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wake_time": {
+          "name": "wake_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wake_ups": {
+          "name": "wake_ups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sleep_latency_minutes": {
+          "name": "sleep_latency_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deep_sleep_minutes": {
+          "name": "deep_sleep_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "light_sleep_minutes": {
+          "name": "light_sleep_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rem_sleep_minutes": {
+          "name": "rem_sleep_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sleep_entries_user_date": {
+          "name": "idx_sleep_entries_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sleep_entries_user_id_users_id_fk": {
+          "name": "sleep_entries_user_id_users_id_fk",
+          "tableFrom": "sleep_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sleep_entries_user_date_unique": {
+          "name": "sleep_entries_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "entry_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sleep_quality_range": {
+          "name": "sleep_quality_range",
+          "value": "\"sleep_entries\".\"quality\" >= 1 AND \"sleep_entries\".\"quality\" <= 10"
+        },
+        "sleep_duration_range": {
+          "name": "sleep_duration_range",
+          "value": "\"sleep_entries\".\"duration_minutes\" > 0 AND \"sleep_entries\".\"duration_minutes\" <= 1440"
+        },
+        "sleep_wakeups_valid": {
+          "name": "sleep_wakeups_valid",
+          "value": "\"sleep_entries\".\"wake_ups\" IS NULL OR \"sleep_entries\".\"wake_ups\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplement_ingredients": {
+      "name": "supplement_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "supplement_id": {
+          "name": "supplement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_supplement_ingredients_supplement_id": {
+          "name": "idx_supplement_ingredients_supplement_id",
+          "columns": [
+            {
+              "expression": "supplement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplement_ingredients_food_id": {
+          "name": "idx_supplement_ingredients_food_id",
+          "columns": [
+            {
+              "expression": "food_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplement_ingredients_supplement_id_supplements_id_fk": {
+          "name": "supplement_ingredients_supplement_id_supplements_id_fk",
+          "tableFrom": "supplement_ingredients",
+          "tableTo": "supplements",
+          "columnsFrom": [
+            "supplement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "supplement_ingredients_food_id_foods_id_fk": {
+          "name": "supplement_ingredients_food_id_foods_id_fk",
+          "tableFrom": "supplement_ingredients",
+          "tableTo": "foods",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplement_ingredients_servings_positive": {
+          "name": "supplement_ingredients_servings_positive",
+          "value": "\"supplement_ingredients\".\"servings\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplements": {
+      "name": "supplements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "schedule_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_days": {
+          "name": "schedule_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_start_date": {
+          "name": "schedule_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supplements_user_id": {
+          "name": "idx_supplements_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplements_user_active": {
+          "name": "idx_supplements_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplements_user_id_users_id_fk": {
+          "name": "supplements_user_id_users_id_fk",
+          "tableFrom": "supplements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplements_schedule_days_required": {
+          "name": "supplements_schedule_days_required",
+          "value": "\"supplements\".\"schedule_type\" NOT IN ('weekly', 'specific_days') OR (\"supplements\".\"schedule_days\" IS NOT NULL AND array_length(\"supplements\".\"schedule_days\", 1) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_goals": {
+      "name": "user_goals",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "calorie_goal": {
+          "name": "calorie_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_goal": {
+          "name": "protein_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carb_goal": {
+          "name": "carb_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fat_goal": {
+          "name": "fat_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiber_goal": {
+          "name": "fiber_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sodium_goal": {
+          "name": "sodium_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sugar_goal": {
+          "name": "sugar_goal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_goals_user_id_users_id_fk": {
+          "name": "user_goals_user_id_users_id_fk",
+          "tableFrom": "user_goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_goals_positive": {
+          "name": "user_goals_positive",
+          "value": "\"user_goals\".\"calorie_goal\" > 0 AND \"user_goals\".\"protein_goal\" >= 0 AND \"user_goals\".\"carb_goal\" >= 0 AND \"user_goals\".\"fat_goal\" >= 0 AND \"user_goals\".\"fiber_goal\" >= 0"
+        },
+        "user_goals_optional_nonnegative": {
+          "name": "user_goals_optional_nonnegative",
+          "value": "(\"user_goals\".\"sodium_goal\" IS NULL OR \"user_goals\".\"sodium_goal\" >= 0) AND (\"user_goals\".\"sugar_goal\" IS NULL OR \"user_goals\".\"sugar_goal\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_chart_widget": {
+          "name": "show_chart_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_favorites_widget": {
+          "name": "show_favorites_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_supplements_widget": {
+          "name": "show_supplements_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_weight_widget": {
+          "name": "show_weight_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_meal_breakdown_widget": {
+          "name": "show_meal_breakdown_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_top_foods_widget": {
+          "name": "show_top_foods_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_sleep_widget": {
+          "name": "show_sleep_widget",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "widget_order": {
+          "name": "widget_order",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['chart', 'favorites', 'supplements', 'weight', 'daylog']::text[]"
+        },
+        "start_page": {
+          "name": "start_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dashboard'"
+        },
+        "favorite_tap_action": {
+          "name": "favorite_tap_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instant'"
+        },
+        "favorite_meal_assignment_mode": {
+          "name": "favorite_meal_assignment_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_based'"
+        },
+        "visible_nutrients": {
+          "name": "visible_nutrients",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['sodium', 'sugar', 'saturatedFat', 'cholesterol']::text[]"
+        },
+        "meal_order": {
+          "name": "meal_order",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['Breakfast', 'Lunch', 'Dinner', 'Snacks']::text[]"
+        },
+        "caloric_lag_days_override": {
+          "name": "caloric_lag_days_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_window_days": {
+          "name": "correlation_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "infomaniak_sub": {
+          "name": "infomaniak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_infomaniak_sub_unique": {
+          "name": "users_infomaniak_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "infomaniak_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_entries": {
+      "name": "weight_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_weight_entries_user_date": {
+          "name": "idx_weight_entries_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weight_entries_user_logged": {
+          "name": "idx_weight_entries_user_logged",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_user_id_users_id_fk": {
+          "name": "weight_entries_user_id_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "weight_entries_user_date_unique": {
+          "name": "weight_entries_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "entry_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "weight_entries_valid": {
+          "name": "weight_entries_valid",
+          "value": "\"weight_entries\".\"weight_kg\" > 0 AND \"weight_entries\".\"weight_kg\" <= 500"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.food_kind": {
+      "name": "food_kind",
+      "schema": "public",
+      "values": [
+        "food",
+        "supplement"
+      ]
+    },
+    "public.schedule_type": {
+      "name": "schedule_type",
+      "schema": "public",
+      "values": [
+        "daily",
+        "every_other_day",
+        "weekly",
+        "specific_days"
+      ]
+    },
+    "public.serving_unit": {
+      "name": "serving_unit",
+      "schema": "public",
+      "values": [
+        "g",
+        "kg",
+        "ml",
+        "l",
+        "oz",
+        "lb",
+        "fl_oz",
+        "cup",
+        "tbsp",
+        "tsp"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1782159646528,
       "tag": "0039_burly_martin_li",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1782760517924,
+      "tag": "0040_eminent_nuke",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/screens/InsightsScreen.kt
@@ -540,6 +540,12 @@ fun InsightsScreen() {
 
                             // Recent entries list (last 5)
                             sleepEntries.sortedByDescending { it.entryDate }.take(5).forEach { entry ->
+                                val qStr =
+                                    if (entry.quality % 1.0 == 0.0) {
+                                        entry.quality.toInt().toString()
+                                    } else {
+                                        "%.1f".format(entry.quality)
+                                    }
                                 Row(
                                     modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -556,7 +562,7 @@ fun InsightsScreen() {
                                         Column {
                                             Text(entry.entryDate, style = MaterialTheme.typography.bodySmall)
                                             Text(
-                                                "%.1fh · Quality %d/10".format(entry.durationMinutes / 60.0, entry.quality),
+                                                "%.1fh · Quality $qStr/10".format(entry.durationMinutes / 60.0),
                                                 style = MaterialTheme.typography.labelSmall,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                             )
@@ -1005,7 +1011,7 @@ private fun GoalAdherenceCard(
 @Composable
 private fun SleepLogDialog(
     onDismiss: () -> Unit,
-    onSave: (duration: Int, quality: Int, date: String, notes: String) -> Unit,
+    onSave: (duration: Int, quality: Double, date: String, notes: String) -> Unit,
 ) {
     val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
     var durationHours by remember { mutableStateOf("8") }
@@ -1116,7 +1122,7 @@ private fun SleepLogDialog(
             TextButton(
                 onClick = {
                     if (!durationError) {
-                        onSave(totalMinutes, quality.roundToInt(), date, notes)
+                        onSave(totalMinutes, quality.roundToInt().toDouble(), date, notes)
                     }
                 },
                 enabled = !durationError,

--- a/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModel.kt
+++ b/mobile/androidApp/src/androidMain/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModel.kt
@@ -663,7 +663,7 @@ class InsightsViewModel(
                             .map { CaffeineEntry(it.date, it.eatenAt, it.caffeine!!) }
                     val sleepDataPoints =
                         sleepEntries.value.map {
-                            SleepDataPoint(it.entryDate, it.quality.toDouble(), it.durationMinutes.toDouble())
+                            SleepDataPoint(it.entryDate, it.quality, it.durationMinutes.toDouble())
                         }
                     _caffeineSleepResult.value = computeCaffeineSleepCutoff(caffeineEntries, sleepDataPoints, deviceTz)
                 }

--- a/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModelTest.kt
+++ b/mobile/androidApp/src/test/kotlin/com/bissbilanz/android/ui/viewmodels/InsightsViewModelTest.kt
@@ -143,7 +143,7 @@ class InsightsViewModelTest {
     @Test
     fun createSleepEntryShowsSuccessSnackbar() =
         runTest {
-            val entry = SleepCreate(durationMinutes = 480, quality = 8, entryDate = "2024-01-20")
+            val entry = SleepCreate(durationMinutes = 480, quality = 8.0, entryDate = "2024-01-20")
             coEvery { sleepRepo.createEntry(entry) } returns testSleepEntry("new")
 
             val viewModel = createViewModel()
@@ -155,7 +155,7 @@ class InsightsViewModelTest {
     @Test
     fun createSleepEntryShowsFailureSnackbarOnError() =
         runTest {
-            val entry = SleepCreate(durationMinutes = 480, quality = 8, entryDate = "2024-01-20")
+            val entry = SleepCreate(durationMinutes = 480, quality = 8.0, entryDate = "2024-01-20")
             coEvery { sleepRepo.createEntry(entry) } throws RuntimeException("Network error")
 
             val viewModel = createViewModel()
@@ -405,7 +405,7 @@ class InsightsViewModelTest {
                 userId = "user-1",
                 entryDate = "2024-01-20",
                 durationMinutes = 480,
-                quality = 8,
+                quality = 8.0,
                 bedtime = null,
                 wakeTime = null,
                 wakeUps = null,

--- a/mobile/iosApp/Bissbilanz/Models/Sleep.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Sleep.swift
@@ -5,7 +5,7 @@ struct SleepEntry: Codable, Identifiable {
     let userId: String
     let entryDate: String
     let durationMinutes: Int
-    let quality: Int
+    let quality: Double
     let bedtime: String?
     let wakeTime: String?
     let wakeUps: Int?
@@ -22,7 +22,7 @@ struct SleepEntry: Codable, Identifiable {
 
 struct SleepCreate: Codable {
     let durationMinutes: Int
-    let quality: Int
+    let quality: Double
     let entryDate: String
     var bedtime: String?
     var wakeTime: String?
@@ -32,7 +32,7 @@ struct SleepCreate: Codable {
 
 struct SleepUpdate: Codable {
     var durationMinutes: Int?
-    var quality: Int?
+    var quality: Double?
     var entryDate: String?
     var bedtime: String?
     var wakeTime: String?

--- a/mobile/iosApp/Bissbilanz/Persistence/LocalModels.swift
+++ b/mobile/iosApp/Bissbilanz/Persistence/LocalModels.swift
@@ -231,14 +231,16 @@ final class LocalSleepEntry {
         id = entry.id
         entryDate = entry.entryDate
         durationMinutes = entry.durationMinutes
-        quality = entry.quality
+        // Denormalized index column only — the source of truth (incl. any
+        // decimal quality) round-trips through `jsonData`.
+        quality = Int(entry.quality)
         jsonData = LocalStoreCoding.encode(entry)
     }
 
     func update(from entry: SleepEntry) {
         entryDate = entry.entryDate
         durationMinutes = entry.durationMinutes
-        quality = entry.quality
+        quality = Int(entry.quality)
         jsonData = LocalStoreCoding.encode(entry)
     }
 

--- a/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
@@ -57,16 +57,23 @@ struct FoodEditSheet: View {
                 }
 
                 Section(L10n.servingSize) {
-                    HStack {
-                        TextField("100", text: $servingSize)
-                            .keyboardType(.decimalPad)
-                            .frame(width: 80)
-                        Picker(L10n.unit, selection: $servingUnit) {
-                            ForEach(ServingUnit.allCases, id: \.self) { unit in
-                                Text(unit.displayName).tag(unit)
+                    // Split the row 60/40 so the amount gets most of the width
+                    // and the unit picker no longer crowds it out.
+                    GeometryReader { geo in
+                        HStack(spacing: 8) {
+                            TextField("100", text: $servingSize)
+                                .keyboardType(.decimalPad)
+                                .frame(width: max(geo.size.width * 0.6 - 4, 0), alignment: .leading)
+                            Picker(L10n.unit, selection: $servingUnit) {
+                                ForEach(ServingUnit.allCases, id: \.self) { unit in
+                                    Text(unit.displayName).tag(unit)
+                                }
                             }
+                            .labelsHidden()
+                            .frame(width: max(geo.size.width * 0.4 - 4, 0), alignment: .trailing)
                         }
                     }
+                    .frame(height: 34)
                 }
 
                 Section(L10n.mainMacros) {

--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -328,7 +328,9 @@ struct InsightsView: View {
                 .font(.subheadline)
                 .fontWeight(.bold)
                 .monospacedDigit()
-                .frame(width: 44, alignment: .trailing)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .frame(width: 52, alignment: .trailing)
         }
     }
 
@@ -358,30 +360,38 @@ struct InsightsView: View {
                     }
                 }
 
+                // Headers and day cells share one column set so the weekday
+                // labels line up exactly with the cells beneath them.
+                let gridColumns = Array(repeating: GridItem(.flexible(), spacing: 2), count: 7)
+
                 // Weekday headers
-                HStack(spacing: 0) {
+                LazyVGrid(columns: gridColumns, spacing: 2) {
                     ForEach(Array(L10n.weekdayHeaders.enumerated()), id: \.offset) { _, header in
                         Text(header)
                             .font(.caption2)
                             .fontWeight(.medium)
                             .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
                     }
                 }
 
                 // Calendar grid
-                let startOfMonth = calendarMonth.startOfMonth
+                let monthComps = Calendar.current.dateComponents([.year, .month], from: calendarMonth)
+                let year = monthComps.year ?? Calendar.current.component(.year, from: Date())
+                let month = monthComps.month ?? 1
                 let daysInMonth = calendarMonth.daysInMonth
-                let offset = startOfMonth.weekdayOffset
-                let dayMap = Dictionary(uniqueKeysWithValues: calendarDays.map { ($0.date, $0) })
+                let offset = calendarMonth.startOfMonth.weekdayOffset
+                let dayMap = Dictionary(calendarDays.map { ($0.date, $0) }, uniquingKeysWith: { first, _ in first })
 
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 2), count: 7), spacing: 2) {
+                LazyVGrid(columns: gridColumns, spacing: 2) {
                     ForEach(0 ..< offset, id: \.self) { _ in
                         Color.clear.frame(height: 28)
                     }
                     ForEach(1 ... daysInMonth, id: \.self) { day in
-                        let date = Calendar.current.date(byAdding: .day, value: day - 1, to: startOfMonth)
-                        let dateStr = date.map { DateFormatting.isoString(from: $0) } ?? ""
+                        // Build the lookup key from calendar components rather than
+                        // date arithmetic + a locale-less formatter, so it always
+                        // matches the server's yyyy-MM-dd and the colors line up
+                        // regardless of the device time zone.
+                        let dateStr = String(format: "%04d-%02d-%02d", year, month, day)
                         let calDay = dayMap[dateStr]
 
                         RoundedRectangle(cornerRadius: 4)
@@ -433,19 +443,21 @@ struct InsightsView: View {
                     Label(L10n.avgComparison, systemImage: "arrow.left.arrow.right")
                         .font(.headline)
 
-                    HStack {
+                    HStack(spacing: 8) {
                         Text("")
                             .frame(maxWidth: .infinity, alignment: .leading)
                         Text(L10n.weeklyAvg)
-                            .font(.caption)
-                            .fontWeight(.bold)
-                            .frame(maxWidth: .infinity)
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                         Text(L10n.monthlyAvg)
-                            .font(.caption)
-                            .fontWeight(.bold)
-                            .frame(maxWidth: .infinity)
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                         Text("")
-                            .frame(width: 48)
+                            .frame(width: 52)
                     }
 
                     Divider()
@@ -496,22 +508,32 @@ struct InsightsView: View {
         let arrow = diff > 0 ? "\u{2191}" : (diff < 0 ? "\u{2193}" : "\u{2192}")
         let trendColor: Color = diff > 0 ? MacroColors.fiber : (diff < 0 ? MacroColors.protein : .secondary)
 
-        return HStack {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(color)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        return HStack(spacing: 8) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 7, height: 7)
+                Text(label)
+                    .font(.subheadline)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
             Text("\(Int(weekly)) \(unit)")
-                .font(.caption)
-                .frame(maxWidth: .infinity)
+                .font(.subheadline)
+                .monospacedDigit()
+                .frame(maxWidth: .infinity, alignment: .trailing)
             Text("\(Int(monthly)) \(unit)")
+                .font(.subheadline)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            Text("\(arrow)\(Int(abs(diffPct)))%")
                 .font(.caption)
-                .frame(maxWidth: .infinity)
-            Text("\(arrow) \(Int(abs(diffPct)))%")
-                .font(.caption2)
-                .fontWeight(.bold)
+                .fontWeight(.semibold)
+                .monospacedDigit()
                 .foregroundStyle(trendColor)
-                .frame(width: 48, alignment: .trailing)
+                .lineLimit(1)
+                .frame(width: 52, alignment: .trailing)
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/SleepView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SleepView.swift
@@ -8,6 +8,13 @@ func formatSleepDuration(_ minutes: Int) -> String {
     return remainder == 0 ? "\(hours)h" : "\(hours)h \(remainder)m"
 }
 
+/// Sleep quality on the 1–10 scale. Manual entries are whole numbers; synced
+/// sources can carry one decimal (e.g. a 0–100 score mapped to 9.7), so a
+/// fractional value shows one decimal and a round value stays integer.
+func formatSleepQuality(_ quality: Double) -> String {
+    quality == quality.rounded() ? String(Int(quality)) : String(format: "%.1f", quality)
+}
+
 struct SleepView: View {
     @Environment(SleepRepository.self) private var sleepRepository
 
@@ -20,13 +27,12 @@ struct SleepView: View {
 
     /// Imported Health nights carry no subjective rating — they get the
     /// neutral middle of the 1–10 scale, editable afterwards.
-    static let importedQuality = 5
+    static let importedQuality = 5.0
 
     private enum RangeOption: Int, CaseIterable, Identifiable {
         case week = 7
         case month = 30
         case quarter = 90
-        case all = 0
 
         var id: Int {
             rawValue
@@ -37,7 +43,6 @@ struct SleepView: View {
             case .week: "7d"
             case .month: "30d"
             case .quarter: "90d"
-            case .all: L10n.history
             }
         }
     }
@@ -364,7 +369,7 @@ struct SleepEntryRow: View {
                 VStack(alignment: .trailing, spacing: 2) {
                     Text(formatSleepDuration(entry.durationMinutes))
                         .foregroundStyle(.secondary)
-                    Text("\(entry.quality)/10")
+                    Text("\(formatSleepQuality(entry.quality))/10")
                         .font(.caption)
                         .foregroundStyle(.purple)
                 }
@@ -634,7 +639,7 @@ struct AddSleepSheet: View {
         guard let entry = existingEntry else { return }
         hoursText = "\(entry.durationMinutes / 60)"
         minutesText = "\(entry.durationMinutes % 60)"
-        quality = Double(entry.quality)
+        quality = entry.quality
         if let d = DateFormatting.date(from: entry.entryDate) {
             date = d
         }
@@ -664,7 +669,7 @@ struct AddSleepSheet: View {
             if let existing = existingEntry {
                 let update = SleepUpdate(
                     durationMinutes: durationMinutes,
-                    quality: Int(quality),
+                    quality: quality,
                     entryDate: dateStr,
                     bedtime: bedtimeIso,
                     wakeTime: wakeTimeIso,
@@ -675,7 +680,7 @@ struct AddSleepSheet: View {
             } else {
                 let create = SleepCreate(
                     durationMinutes: durationMinutes,
-                    quality: Int(quality),
+                    quality: quality,
                     entryDate: dateStr,
                     bedtime: bedtimeIso,
                     wakeTime: wakeTimeIso,

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -114,6 +114,9 @@ struct WeightView: View {
     @State private var errorMessage: String?
     @State private var showProjection = false
     @State private var projectionDays = 30
+    /// X-position the user is touching on the chart, used to surface the nearest
+    /// data point (Apple Health-style scrubbing).
+    @State private var selectedDate: Date?
 
     private enum RangeOption: Int, CaseIterable, Identifiable {
         case week = 7
@@ -208,6 +211,19 @@ struct WeightView: View {
         }
         let padding = max((maxW - minW) * 0.15, 0.5)
         return (minW - padding) ... (maxW + padding)
+    }
+
+    /// The charted entry closest to the touched x-position, or nil when the
+    /// user isn't scrubbing.
+    private var selectedEntry: (date: Date, weightKg: Double)? {
+        guard let selectedDate else { return nil }
+        let dated = chartEntries.compactMap { entry -> (Date, Double)? in
+            guard let date = DateFormatting.date(from: entry.entryDate) else { return nil }
+            return (date, entry.weightKg)
+        }
+        return dated
+            .min { abs($0.0.timeIntervalSince(selectedDate)) < abs($1.0.timeIntervalSince(selectedDate)) }
+            .map { (date: $0.0, weightKg: $0.1) }
     }
 
     var body: some View {
@@ -438,7 +454,38 @@ struct WeightView: View {
                             .interpolationMethod(.linear)
                         }
                     }
+
+                    if let selected = selectedEntry {
+                        RuleMark(x: .value("Date", selected.date))
+                            .foregroundStyle(.secondary.opacity(0.4))
+                            .annotation(
+                                position: .top,
+                                spacing: 0,
+                                overflowResolution: .init(x: .fit(to: .chart), y: .disjoint)
+                            ) {
+                                VStack(spacing: 2) {
+                                    Text(DateFormatting.displayString(from: selected.date))
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(String(format: "%.1f kg", selected.weightKg))
+                                        .font(.caption)
+                                        .fontWeight(.semibold)
+                                        .foregroundStyle(.blue)
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            }
+
+                        PointMark(
+                            x: .value("Date", selected.date),
+                            y: .value(L10n.weight, selected.weightKg)
+                        )
+                        .foregroundStyle(.blue)
+                        .symbolSize(80)
+                    }
                 }
+                .chartXSelection(value: $selectedDate)
                 .chartYScale(domain: weightRange)
                 .chartYAxis {
                     AxisMarks(position: .leading) { value in

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -461,7 +461,7 @@ struct WeightView: View {
                             .annotation(
                                 position: .top,
                                 spacing: 0,
-                                overflowResolution: .init(x: .fit(to: .chart), y: .disjoint)
+                                overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))
                             ) {
                                 VStack(spacing: 2) {
                                     Text(DateFormatting.displayString(from: selected.date))

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/migration/LocalDataMigratorTest.kt
@@ -839,7 +839,7 @@ class LocalDataMigratorTest {
             userId = "user-1",
             entryDate = "2024-01-15",
             durationMinutes = 480,
-            quality = 4,
+            quality = 4.0,
             bedtime = null,
             wakeTime = null,
             wakeUps = null,

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SleepRepositoryTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/repository/SleepRepositoryTest.kt
@@ -81,7 +81,7 @@ class SleepRepositoryTest {
             coEvery { api.getSleepEntries(any(), any()) } returns listOf(existing)
             repository.refresh()
 
-            val create = SleepCreate(durationMinutes = 480, quality = 8, entryDate = "2024-01-20")
+            val create = SleepCreate(durationMinutes = 480, quality = 8.0, entryDate = "2024-01-20")
 
             repository.createEntry(create)
 
@@ -92,19 +92,19 @@ class SleepRepositoryTest {
     @Test
     fun createEntryReturnsTempEntry() =
         runTest {
-            val create = SleepCreate(durationMinutes = 480, quality = 9, entryDate = "2024-01-20")
+            val create = SleepCreate(durationMinutes = 480, quality = 9.0, entryDate = "2024-01-20")
 
             val result = repository.createEntry(create)
 
             assertTrue(result.id.startsWith("temp_"))
-            assertEquals(9, result.quality)
+            assertEquals(9.0, result.quality)
             assertEquals(480, result.durationMinutes)
         }
 
     @Test
     fun createEntryEnqueuesSyncOperation() =
         runTest {
-            val create = SleepCreate(durationMinutes = 480, quality = 8, entryDate = "2024-01-20")
+            val create = SleepCreate(durationMinutes = 480, quality = 8.0, entryDate = "2024-01-20")
 
             repository.createEntry(create)
 
@@ -136,16 +136,16 @@ class SleepRepositoryTest {
     @Test
     fun updateEntryReplacesInFlow() =
         runTest {
-            val original = sleepEntry("1", quality = 5)
+            val original = sleepEntry("1", quality = 5.0)
             coEvery { api.getSleepEntries(any(), any()) } returns listOf(original)
             repository.refresh()
 
-            val update = SleepUpdate(quality = 8)
+            val update = SleepUpdate(quality = 8.0)
             repository.updateEntry("1", update)
 
             val entries = repository.entries().first()
             assertEquals(1, entries.size)
-            assertEquals(8, entries[0].quality)
+            assertEquals(8.0, entries[0].quality)
         }
 
     @Test
@@ -154,10 +154,10 @@ class SleepRepositoryTest {
             coEvery { api.getSleepEntries(any(), any()) } returns listOf(sleepEntry("1"))
             repository.refresh()
 
-            val update = SleepUpdate(quality = 9)
+            val update = SleepUpdate(quality = 9.0)
             val result = repository.updateEntry("1", update)
 
-            assertEquals(9, result.quality)
+            assertEquals(9.0, result.quality)
         }
 
     @Test
@@ -166,7 +166,7 @@ class SleepRepositoryTest {
             coEvery { api.getSleepEntries(any(), any()) } returns listOf(sleepEntry("1"))
             repository.refresh()
 
-            repository.updateEntry("1", SleepUpdate(quality = 9))
+            repository.updateEntry("1", SleepUpdate(quality = 9.0))
 
             coVerify { syncQueue.enqueue(any()) }
         }
@@ -178,7 +178,7 @@ class SleepRepositoryTest {
             coEvery { api.getSleepEntries(any(), any()) } returns entries
             repository.refresh()
 
-            repository.updateEntry("2", SleepUpdate(quality = 10))
+            repository.updateEntry("2", SleepUpdate(quality = 10.0))
 
             val result = repository.entries().first()
             assertEquals(3, result.size)
@@ -220,7 +220,7 @@ class SleepRepositoryTest {
     companion object {
         fun sleepEntry(
             id: String,
-            quality: Int = 7,
+            quality: Double = 7.0,
         ) = SleepEntry(
             id = id,
             userId = "user-1",

--- a/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
+++ b/mobile/shared/src/androidUnitTest/kotlin/com/bissbilanz/sync/TempIdCoalescingTest.kt
@@ -270,14 +270,14 @@ class TempIdCoalescingTest {
     fun sleepCreateThenUpdateRewritesQueuedCreateBody() =
         runTest {
             val repo = sleepRepository()
-            val temp = repo.createEntry(SleepCreate(durationMinutes = 480, quality = 7, entryDate = "2024-01-15"))
+            val temp = repo.createEntry(SleepCreate(durationMinutes = 480, quality = 7.0, entryDate = "2024-01-15"))
 
-            repo.updateEntry(temp.id, SleepUpdate(quality = 9, notes = "slept well"))
+            repo.updateEntry(temp.id, SleepUpdate(quality = 9.0, notes = "slept well"))
 
             val create = syncQueue.drain().single().operation as SyncOperation.CreateSleep
             assertEquals(temp.id, create.localId)
             val body = json.decodeFromString<SleepCreate>(create.body)
-            assertEquals(9, body.quality)
+            assertEquals(9.0, body.quality)
             assertEquals(480, body.durationMinutes)
             assertEquals("2024-01-15", body.entryDate)
             assertEquals("slept well", body.notes)
@@ -287,7 +287,7 @@ class TempIdCoalescingTest {
     fun sleepCreateThenDeleteLeavesQueueEmpty() =
         runTest {
             val repo = sleepRepository()
-            val temp = repo.createEntry(SleepCreate(durationMinutes = 480, quality = 7, entryDate = "2024-01-15"))
+            val temp = repo.createEntry(SleepCreate(durationMinutes = 480, quality = 7.0, entryDate = "2024-01-15"))
 
             repo.deleteEntry(temp.id)
 
@@ -299,7 +299,7 @@ class TempIdCoalescingTest {
         runTest {
             val repo = sleepRepository()
 
-            repo.updateEntry("server-1", SleepUpdate(quality = 8))
+            repo.updateEntry("server-1", SleepUpdate(quality = 8.0))
             repo.deleteEntry("server-2")
 
             val ops = syncQueue.drain().map { it.operation }

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/generated/model/SleepCreate.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/generated/model/SleepCreate.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.encoding.*
 @Serializable
 data class SleepCreate(
     @SerialName(value = "durationMinutes") @Required val durationMinutes: kotlin.Int,
-    @SerialName(value = "quality") @Required val quality: kotlin.Int,
+    @SerialName(value = "quality") @Required val quality: kotlin.Double,
     @SerialName(value = "entryDate") @Required val entryDate: kotlin.String,
     @SerialName(value = "bedtime") val bedtime: kotlin.String? = null,
     @SerialName(value = "wakeTime") val wakeTime: kotlin.String? = null,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/generated/model/SleepEntry.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/generated/model/SleepEntry.kt
@@ -46,7 +46,7 @@ data class SleepEntry(
     @SerialName(value = "userId") @Required val userId: kotlin.String,
     @SerialName(value = "entryDate") @Required val entryDate: kotlin.String,
     @SerialName(value = "durationMinutes") @Required val durationMinutes: kotlin.Int,
-    @SerialName(value = "quality") @Required val quality: kotlin.Int,
+    @SerialName(value = "quality") @Required val quality: kotlin.Double,
     @SerialName(value = "bedtime") @Required val bedtime: kotlin.String?,
     @SerialName(value = "wakeTime") @Required val wakeTime: kotlin.String?,
     @SerialName(value = "wakeUps") @Required val wakeUps: kotlin.Int?,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/generated/model/SleepUpdate.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/api/generated/model/SleepUpdate.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.encoding.*
 @Serializable
 data class SleepUpdate(
     @SerialName(value = "durationMinutes") val durationMinutes: kotlin.Int? = null,
-    @SerialName(value = "quality") val quality: kotlin.Int? = null,
+    @SerialName(value = "quality") val quality: kotlin.Double? = null,
     @SerialName(value = "entryDate") val entryDate: kotlin.String? = null,
     @SerialName(value = "bedtime") val bedtime: kotlin.String? = null,
     @SerialName(value = "wakeTime") val wakeTime: kotlin.String? = null,

--- a/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
+++ b/mobile/shared/src/commonMain/kotlin/com/bissbilanz/repository/SleepRepository.kt
@@ -87,7 +87,7 @@ class SleepRepository(
                     userId = "",
                     entryDate = entry.entryDate ?: "",
                     durationMinutes = entry.durationMinutes ?: 0,
-                    quality = entry.quality ?: 0,
+                    quality = entry.quality ?: 0.0,
                     bedtime = entry.bedtime,
                     wakeTime = entry.wakeTime,
                     wakeUps = entry.wakeUps,

--- a/src/lib/components/sleep/SleepHistoryList.svelte
+++ b/src/lib/components/sleep/SleepHistoryList.svelte
@@ -84,6 +84,10 @@
 		if (q >= 5) return '#f59e0b';
 		return '#ef4444';
 	};
+
+	// Synced sources can carry a decimal score (e.g. 9.7); manual entries are
+	// whole numbers — show one decimal only when it isn't a round value.
+	const formatQuality = (q: number) => (Number.isInteger(q) ? String(q) : q.toFixed(1));
 </script>
 
 <div class="space-y-2">
@@ -126,7 +130,7 @@
 									class="inline-block size-2 rounded-full"
 									style="background-color: {qualityColor(entry.quality)}"
 								></span>
-								<span class="text-sm tabular-nums">{entry.quality}/10</span>
+								<span class="text-sm tabular-nums">{formatQuality(entry.quality)}/10</span>
 							</div>
 							<span class="text-sm text-muted-foreground">{formatDate(entry.entryDate)}</span>
 							{#if entry.bedtime || entry.wakeTime}

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -477,7 +477,9 @@ export const sleepEntries = pgTable(
 			.references(() => users.id, { onDelete: 'cascade' }),
 		entryDate: date('entry_date').notNull(),
 		durationMinutes: integer('duration_minutes').notNull(),
-		quality: integer('quality').notNull(),
+		// Stored as a float so synced sources (e.g. a 0–100 sleep score mapped to
+		// the 1–10 scale) can carry one decimal; the manual slider stays integer.
+		quality: real('quality').notNull(),
 		bedtime: timestamp('bedtime', { withTimezone: true }),
 		wakeTime: timestamp('wake_time', { withTimezone: true }),
 		wakeUps: integer('wake_ups'),

--- a/src/lib/server/validation/responses/sleep.ts
+++ b/src/lib/server/validation/responses/sleep.ts
@@ -7,7 +7,7 @@ const sleepEntrySchema = z
 		userId: z.string().uuid(),
 		entryDate: z.string(),
 		durationMinutes: z.number().int(),
-		quality: z.number().int(),
+		quality: z.number(),
 		bedtime: z.string().nullable(),
 		wakeTime: z.string().nullable(),
 		wakeUps: z.number().int().nullable(),

--- a/src/lib/server/validation/sleep.ts
+++ b/src/lib/server/validation/sleep.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 export const sleepCreateSchema = z
 	.object({
 		durationMinutes: z.coerce.number().int().positive().max(1440),
-		quality: z.coerce.number().int().min(1).max(10),
+		quality: z.coerce.number().min(1).max(10),
 		entryDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 		bedtime: z.string().datetime().optional().nullable(),
 		wakeTime: z.string().datetime().optional().nullable(),
@@ -16,7 +16,7 @@ export const sleepCreateSchema = z
 export const sleepUpdateSchema = z
 	.object({
 		durationMinutes: z.coerce.number().int().positive().max(1440).optional(),
-		quality: z.coerce.number().int().min(1).max(10).optional(),
+		quality: z.coerce.number().min(1).max(10).optional(),
 		entryDate: z
 			.string()
 			.regex(/^\d{4}-\d{2}-\d{2}$/)


### PR DESCRIPTION
Addresses the latest batch of TestFlight screenshot feedback that wasn't covered by #358.

## Changes

1. **Insights calendar** — the heatmap weekday headers now share the day grid's columns so they line up, and day keys are built from calendar components instead of date arithmetic + a locale-less formatter, so the On Target / Has Entries colors match the server dates regardless of time zone.
2. **Insights goal %** — percentages stay on one line when they reach 100% (wider frame, no wrap), so the bars keep a uniform height.
3. **Insights average comparison** — dropped the garish colorized macro labels for a small colored dot + neutral text, widened the value columns and stopped the trend % column from wrapping.
4. **Weight chart** — tap/drag to scrub and surface the nearest weigh-in as a lollipop (rule line, emphasized point, date + value callout), like Apple Health.
5. **Sleep history tab** — removed the chart "History" range (identical to 90d); the range picker is now 7d / 30d / 90d.
6. **Decimal sleep quality** (full-stack) — quality is now stored as a float so an Apple Health-style 0–100 score can map to the 1–10 scale and display as e.g. `9.7/10`. The manual slider stays integer 1–10. Server column `int → real` + migration, validation/OpenAPI/Kotlin DTOs updated, web + iOS + Android display one decimal only when fractional. The iOS/Android local caches keep the denormalized quality column integer; the real value round-trips through the serialized entry. (Note: HealthKit's sleep data carries no score field, so nothing produces a fractional value *yet* — this makes the type ready for when a 0–100 source exists.)
7. **Serving size input** — split the row 60/40 so the amount field gets most of the width instead of the unit picker crowding it out.

## Verification
- `bun run check` (svelte-check + prettier): clean
- `bun run api:check`: regenerated OpenAPI/TS in sync (the only schema diff is sleep `quality` integer → number)
- Sleep unit tests: 93 passing
- Android `:shared` + `:androidApp` compile and ktlint pass
- iOS compiles in CI (no local macOS); deployment target is iOS 18, so the chart scrubbing APIs are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)