### PR TITLE
feat(ios): dashboard refresh fix + TestFlight feedback batch

### DIFF
--- a/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
+++ b/mobile/iosApp/Bissbilanz/API/BissbilanzAPI.swift
@@ -572,6 +572,10 @@ final class BissbilanzAPI {
         }
         var request = URLRequest(url: components.url!)
         request.httpMethod = "GET"
+        // Never serve API reads from URLCache: these are per-user, frequently
+        // mutated rows (an entry logged on web/MCP must show on the next pull),
+        // and a stale 200 would silently hide fresh data with no error to debug.
+        request.cachePolicy = .reloadIgnoringLocalCacheData
         return try await performRequest(request)
     }
 

--- a/mobile/iosApp/Bissbilanz/Components/MealCard.swift
+++ b/mobile/iosApp/Bissbilanz/Components/MealCard.swift
@@ -38,9 +38,16 @@ struct MealCard: View {
 
             ForEach(entries) { entry in
                 HStack {
-                    Text(entry.displayName)
-                        .font(.subheadline)
-                        .lineLimit(1)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(entry.displayName)
+                            .font(.subheadline)
+                            .lineLimit(1)
+                        if let time = entry.loggedTimeString {
+                            Text(time)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
                     Spacer()
                     Text("\(entry.servings, specifier: "%.1g")x")
                         .font(.caption)

--- a/mobile/iosApp/Bissbilanz/Models/Entry.swift
+++ b/mobile/iosApp/Bissbilanz/Models/Entry.swift
@@ -53,6 +53,20 @@ struct Entry: Codable, Identifiable {
     var totalFiber: Double {
         (fiber ?? quickFiber ?? 0) * servings
     }
+
+    /// When the entry was logged, preferring the user-set eaten time and
+    /// falling back to the row's creation timestamp. `nil` when neither parses.
+    var loggedAt: Date? {
+        if let eatenAt, let date = DateFormatting.isoDateTime(from: eatenAt) { return date }
+        if let createdAt, let date = DateFormatting.isoDateTime(from: createdAt) { return date }
+        return nil
+    }
+
+    /// Short local time-of-day ("1:30 PM") for display, or `nil` when unknown.
+    var loggedTimeString: String? {
+        guard let loggedAt else { return nil }
+        return DateFormatting.timeString(from: loggedAt)
+    }
 }
 
 struct EntryCreate: Codable {

--- a/mobile/iosApp/Bissbilanz/Services/ErrorReporter.swift
+++ b/mobile/iosApp/Bissbilanz/Services/ErrorReporter.swift
@@ -129,6 +129,34 @@ enum ErrorReporter {
         SentrySDK.capture(message: "Bissbilanz iOS test event")
     }
 
+    /// Short, stable classification of a failure for telemetry — so a captured
+    /// warning says *why* (offline / timeout / server_error_500 / decoding_error_200
+    /// / unauthorized …) instead of a bare localized string. Use alongside
+    /// `captureWarning` at the point a failure becomes user-visible, since the
+    /// most common causes here (offline, 401, 404) are filtered out of `capture`.
+    static func reason(for error: Error) -> String {
+        if error is CancellationError { return "cancelled" }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .dataNotAllowed: return "offline"
+            case .timedOut: return "timeout"
+            case .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed: return "cannot_reach_host"
+            default: return "url_error_\(urlError.code.rawValue)"
+            }
+        }
+        switch error as? APIError {
+        case .unauthorized: return "unauthorized"
+        case .notFound: return "not_found"
+        case .gone: return "gone"
+        case .conflict: return "conflict"
+        case .badRequest: return "bad_request"
+        case let .serverError(code, _): return "server_error_\(code)"
+        case let .networkError(underlying): return reason(for: underlying)
+        case let .decodingError(_, statusCode, _): return "decoding_error_\(statusCode)"
+        case nil: return "other: \(error.localizedDescription)"
+        }
+    }
+
     private static func shouldIgnore(_ error: Error) -> Bool {
         if error is CancellationError {
             return true

--- a/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/EntryEditSheet.swift
@@ -43,6 +43,7 @@ struct EntryEditSheet: View {
                             Text(L10n.mealName(meal)).tag(meal)
                         }
                     }
+                    .pickerStyle(.menu)
                 }
             }
             .navigationTitle(L10n.editEntry)

--- a/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/FoodEditSheet.swift
@@ -17,6 +17,11 @@ struct FoodEditSheet: View {
     @State private var carbs = ""
     @State private var fat = ""
     @State private var fiber = ""
+    /// Whether the entered macro/nutrient values are per 100 g/ml (true) or for
+    /// one serving (false). Per-100 g entries are scaled to the per-serving
+    /// basis the food record stores when saving, so the user never has to do
+    /// the math themselves.
+    @State private var perHundredBasis = false
     @State private var isFavorite = false
     @State private var isSaving = false
     @State private var errorMessage: String?
@@ -76,12 +81,21 @@ struct FoodEditSheet: View {
                     .frame(height: 34)
                 }
 
-                Section(L10n.mainMacros) {
+                Section {
+                    Picker(L10n.valuesPer, selection: $perHundredBasis) {
+                        Text(L10n.perServing).tag(false)
+                        Text(L10n.per100).tag(true)
+                    }
+                    .pickerStyle(.segmented)
                     macroField(L10n.calories, text: $calories, unit: "kcal")
                     macroField(L10n.protein, text: $protein, unit: "g")
                     macroField(L10n.carbs, text: $carbs, unit: "g")
                     macroField(L10n.fat, text: $fat, unit: "g")
                     macroField(L10n.fiber, text: $fiber, unit: "g")
+                } header: {
+                    Text(L10n.mainMacros)
+                } footer: {
+                    Text(L10n.macroBasisFooter)
                 }
 
                 Section(L10n.additionalNutrients) {
@@ -209,6 +223,9 @@ struct FoodEditSheet: View {
     private func apply(_ parsed: ParsedNutrition) {
         servingSize = "100"
         servingUnit = .g
+        // The parser reports per-100 g values, so switch the basis to match;
+        // the user can change the serving and the totals are scaled on save.
+        perHundredBasis = true
         if let value = parsed.calories { calories = Self.numberString(value) }
         if let value = parsed.protein { protein = Self.numberString(value) }
         if let value = parsed.carbs { carbs = Self.numberString(value) }
@@ -229,26 +246,33 @@ struct FoodEditSheet: View {
         isSaving = true
         errorMessage = nil
 
+        let serving = Double.parseUserInput(servingSize) ?? 100
+        // The food record stores per-serving values. When the user entered the
+        // per-100 g basis, scale everything by serving/100; per-serving entries
+        // are stored as-is (factor 1).
+        let factor = perHundredBasis && serving > 0 ? serving / 100 : 1
+
         var foodData = FoodCreate(
             name: name,
             brand: brand.isEmpty ? nil : brand,
-            servingSize: Double.parseUserInput(servingSize) ?? 100,
+            servingSize: serving,
             servingUnit: servingUnit,
-            calories: Double.parseUserInput(calories) ?? 0,
-            protein: Double.parseUserInput(protein) ?? 0,
-            carbs: Double.parseUserInput(carbs) ?? 0,
-            fat: Double.parseUserInput(fat) ?? 0,
-            fiber: Double.parseUserInput(fiber) ?? 0,
+            calories: (Double.parseUserInput(calories) ?? 0) * factor,
+            protein: (Double.parseUserInput(protein) ?? 0) * factor,
+            carbs: (Double.parseUserInput(carbs) ?? 0) * factor,
+            fat: (Double.parseUserInput(fat) ?? 0) * factor,
+            fiber: (Double.parseUserInput(fiber) ?? 0) * factor,
             barcode: barcode.isEmpty ? nil : barcode,
             isFavorite: isFavorite
         )
 
         // Overlay the additional nutrient values onto the matching FoodCreate
-        // fields by their JSON key. Blank or unparseable rows are skipped.
+        // fields by their JSON key, scaled by the same basis factor. Blank or
+        // unparseable rows are skipped.
         var patch: [String: Any] = [:]
         for (key, text) in additionalValues {
             if let value = Double.parseUserInput(text) {
-                patch[key] = value
+                patch[key] = value * factor
             }
         }
         if !patch.isEmpty {

--- a/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
+++ b/mobile/iosApp/Bissbilanz/Sheets/QuickEntrySheet.swift
@@ -29,6 +29,7 @@ struct QuickEntrySheet: View {
                             Text(L10n.mealName(meal)).tag(meal)
                         }
                     }
+                    .pickerStyle(.menu)
                 }
 
                 Section(L10n.nutrition) {

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -580,12 +580,8 @@ enum L10n {
         localized("monthly_avg", en: "Monthly Average", de: "Monatsdurchschnitt")
     }
 
-    static var weekly: String {
-        localized("weekly", en: "Weekly", de: "Woche")
-    }
-
     static var monthly: String {
-        localized("monthly", en: "Monthly", de: "Monat")
+        localized("monthly", en: "Monthly", de: "Monatlich")
     }
 
     static var topFoods: String {

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -105,6 +105,14 @@ enum L10n {
         localized("something_went_wrong", en: "Something went wrong", de: "Etwas ist schiefgelaufen")
     }
 
+    static var couldNotRefresh: String {
+        localized(
+            "could_not_refresh",
+            en: "Couldn't reach the server, so this day may be out of date. Pull to refresh or tap retry.",
+            de: "Server nicht erreichbar – dieser Tag ist evtl. nicht aktuell. Zum Aktualisieren ziehen oder erneut versuchen."
+        )
+    }
+
     static var typeToSearchHint: String {
         localized("type_to_search_hint", en: "Type at least 2 characters", de: "Mindestens 2 Zeichen eingeben")
     }

--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -432,6 +432,22 @@ enum L10n {
         localized("per_serving", en: "Per Serving", de: "Pro Portion")
     }
 
+    static var per100: String {
+        localized("per_100", en: "Per 100 g", de: "Pro 100 g")
+    }
+
+    static var valuesPer: String {
+        localized("values_per", en: "Values per", de: "Werte pro")
+    }
+
+    static var macroBasisFooter: String {
+        localized(
+            "macro_basis_footer",
+            en: "Enter the macros per serving or per 100 g — the values are converted for you.",
+            de: "Makros pro Portion oder pro 100 g eingeben — die Werte werden für dich umgerechnet."
+        )
+    }
+
     static var totals: String {
         localized("totals", en: "Totals", de: "Gesamt")
     }
@@ -562,6 +578,14 @@ enum L10n {
 
     static var monthlyAvg: String {
         localized("monthly_avg", en: "Monthly Average", de: "Monatsdurchschnitt")
+    }
+
+    static var weekly: String {
+        localized("weekly", en: "Weekly", de: "Woche")
+    }
+
+    static var monthly: String {
+        localized("monthly", en: "Monthly", de: "Monat")
     }
 
     static var topFoods: String {
@@ -1344,6 +1368,14 @@ enum L10n {
 
     static var minutes: String {
         localized("minutes", en: "Minutes", de: "Minuten")
+    }
+
+    static var hoursShort: String {
+        localized("hours_short", en: "hr", de: "Std")
+    }
+
+    static var minutesShort: String {
+        localized("minutes_short", en: "min", de: "Min")
     }
 
     // MARK: - Insights (additional)

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -78,6 +78,10 @@ struct DashboardView: View {
                     }
                 }
                 .padding()
+                // Extra bottom room so the floating action buttons never cover
+                // the last meal card's totals — the content can always scroll
+                // clear of the FAB instead of sitting permanently behind it.
+                .padding(.bottom, 104)
             }
             .simultaneousGesture(dateSwipeGesture)
             .navigationTitle(L10n.appName)

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -12,6 +12,10 @@ struct DashboardView: View {
     @State private var preferences: Preferences = .defaults
     @State private var selectedDate = Date()
     @State private var isLoading = false
+    /// True when the last entries refresh failed and the day is empty — lets us
+    /// show a retry affordance instead of a misleading "No entries yet" state
+    /// (a swallowed refresh error looks identical to a genuinely empty day).
+    @State private var refreshFailed = false
     @State private var showFoodSearch = false
     @State private var showScanner = false
     @State private var showQuickEntry = false
@@ -135,7 +139,7 @@ struct DashboardView: View {
         VStack(spacing: 16) {
             macroRings
 
-            if totalCalories == 0 {
+            if totalCalories == 0, !refreshFailed {
                 HStack {
                     Image(systemName: "fork.knife")
                         .foregroundStyle(.secondary)
@@ -173,7 +177,11 @@ struct DashboardView: View {
             }
 
             if mealGroups.isEmpty, !isLoading {
-                emptyState
+                if refreshFailed {
+                    refreshErrorState
+                } else {
+                    emptyState
+                }
             } else {
                 ForEach(mealGroups, id: \.0) { meal, mealEntries in
                     NavigationLink(value: dateString) {
@@ -395,6 +403,24 @@ struct DashboardView: View {
         .padding(.vertical, 24)
     }
 
+    /// Shown when the live entries refresh failed and the local store is empty,
+    /// so a swallowed network error isn't mistaken for a day with no food. The
+    /// Retry button re-runs `loadData` directly — a reliable refresh path that
+    /// doesn't depend on the pull-to-refresh gesture.
+    private var refreshErrorState: some View {
+        ContentUnavailableView {
+            Label(L10n.somethingWentWrong, systemImage: "wifi.exclamationmark")
+        } description: {
+            Text(L10n.couldNotRefresh)
+        } actions: {
+            Button(L10n.retry) {
+                Task { await loadData() }
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(.vertical, 24)
+    }
+
     // MARK: - FAB
 
     private var fab: some View {
@@ -456,7 +482,9 @@ struct DashboardView: View {
         isLoading = true
         defer { isLoading = false }
 
-        async let entriesTask: Void? = try? entryRepository.refresh(date: dateString)
+        // Track the entries refresh outcome: a failure that leaves the day
+        // empty must surface (retry) rather than masquerade as "No entries yet".
+        async let entriesOk: Bool = refreshEntries()
         async let goalsTask: Void? = try? goalsRepository.refresh()
         async let prefsTask: Void? = try? preferencesRepository.refresh()
         async let dayPropsTask: Void? = try? entryRepository.refreshDayProperties(date: dateString)
@@ -470,11 +498,27 @@ struct DashboardView: View {
         // Report the device timezone so server-side analytics/MCP use the user's tz.
         async let tzTask: Void? = try? preferencesRepository.reportTimeZone(TimeZone.current.identifier)
 
-        _ = await (entriesTask, goalsTask, prefsTask, dayPropsTask, suppListTask, weightTask, tzTask)
+        let (entriesRefreshed, _, _, _, _, _, _) = await (
+            entriesOk, goalsTask, prefsTask, dayPropsTask, suppListTask, weightTask, tzTask
+        )
         let checklist = await supplementsTask
 
         loadFromStore()
+        // Only flag the empty-day error case; a failed refresh that still has
+        // cached entries keeps showing them (stale beats blank).
+        refreshFailed = !entriesRefreshed && entries.isEmpty
         if let checklist { supplementChecklist = checklist }
+    }
+
+    /// Pulls the day's entries, returning whether the live refresh succeeded so
+    /// `loadData` can distinguish "server says empty" from "couldn't reach server".
+    private func refreshEntries() async -> Bool {
+        do {
+            try await entryRepository.refresh(date: dateString)
+            return true
+        } catch {
+            return false
+        }
     }
 
     private func copyYesterday() async {

--- a/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DashboardView.swift
@@ -484,7 +484,8 @@ struct DashboardView: View {
 
         // Track the entries refresh outcome: a failure that leaves the day
         // empty must surface (retry) rather than masquerade as "No entries yet".
-        async let entriesOk: Bool = refreshEntries()
+        // `refreshEntries` returns nil on success or a short failure reason.
+        async let entriesFailureReason: String? = refreshEntries()
         async let goalsTask: Void? = try? goalsRepository.refresh()
         async let prefsTask: Void? = try? preferencesRepository.refresh()
         async let dayPropsTask: Void? = try? entryRepository.refreshDayProperties(date: dateString)
@@ -498,26 +499,51 @@ struct DashboardView: View {
         // Report the device timezone so server-side analytics/MCP use the user's tz.
         async let tzTask: Void? = try? preferencesRepository.reportTimeZone(TimeZone.current.identifier)
 
-        let (entriesRefreshed, _, _, _, _, _, _) = await (
-            entriesOk, goalsTask, prefsTask, dayPropsTask, suppListTask, weightTask, tzTask
+        let (entriesFailReason, _, _, _, _, _, _) = await (
+            entriesFailureReason, goalsTask, prefsTask, dayPropsTask, suppListTask, weightTask, tzTask
         )
         let checklist = await supplementsTask
 
         loadFromStore()
         // Only flag the empty-day error case; a failed refresh that still has
         // cached entries keeps showing them (stale beats blank).
-        refreshFailed = !entriesRefreshed && entries.isEmpty
+        refreshFailed = entriesFailReason != nil && entries.isEmpty
+        if refreshFailed, let entriesFailReason {
+            // Whenever the user actually sees the "couldn't refresh" state, log
+            // why — at warning level so it bypasses the API layer's noise filter
+            // (offline/401/404), which would otherwise leave the failure invisible.
+            ErrorReporter.captureWarning(
+                "Dashboard entries refresh failed — showing retry",
+                context: [
+                    "date": dateString,
+                    "endpoint": "/api/entries",
+                    "reason": entriesFailReason
+                ]
+            )
+        }
         if let checklist { supplementChecklist = checklist }
     }
 
-    /// Pulls the day's entries, returning whether the live refresh succeeded so
-    /// `loadData` can distinguish "server says empty" from "couldn't reach server".
-    private func refreshEntries() async -> Bool {
+    /// Pulls the day's entries. Returns `nil` on success, or a short failure
+    /// reason (offline / server_error_500 / decoding_error_200 …) so `loadData`
+    /// can distinguish "server says empty" from "couldn't reach server" and
+    /// report *why* when it surfaces the error state. A String (not the Error)
+    /// is returned so it crosses the `async let` boundary as a Sendable value.
+    private func refreshEntries() async -> String? {
         do {
             try await entryRepository.refresh(date: dateString)
-            return true
+            return nil
         } catch {
-            return false
+            let reason = ErrorReporter.reason(for: error)
+            // Breadcrumb on every failure (even when stale entries still render),
+            // so any later event carries the trail that led to it.
+            ErrorReporter.addBreadcrumb(
+                "entries refresh failed",
+                category: "sync",
+                level: .warning,
+                data: ["date": dateString, "reason": reason]
+            )
+            return reason
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/DayLogView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/DayLogView.swift
@@ -12,9 +12,21 @@ struct DayLogView: View {
     @State private var isCopying = false
     @State private var showQuickEntry = false
     @State private var errorMessage: String?
+    @State private var searchText = ""
+
+    /// Entries narrowed by the search field (matches the displayed name).
+    private var filteredEntries: [Entry] {
+        guard !searchText.isEmpty else { return entries }
+        return entries.filter { $0.displayName.localizedCaseInsensitiveContains(searchText) }
+    }
 
     private var mealGroups: [(String, [Entry])] {
-        MealGrouping.group(entries)
+        MealGrouping.group(filteredEntries)
+    }
+
+    /// Logged-time order within a meal; entries without a timestamp sort last.
+    private func sortedByTime(_ items: [Entry]) -> [Entry] {
+        items.sorted { ($0.loggedAt ?? .distantFuture) < ($1.loggedAt ?? .distantFuture) }
     }
 
     var body: some View {
@@ -123,7 +135,7 @@ struct DayLogView: View {
         List {
             ForEach(mealGroups, id: \.0) { mealType, mealEntries in
                 Section {
-                    ForEach(mealEntries) { entry in
+                    ForEach(sortedByTime(mealEntries)) { entry in
                         entryRow(entry)
                             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                                 Button(role: .destructive) {
@@ -142,40 +154,35 @@ struct DayLogView: View {
                             }
                     }
                 } header: {
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack {
-                            Text(L10n.mealName(mealType))
-                            Spacer()
-                            let cal = mealEntries.reduce(0.0) { $0 + $1.totalCalories }
-                            Text("\(Int(cal)) cal")
-                                .font(.caption)
-                                .fontWeight(.bold)
-                                .monospacedDigit()
-                                .contentTransition(.numericText(value: cal))
-                                .foregroundStyle(MacroColors.calories)
-                        }
-                        HStack(spacing: 12) {
-                            let p = mealEntries.reduce(0.0) { $0 + $1.totalProtein }
-                            let c = mealEntries.reduce(0.0) { $0 + $1.totalCarbs }
-                            let f = mealEntries.reduce(0.0) { $0 + $1.totalFat }
-                            Text("P \(Int(p))g")
-                                .font(.caption2)
-                                .monospacedDigit()
-                                .foregroundStyle(MacroColors.protein)
-                            Text("C \(Int(c))g")
-                                .font(.caption2)
-                                .monospacedDigit()
-                                .foregroundStyle(MacroColors.carbs)
-                            Text("F \(Int(f))g")
-                                .font(.caption2)
-                                .monospacedDigit()
-                                .foregroundStyle(MacroColors.fat)
-                        }
-                    }
+                    mealHeader(mealType, mealEntries)
                 }
             }
         }
         .listStyle(.insetGrouped)
+        .searchable(text: $searchText, prompt: L10n.search)
+        .overlay {
+            if mealGroups.isEmpty, !searchText.isEmpty {
+                ContentUnavailableView.search(text: searchText)
+            }
+        }
+    }
+
+    /// Meal section header: the meal name with the per-meal totals as compact,
+    /// quietly tinted pills instead of a row of bright coloured numbers.
+    private func mealHeader(_ mealType: String, _ mealEntries: [Entry]) -> some View {
+        let cal = mealEntries.reduce(0.0) { $0 + $1.totalCalories }
+        let p = mealEntries.reduce(0.0) { $0 + $1.totalProtein }
+        let c = mealEntries.reduce(0.0) { $0 + $1.totalCarbs }
+        let f = mealEntries.reduce(0.0) { $0 + $1.totalFat }
+        return VStack(alignment: .leading, spacing: 6) {
+            Text(L10n.mealName(mealType))
+            HStack(spacing: 6) {
+                MacroPill(value: "\(Int(cal)) cal", color: MacroColors.calories)
+                MacroPill(label: "P", value: "\(Int(p))g", color: MacroColors.protein)
+                MacroPill(label: "C", value: "\(Int(c))g", color: MacroColors.carbs)
+                MacroPill(label: "F", value: "\(Int(f))g", color: MacroColors.fat)
+            }
+        }
     }
 
     private func entryRow(_ entry: Entry) -> some View {
@@ -187,22 +194,24 @@ struct DayLogView: View {
                     Text(entry.displayName)
                         .font(.body)
                         .foregroundStyle(.primary)
-                    Text("\(entry.servings, specifier: "%.2g")x \u{00B7} \(Int(entry.totalCalories)) cal")
-                        .font(.caption)
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
+                    HStack(spacing: 5) {
+                        if let time = entry.loggedTimeString {
+                            Text(time)
+                            Text("\u{00B7}")
+                        }
+                        Text("\(entry.servings, specifier: "%.2g")x \u{00B7} \(Int(entry.totalCalories)) cal")
+                    }
+                    .font(.caption)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
                 }
                 Spacer()
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text("P\(Int(entry.totalProtein))")
-                        .font(.caption2)
-                        .monospacedDigit()
-                        .foregroundStyle(MacroColors.protein)
-                    Text("C\(Int(entry.totalCarbs)) F\(Int(entry.totalFat))")
-                        .font(.caption2)
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
-                }
+                // Neutral, single-line macro summary — the colour now lives only
+                // in the meal-header pills, so the list reads calmly.
+                Text("P\(Int(entry.totalProtein)) C\(Int(entry.totalCarbs)) F\(Int(entry.totalFat))")
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -242,5 +251,27 @@ struct DayLogView: View {
             errorMessage = error.localizedDescription
         }
         isCopying = false
+    }
+}
+
+/// A compact, quietly tinted capsule for a single macro total — used in the
+/// day-log meal headers to replace the row of bright coloured numbers.
+private struct MacroPill: View {
+    var label: String = ""
+    let value: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 3) {
+            if !label.isEmpty {
+                Text(label).fontWeight(.semibold)
+            }
+            Text(value).monospacedDigit()
+        }
+        .font(.caption2)
+        .foregroundStyle(color)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(color.opacity(0.16), in: Capsule())
     }
 }

--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -113,12 +113,29 @@ struct FoodSearchView: View {
         }
     }
 
+    /// The shared search field filters the Recent/Favorites lists too — typing
+    /// here narrows whichever tab is showing, not just the Search tab.
+    private func matches(_ food: Food) -> Bool {
+        query.isEmpty
+            || food.name.localizedCaseInsensitiveContains(query)
+            || (food.brand?.localizedCaseInsensitiveContains(query) ?? false)
+    }
+
     private var recentTab: some View {
-        Group {
-            if recentFoods.isEmpty {
-                ContentUnavailableView(L10n.recent, systemImage: "clock", description: Text(L10n.noRecentFoods))
+        let items = recentFoods.filter(matches)
+        return Group {
+            if items.isEmpty {
+                if query.isEmpty {
+                    ContentUnavailableView(L10n.recent, systemImage: "clock", description: Text(L10n.noRecentFoods))
+                } else {
+                    ContentUnavailableView(
+                        L10n.noResults,
+                        systemImage: "magnifyingglass",
+                        description: Text("\(L10n.noResults): \"\(query)\"")
+                    )
+                }
             } else {
-                List(recentFoods) { food in
+                List(items) { food in
                     foodRow(food)
                 }
                 .listStyle(.plain)
@@ -127,11 +144,24 @@ struct FoodSearchView: View {
     }
 
     private var favoritesTab: some View {
-        Group {
-            if favoriteFoods.isEmpty {
-                ContentUnavailableView(L10n.favorites, systemImage: "star", description: Text(L10n.markFavoritesHint))
+        let items = favoriteFoods.filter(matches)
+        return Group {
+            if items.isEmpty {
+                if query.isEmpty {
+                    ContentUnavailableView(
+                        L10n.favorites,
+                        systemImage: "star",
+                        description: Text(L10n.markFavoritesHint)
+                    )
+                } else {
+                    ContentUnavailableView(
+                        L10n.noResults,
+                        systemImage: "magnifyingglass",
+                        description: Text("\(L10n.noResults): \"\(query)\"")
+                    )
+                }
             } else {
-                List(favoriteFoods) { food in
+                List(items) { food in
                     foodRow(food)
                 }
                 .listStyle(.plain)

--- a/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/InsightsView.swift
@@ -325,8 +325,10 @@ struct InsightsView: View {
                 .fontWeight(.bold)
                 .monospacedDigit()
                 .lineLimit(1)
+                // Wide enough that "100%" renders at full size like the rest, so
+                // the column never wraps to a second line or shrinks at 100%.
                 .minimumScaleFactor(0.8)
-                .frame(width: 52, alignment: .trailing)
+                .frame(width: 60, alignment: .trailing)
         }
     }
 
@@ -441,19 +443,21 @@ struct InsightsView: View {
 
                     HStack(spacing: 8) {
                         Text("")
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Text(L10n.weeklyAvg)
+                            .frame(width: 88, alignment: .leading)
+                        Text(L10n.weekly)
                             .font(.caption2)
                             .fontWeight(.semibold)
                             .foregroundStyle(.secondary)
+                            .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .trailing)
-                        Text(L10n.monthlyAvg)
+                        Text(L10n.monthly)
                             .font(.caption2)
                             .fontWeight(.semibold)
                             .foregroundStyle(.secondary)
+                            .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .trailing)
                         Text("")
-                            .frame(width: 52)
+                            .frame(width: 54)
                     }
 
                     Divider()
@@ -512,16 +516,21 @@ struct InsightsView: View {
                 Text(label)
                     .font(.subheadline)
                     .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            // Fixed label column so the two value columns get equal, generous
+            // room and never crowd into a wrap or a hyphenated truncation.
+            .frame(width: 88, alignment: .leading)
             Text("\(Int(weekly)) \(unit)")
                 .font(.subheadline)
                 .monospacedDigit()
+                .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .trailing)
             Text("\(Int(monthly)) \(unit)")
                 .font(.subheadline)
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
+                .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .trailing)
             Text("\(arrow)\(Int(abs(diffPct)))%")
                 .font(.caption)
@@ -529,7 +538,7 @@ struct InsightsView: View {
                 .monospacedDigit()
                 .foregroundStyle(trendColor)
                 .lineLimit(1)
-                .frame(width: 52, alignment: .trailing)
+                .frame(width: 54, alignment: .trailing)
         }
     }
 

--- a/mobile/iosApp/Bissbilanz/Views/SleepView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SleepView.swift
@@ -469,8 +469,8 @@ struct AddSleepSheet: View {
     let existingEntry: SleepEntry?
     let onSaved: () -> Void
 
-    @State private var hoursText = "7"
-    @State private var minutesText = "30"
+    @State private var hours = 7
+    @State private var minutes = 30
     @State private var quality = 7.0
     @State private var date = Date()
     @State private var timesEnabled = false
@@ -491,7 +491,7 @@ struct AddSleepSheet: View {
     }
 
     private var durationMinutes: Int {
-        (Int(hoursText) ?? 0) * 60 + (Int(minutesText) ?? 0)
+        hours * 60 + minutes
     }
 
     private var isValid: Bool {
@@ -502,18 +502,26 @@ struct AddSleepSheet: View {
         NavigationStack {
             Form {
                 Section(L10n.sleepDuration) {
-                    HStack {
-                        TextField("7", text: $hoursText)
-                            .keyboardType(.numberPad)
-                            .multilineTextAlignment(.trailing)
-                        Text(L10n.hours)
-                            .foregroundStyle(.secondary)
-                        TextField("30", text: $minutesText)
-                            .keyboardType(.numberPad)
-                            .multilineTextAlignment(.trailing)
-                        Text(L10n.minutes)
-                            .foregroundStyle(.secondary)
+                    // Clock-style hour/minute wheels (like the Apple Clock timer)
+                    // instead of free-text fields.
+                    HStack(spacing: 0) {
+                        Picker(L10n.hours, selection: $hours) {
+                            ForEach(0 ..< 24, id: \.self) { hour in
+                                Text("\(hour) \(L10n.hoursShort)").tag(hour)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                        .frame(maxWidth: .infinity)
+
+                        Picker(L10n.minutes, selection: $minutes) {
+                            ForEach(0 ..< 60, id: \.self) { minute in
+                                Text("\(minute) \(L10n.minutesShort)").tag(minute)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                        .frame(maxWidth: .infinity)
                     }
+                    .frame(height: 160)
                 }
 
                 Section {
@@ -616,9 +624,9 @@ struct AddSleepSheet: View {
 
     private func syncDurationFromTimes() {
         guard let (bed, wake) = resolvedTimes() else { return }
-        let minutes = Int(wake.timeIntervalSince(bed) / 60)
-        hoursText = "\(minutes / 60)"
-        minutesText = "\(minutes % 60)"
+        let total = Int(wake.timeIntervalSince(bed) / 60)
+        hours = min(total / 60, 23)
+        minutes = total % 60
     }
 
     // MARK: - Health write-back
@@ -637,8 +645,8 @@ struct AddSleepSheet: View {
 
     private func prefill() {
         guard let entry = existingEntry else { return }
-        hoursText = "\(entry.durationMinutes / 60)"
-        minutesText = "\(entry.durationMinutes % 60)"
+        hours = min(entry.durationMinutes / 60, 23)
+        minutes = entry.durationMinutes % 60
         quality = entry.quality
         if let d = DateFormatting.date(from: entry.entryDate) {
             date = d

--- a/mobile/iosApp/Bissbilanz/Views/WeightView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/WeightView.swift
@@ -474,7 +474,14 @@ struct WeightView: View {
                                 }
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 4)
-                                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                                // Solid background instead of a glass material so
+                                // the values stay legible over the chart lines.
+                                .background(Color(.systemBackground), in: RoundedRectangle(cornerRadius: 8))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(.quaternary, lineWidth: 0.5)
+                                }
+                                .shadow(color: .black.opacity(0.12), radius: 3, y: 1)
                             }
 
                         PointMark(


### PR DESCRIPTION
## 1. Dashboard refresh visibility (original fix)

> "I just used the MCP AI integration to create a food item for coffee and log it. On the web it appears under Snacks but the iOS App does not show it even when I pull down to refresh."

`DashboardView.loadData` refreshed entries with `try?`, silently swallowing failures, so a refresh that didn't complete looked identical to a genuinely empty day. Now the entries-refresh outcome is tracked: when it fails **and** the day is empty, the dashboard shows an error state with a **Retry** button (a reliable refresh path independent of the pull gesture) instead of a misleading "No entries yet". URLCache is disabled for API GETs, the fasting-day toggle is hidden on a real failure, and every surfaced failure is captured at warning level (bypassing the offline/401/404 noise filter) so it's no longer invisible in Sentry.

## 2. TestFlight UI feedback batch

Implemented the remaining screenshot feedback that wasn't already covered by current code (all iOS-only):

| Feedback | Change |
| --- | --- |
| Day log has too many colours; want pills, logged time, sorting, search | `DayLogView`: per-meal totals as compact tinted **pills**; **logged time** on each entry; entries **sorted by time**; **search** filter over entry names (neutral, single-colour rows) |
| Dashboard action buttons overlap content; show logged time | `DashboardView`: 104pt bottom scroll inset so the FAB never covers the last meal card; `MealCard` rows show the logged time |
| Food create: unclear if macros are per-serving or per-100 g | `FoodEditSheet`: **"Values per: Per Serving / Per 100 g"** toggle; per-100 g entries are scaled to the stored per-serving basis on save (macros + nutrients); label scan defaults to per-100 g |
| Sleep duration should use the Apple Clock timer wheel | `AddSleepSheet`: hour/minute **`.wheel` pickers** instead of text fields |
| Chart tooltip glass background hurts readability | `WeightView`: solid `systemBackground` tooltip with hairline border + subtle shadow |
| Goal % wraps to a second line / inconsistent sizes at 100% | `InsightsView`: widened the percent column so `100%` renders full-size, single line |
| Average comparison items too narrow; colourised labels look off | `InsightsView`: fixed label column + single-line `Weekly`/`Monthly` headers so value columns stop crowding (labels already use a small colour dot, not coloured text) |
| Search filter doesn't filter results | `FoodSearchView`: the search field now also filters the **Recent** and **Favorites** tabs, not just Search |
| Meal type should be a dropdown, not a boxed tab set | `QuickEntrySheet`/`EntryEditSheet` meal pickers use `.menu` (matching `LogFoodSheet`, which already did) |

### Already satisfied in current code (reports were on older TestFlight builds)

Verified against the current branch — no change needed:

- **Insights calendar** weekday alignment + colour highlighting — both calendars already build the grid sequentially with the correct Monday-first offset and timezone-independent `yyyy-MM-dd` keys (July 1 2026 → Wednesday).
- **Barcode food detail**: Log button already in the bottom `safeAreaInset`, star already top-right, macros already plain (uncoloured).
- **Weight chart** already supports tap-to-select (`.chartXSelection`).
- **Sign-out confirmation** already anchored to the button.
- **Serving-size 60/40** split already in place.
- **Sleep range tabs** already 7d/30d/90d (no History tab).
- **Sleep quality decimal** data type already `Double` end-to-end (model/DB/API); `formatSleepQuality` already renders `9.7`.
- **Scan → create → label** empty-sheet race already fixed via the `pendingCreatedFood` + `onDismiss` buffer.

### Deferred (need a cross-platform/backend change — out of scope for this iOS PR)

- **Apple Health sleep *score* sync** (1–100 → x.y/10): the decimal data type is done, but reading Apple's sleep score needs an on-device-only HealthKit capability that can't be verified from this environment. Import currently uses a neutral 5.0.
- **Free-form custom nutrients** (Taurine, Ginseng, …): the DB/API store a fixed ~43-nutrient column set, so arbitrary keys would be silently dropped. Caffeine and 40+ nutrients are already addable via the catalog. Needs a backend schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
