### PR TITLE
feat(ios): derive imported sleep quality from Apple Health

### DIFF
--- a/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
+++ b/mobile/iosApp/Bissbilanz/Services/HealthKitService.swift
@@ -268,6 +268,11 @@ final class HealthKitService {
         let wakeTime: Date
         let asleepMinutes: Int
         let wakeUps: Int
+        /// Estimated 1–10 quality. Apple's own Sleep Score isn't exposed
+        /// through public HealthKit, so this is derived from sleep efficiency
+        /// penalised by the awakening count — see `derivedQuality`. It stays a
+        /// real, editable rating instead of a flat placeholder.
+        let quality: Double
     }
 
     /// Writes one sleep session to Health. Only called for entries with known
@@ -344,6 +349,31 @@ final class HealthKitService {
     /// Sessions shorter than this are ignored — micro-naps aren't a night.
     nonisolated static let minimumNightMinutes = 30
 
+    /// Each awakening shaves this much off the 1–10 quality estimate…
+    nonisolated static let wakeUpQualityPenalty = 0.3
+
+    /// …but the combined wake-up penalty never exceeds this, so a fragmented
+    /// night still keeps a score driven mostly by how much of the time in bed
+    /// was actually spent asleep.
+    nonisolated static let maxWakeUpQualityPenalty = 2.0
+
+    /// Estimates a 1–10 quality for an imported night. Apple's own Sleep Score
+    /// isn't readable through public HealthKit (it's a Health-app metric, not a
+    /// sample type), so quality is derived from sleep efficiency — asleep
+    /// minutes over time in bed — scaled onto the 1–10 range and penalised by
+    /// the number of awakenings. The result is clamped to 1.0…10.0 and rounded
+    /// to one decimal so it always satisfies the server's `1..10` CHECK (a 0 or
+    /// >10 value would be rejected and the sync op dropped). Example: 97%
+    /// efficiency with no awakenings maps to 9.7.
+    nonisolated static func derivedQuality(asleepMinutes: Int, timeInBedMinutes: Int, wakeUps: Int) -> Double {
+        let inBed = max(timeInBedMinutes, asleepMinutes, 1)
+        let efficiency = min(Double(asleepMinutes) / Double(inBed), 1.0)
+        let penalty = min(Double(max(wakeUps, 0)) * wakeUpQualityPenalty, maxWakeUpQualityPenalty)
+        let score = efficiency * 10 - penalty
+        let clamped = min(max(score, 1.0), 10.0)
+        return (clamped * 10).rounded() / 10
+    }
+
     /// Groups raw samples into per-night aggregates: samples closer than
     /// `sessionGapSeconds` form a session; each session is keyed by the day it
     /// ends on (the wake day) and the longest session per day wins (the main
@@ -377,12 +407,19 @@ final class HealthKitService {
             let asleepMinutes = asleep.isEmpty ? totalMinutes(of: inBed) : totalMinutes(of: asleep)
             guard asleepMinutes >= minimumNightMinutes else { continue }
 
+            let cappedAsleep = min(asleepMinutes, 1440)
+            let timeInBedMinutes = Int(wakeTime.timeIntervalSince(bedtime) / 60)
             let night = SleepNight(
                 entryDate: DateFormatting.isoString(from: wakeTime),
                 bedtime: bedtime,
                 wakeTime: wakeTime,
-                asleepMinutes: min(asleepMinutes, 1440),
-                wakeUps: awake.count
+                asleepMinutes: cappedAsleep,
+                wakeUps: awake.count,
+                quality: derivedQuality(
+                    asleepMinutes: cappedAsleep,
+                    timeInBedMinutes: timeInBedMinutes,
+                    wakeUps: awake.count
+                )
             )
             if let existing = bestPerDay[night.entryDate], existing.asleepMinutes >= night.asleepMinutes {
                 continue

--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -122,7 +122,7 @@ struct FoodSearchView: View {
     }
 
     private var recentTab: some View {
-        let items = recentFoods.filter(matches)
+        let items = recentFoods.filter { matches($0) }
         return Group {
             if items.isEmpty {
                 if query.isEmpty {
@@ -144,7 +144,7 @@ struct FoodSearchView: View {
     }
 
     private var favoritesTab: some View {
-        let items = favoriteFoods.filter(matches)
+        let items = favoriteFoods.filter { matches($0) }
         return Group {
             if items.isEmpty {
                 if query.isEmpty {

--- a/mobile/iosApp/Bissbilanz/Views/SleepView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SleepView.swift
@@ -25,10 +25,6 @@ struct SleepView: View {
     @State private var selectedRange = 30
     @State private var errorMessage: String?
 
-    /// Imported Health nights carry no subjective rating — they get the
-    /// neutral middle of the 1–10 scale, editable afterwards.
-    static let importedQuality = 5.0
-
     private enum RangeOption: Int, CaseIterable, Identifiable {
         case week = 7
         case month = 30
@@ -296,7 +292,10 @@ struct SleepView: View {
     }
 
     /// Import nights from Apple Health that the app doesn't have yet
-    /// (read-only — never writes back to Health from here).
+    /// (read-only — never writes back to Health from here). Each night carries
+    /// a quality estimated from its sleep efficiency and awakenings
+    /// (`HealthKitService.derivedQuality`), since Apple's Sleep Score isn't
+    /// exposed through public HealthKit; the value stays editable afterwards.
     private func importFromHealthKit() async {
         let healthKit = HealthKitService.shared
         guard healthKit.isAvailable else { return }
@@ -308,7 +307,7 @@ struct SleepView: View {
         for night in HealthKitService.nights(from: samples) where !existingDates.contains(night.entryDate) {
             let create = SleepCreate(
                 durationMinutes: night.asleepMinutes,
-                quality: Self.importedQuality,
+                quality: night.quality,
                 entryDate: night.entryDate,
                 bedtime: DateFormatting.isoDateTimeString(from: night.bedtime),
                 wakeTime: DateFormatting.isoDateTimeString(from: night.wakeTime),

--- a/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
+++ b/mobile/iosApp/BissbilanzTests/HealthKitServiceTests.swift
@@ -215,6 +215,8 @@ struct SleepNightAggregationTests {
         // 23:00–01:00 plus 01:20–07:00 — the awake gap doesn't count.
         #expect(night.asleepMinutes == 460)
         #expect(night.wakeUps == 1)
+        // 460 asleep / 480 in bed = 95.8% → 9.58, minus one awakening (0.3).
+        #expect(night.quality == 9.3)
     }
 
     @Test("Overlapping samples from two sources are not double-counted")
@@ -277,6 +279,55 @@ struct SleepNightAggregationTests {
         let nights = HealthKitService.nights(from: samples)
 
         #expect(nights.map(\.entryDate) == ["2026-06-02", "2026-06-03"])
+    }
+}
+
+@Suite("Derived Sleep Quality Tests")
+struct DerivedSleepQualityTests {
+    @Test("97% efficiency with no awakenings maps to 9.7")
+    func highEfficiencyMapsToScore() {
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 97, timeInBedMinutes: 100, wakeUps: 0) == 9.7)
+    }
+
+    @Test("Perfect efficiency caps at 10")
+    func perfectEfficiency() {
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 480, timeInBedMinutes: 480, wakeUps: 0) == 10.0)
+    }
+
+    @Test("Efficiency above 1 is clamped, never exceeding 10")
+    func efficiencyClampedAtOne() {
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 1000, timeInBedMinutes: 800, wakeUps: 0) == 10.0)
+    }
+
+    @Test("A poor, fragmented night never drops below 1")
+    func floorAtOne() {
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 10, timeInBedMinutes: 600, wakeUps: 20) == 1.0)
+    }
+
+    @Test("Each awakening reduces the score, capped at the maximum penalty")
+    func wakeUpPenalty() {
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 100, timeInBedMinutes: 100, wakeUps: 0) == 10.0)
+        // 10 − 2 × 0.3 = 9.4
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 100, timeInBedMinutes: 100, wakeUps: 2) == 9.4)
+        // Penalty capped at 2.0 → 10 − 2 = 8.0
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 100, timeInBedMinutes: 100, wakeUps: 100) == 8.0)
+    }
+
+    @Test("Efficiency and penalty combine and round to one decimal")
+    func combinedRounding() {
+        // 437 / 500 = 87.4% → 8.74, minus one awakening (0.3) = 8.44 → 8.4
+        #expect(HealthKitService.derivedQuality(asleepMinutes: 437, timeInBedMinutes: 500, wakeUps: 1) == 8.4)
+    }
+
+    @Test("Imported nights carry a derived quality, not a flat placeholder")
+    func nightsCarryDerivedQuality() {
+        // A clean 8h night with no awakenings → 100% efficiency → 10.0.
+        let bedtime = Calendar.current.date(from: DateComponents(year: 2026, month: 6, day: 1, hour: 23))!
+        let wakeTime = Calendar.current.date(from: DateComponents(year: 2026, month: 6, day: 2, hour: 7))!
+        let samples = [HealthKitService.SleepSample(start: bedtime, end: wakeTime, stage: .asleep)]
+
+        let night = HealthKitService.nights(from: samples).first
+        #expect(night?.quality == 10.0)
     }
 }
 


### PR DESCRIPTION
## What

When iOS imports sleep from Apple Health, imported nights now carry a **real, derived quality** on the 1–10 scale instead of the hardcoded `5.0` placeholder. Manual logging (the 1–10 integer slider), the DB, and the API are untouched.

Deferred half of TestFlight feedback `APN9EN` — the data-type work (sleep `quality` is `Double` end-to-end, UI renders one decimal) already shipped; this is the HealthKit read + mapping.

## Step 0 — which path, and why

**Path B (derived proxy).** Apple's "Sleep Score" is a **watchOS 26 / iOS 26** feature (released Sept 2025, ranges revised in 26.2). It is a Health-app metric computed by Apple and is **not exposed as a public, developer-readable HealthKit sample** — public sleep data is still only `HKCategoryTypeIdentifier.sleepAnalysis` (stages). There is no `HKQuantityType`/`HKCategoryType` for a sleep score.

So Path A isn't implementable: there's no symbol to read, the app's deployment target is **iOS 18.0**, and even gating on an Xcode 26 SDK symbol would only help the few testers already on iOS 26. Path B builds on every supported OS, needs **no new HealthKit type and no new permission** (we already read `sleepAnalysis`), and is strictly better than a flat `5.0`.

## Mapping

`HealthKitService.derivedQuality(asleepMinutes:timeInBedMinutes:wakeUps:)`:

- **Sleep efficiency** = `asleepMinutes / timeInBedMinutes`, clamped to `0…1`, scaled onto the 1–10 range (`efficiency × 10`).
- **Penalised by awakenings**: `−0.3` per wake-up, capped at `−2.0` so a fragmented night still keeps an efficiency-driven score.
- **Clamped to `1.0…10.0` and rounded to one decimal**, so values always satisfy the server's `1..10` CHECK (a `0` or `>10` would be rejected and the sync op dropped).

By construction, **97% efficiency with no awakenings → 9.7/10**, matching the feedback's "97 → 9.7" example. Imported nights remain user-editable afterward (editing snaps quality to an integer via the slider — acceptable).

## Tests

Added a `Derived Sleep Quality Tests` suite plus a quality assertion in the existing single-night aggregation test (efficiency mapping, the 9.7 case, the 1.0 floor / 10.0 cap, the wake-up penalty + cap, rounding, and that `nights(from:)` carries the derived value). Note: the iOS test bundle is compiled/run on macOS — CI runs `xcodebuild build` of the app scheme only.

## Out of scope

Custom-nutrients feedback (`AGOTgs`); the manual slider, duration UI, and sleep chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)