### PR TITLE
fix(ios): drop BissbilanzWidgets iCloud entitlement, broke v1.24.1 archive

### DIFF
--- a/mobile/iosApp/project.yml
+++ b/mobile/iosApp/project.yml
@@ -132,14 +132,21 @@ targets:
       properties:
         com.apple.security.application-groups:
           - group.com.bissbilanz
-        # Lets a widget-extension quick-add (QuickAddFoodIntent, opens its own
-        # ModelContainer against the App Group store) participate in the same
-        # CloudKit mirroring as the main app's container in Local mode — see
-        # the App Group store migration in LocalStore.swift.
-        com.apple.developer.icloud-container-identifiers:
-          - iCloud.com.bissbilanz.ios
-        com.apple.developer.icloud-services:
-          - CloudKit
+        # NOT adding com.apple.developer.icloud-container-identifiers here:
+        # automatic signing can't provision a profile for a capability the App
+        # ID doesn't already have enabled in the Apple Developer Portal, and
+        # this extension's App ID (com.bissbilanz.ios.widgets) doesn't have
+        # iCloud enabled — adding it broke the v1.24.1 Archive step
+        # ("Provisioning profile ... doesn't match the entitlements file's
+        # value for the com.apple.developer.icloud-container-identifiers
+        # entitlement"). Without it, a widget-extension quick-add
+        # (QuickAddFoodIntent) in Local mode writes locally but its
+        # LocalStore.makeContainerWithFallback call falls back to a plain
+        # on-disk (non-CloudKit) configuration — the entry is never lost, it
+        # just doesn't propagate to the user's other Apple devices until the
+        # main app next runs and rewrites the snapshot. Re-add this (and
+        # enable iCloud for the App ID in the portal first) if that gap needs
+        # closing.
     dependencies:
       - sdk: WidgetKit.framework
       - sdk: SwiftUI.framework


### PR DESCRIPTION
## Summary
- Fixes the v1.24.1 iOS release failure: the iCloud entitlement added to `BissbilanzWidgets` in #378 broke `xcodebuild archive` because `com.bissbilanz.ios.widgets` doesn't have iCloud enabled as a capability in the Apple Developer Portal, so automatic signing couldn't provision a matching profile:
  ```
  error: Provisioning profile "iOS Team Provisioning Profile: com.bissbilanz.ios.widgets"
  doesn't match the entitlements file's value for the
  com.apple.developer.icloud-container-identifiers entitlement (in target 'BissbilanzWidgets')
  ```
- Removes the entitlement. `LocalStore.makeContainerWithFallback` already catches a CloudKit setup failure and retries with a plain on-disk store, so this doesn't change widget quick-add's actual on-device write — only the cross-device CloudKit propagation of a Local-mode quick-add (deferred until iCloud is enabled for the App ID in the portal and the entitlement is re-added).

## Test plan
- [x] YAML syntax validated
- [x] No Swift changes — entitlements-only fix
- [ ] Re-run `mobile-release.yml` via `workflow_dispatch` (version `1.24.1`) once merged to confirm the Archive step succeeds