### PR TITLE
feat(ios): create foods & recipes from the Foods tab + menu

### DIFF
--- a/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
+++ b/mobile/iosApp/Bissbilanz/Utilities/Localization.swift
@@ -624,10 +624,6 @@ enum L10n {
         )
     }
 
-    static var quickActions: String {
-        localized("quick_actions", en: "Quick Actions", de: "Schnellaktionen")
-    }
-
     static var favoriteLogging: String {
         localized(
             "favorite_logging",

--- a/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/FoodSearchView.swift
@@ -16,6 +16,7 @@ struct FoodSearchView: View {
     @State private var selectedFood: Food?
     @State private var showLogSheet = false
     @State private var showCreateFood = false
+    @State private var showCreateRecipe = false
     @State private var searchTask: Task<Void, Never>?
     @State private var errorMessage: String?
     @State private var toastMessage: String?
@@ -52,12 +53,24 @@ struct FoodSearchView: View {
                 }
             }
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    showCreateFood = true
+                // A single + presents a menu: foods and recipes are both
+                // created from here, so the Settings "quick actions" duplicates
+                // are gone and the Foods tab is the one place to add either.
+                Menu {
+                    Button {
+                        showCreateFood = true
+                    } label: {
+                        Label(L10n.createFood, systemImage: "fork.knife")
+                    }
+                    Button {
+                        showCreateRecipe = true
+                    } label: {
+                        Label(L10n.createRecipe, systemImage: "book")
+                    }
                 } label: {
                     Image(systemName: "plus")
                 }
-                .accessibilityLabel(L10n.createFood)
+                .accessibilityLabel(L10n.create)
             }
         }
         .navigationDestination(for: Food.self) { food in
@@ -85,6 +98,9 @@ struct FoodSearchView: View {
             FoodEditSheet { _ in
                 Task { await loadRecent() }
             }
+        }
+        .sheet(isPresented: $showCreateRecipe) {
+            RecipeEditSheet()
         }
         .task {
             await loadRecent()

--- a/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
+++ b/mobile/iosApp/Bissbilanz/Views/SettingsView.swift
@@ -17,8 +17,6 @@ struct SettingsView: View {
     @State private var mealTypes: [MealType] = []
     @State private var isEditingGoals = false
     @State private var showLogoutConfirmation = false
-    @State private var showCreateFood = false
-    @State private var showCreateRecipe = false
     @State private var newMealTypeName = ""
     @State private var errorMessage: String?
     private let healthKitService = HealthKitService.shared
@@ -118,29 +116,6 @@ struct SettingsView: View {
                             }
                         }
                     }
-                }
-
-                // Quick actions — standalone buttons, no card behind them
-                Section(L10n.quickActions) {
-                    HStack(spacing: 12) {
-                        Button {
-                            showCreateFood = true
-                        } label: {
-                            Label(L10n.foods, systemImage: "plus")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.bordered)
-
-                        Button {
-                            showCreateRecipe = true
-                        } label: {
-                            Label(L10n.recipes, systemImage: "plus")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                    .listRowBackground(Color.clear)
-                    .listRowInsets(EdgeInsets())
                 }
 
                 // Language section
@@ -329,12 +304,6 @@ struct SettingsView: View {
             .navigationTitle(L10n.settings)
             .sheet(isPresented: $isEditingGoals) {
                 goalsEditor
-            }
-            .sheet(isPresented: $showCreateFood) {
-                FoodEditSheet()
-            }
-            .sheet(isPresented: $showCreateRecipe) {
-                RecipeEditSheet()
             }
             .task { await loadData() }
             .alert(


### PR DESCRIPTION
## What

Moves food/recipe **creation** to where the content lives. The Foods tab's `+` button is now a small menu offering **Create Food** / **Create Recipe**, and the redundant **Settings → Quick Actions** section is removed.

## Why

The Settings "Quick Actions" section (Create Food / Create Recipe buttons) sat far from the Foods tab where you actually browse foods, and recipe creation already existed in the Recipes list. Consolidating onto the Foods tab's `+` makes it the single, discoverable place to add either.

## Changes

- `FoodSearchView`: the `+` toolbar button becomes a `Menu` → Create Food (`FoodEditSheet`) / Create Recipe (`RecipeEditSheet`).
- `SettingsView`: removed the `Quick Actions` section, its `showCreateFood`/`showCreateRecipe` state, and the two sheets.
- `Localization`: removed the now-orphaned `quickActions` string. No new strings (reuses `createFood` / `createRecipe` / `create`).

Recipe browsing is unchanged (Settings → Recipes), and the Recipes list keeps its own `+`.

## Out of scope

No DB/API/schema changes. Manual logging, the food/recipe edit sheets, and the Recipes list are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)